### PR TITLE
Add examples for the Java Hybrid Scan Parquet Reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,12 @@ cpp/doxygen/xml
 #Java
 target
 
+# Local Maven repo created by java/ci/build-in-docker.sh
+.m2
+
+# Recreated on every Maven `validate` phase by gmaven-plugin:1.5
+java/bin/
+
 # Translations
 *.mo
 *.pot

--- a/java/examples/hybrid_scan_io/README.md
+++ b/java/examples/hybrid_scan_io/README.md
@@ -1,0 +1,106 @@
+# cudf Java hybrid_scan_io examples
+
+Java examples demonstrating how to use the experimental
+`ai.rapids.cudf.HybridScanReader` (the Java binding for
+`cudf::io::parquet::experimental::hybrid_scan_reader`, marked `@Experimental` on the Java
+side) to read Parquet files subject to selective filter expressions.
+
+## Examples
+
+| Class | Purpose |
+|---|---|
+| `GenerateSampleParquetFileMain` | Generates a deterministic five-row-group (250,000-row) Parquet file with COLUMN-level statistics (page index). Run this first. |
+| `HybridScanIoExample` | Reads a file three ways: (1) legacy `Table.readParquet`, (2) hybrid two-step with `ALL_TRUE` row mask (stats-only pruning), and (3) hybrid two-step with `PAGE_INDEX_STATS` row mask (page-index pruning). Prints row counts and elapsed time for each scenario. |
+| `HybridScanPipelineExample` | Splits the file into row-group passes bounded by a byte limit, then streams each pass as cuDF Table chunks via the chunked all-columns API. Demonstrates bounded GPU memory usage with no filter applied. |
+
+`Util.java` contains shared helpers: reading a Parquet file or just its footer into a
+`HostMemoryBuffer`, reading a single targeted byte range from a file, and copying byte
+ranges to device buffers (from either a host buffer or directly from a file).
+
+## Building
+
+The examples expect that the parent `ai.rapids:cudf` artifact has been built and installed
+locally. From the repo root:
+
+```bash
+cd java
+mvn -DskipTests install   # installs cudf-java jar into ~/.m2 so examples can depend on it
+cd examples/hybrid_scan_io
+mvn package               # compiles and packages only this example module
+```
+
+## Generating sample data
+
+The examples read from a Parquet file with three integer columns (`id`, `zip_code`,
+`num_units`) split into five row groups of 50,000 rows each, written with COLUMN-level
+statistics so that a page index is available for page-level pruning. Generate it before
+running the examples:
+
+```bash
+# Generate the sample Parquet file used by the examples
+mvn exec:java \
+  -Dexec.mainClass=ai.rapids.cudf.examples.GenerateSampleParquetFileMain \
+  -Dexec.args="/tmp/sample.parquet"
+```
+
+The `zip_code` values are deliberately distributed across five non-overlapping bases so
+that a filter threshold of 145,000 prunes:
+
+- 1 row group entirely via row-group statistics
+- 2 row groups partially at the page level (2 pages in one, 1 page in the other)
+- 2 row groups not at all (all rows survive)
+
+## Running
+
+The fastest way to exercise all three examples is the bundled `run_examples.sh`:
+
+```bash
+./run_examples.sh                # data-gen + io + pipeline
+./run_examples.sh -b             # also force `mvn package -DskipTests` first
+./run_examples.sh --help         # full usage
+```
+
+`run_examples.sh`:
+
+- Prechecks that the `ai.rapids:cudf` jar is installed in `~/.m2/repository`
+  and prints a clear error (with the `mvn install -DskipTests` invocation)
+  if it isn't.
+- Auto-builds the example module on first run when
+  `target/classes/ai/rapids/cudf/examples/` has no `*.class` files.
+- Accepts `-b` / `--build` to force a rebuild even when classes are already
+  present.
+
+To run a single example by hand (after `mvn package` has been run on the
+examples module):
+
+```bash
+# Single/two-step example
+# Arguments:
+#   parquet-file   Path to a Parquet file (use GenerateSampleParquetFileMain to create one)
+#   column-name    Name of an integer column to filter on (e.g. zip_code)
+#   int-literal    Integer threshold; rows where column-name > int-literal are kept
+mvn exec:java \
+  -Dexec.mainClass=ai.rapids.cudf.examples.HybridScanIoExample \
+  -Dexec.args="/tmp/sample.parquet zip_code 145000"
+
+# Chunked pipeline example
+# Arguments:
+#   parquet-file          Path to a Parquet file (use GenerateSampleParquetFileMain to create one)
+#   row-group-batch-bytes Row group batch size in bytes: maximum total uncompressed size of the
+#                         row groups in a single pass (batch). A pass is a batch of row groups
+#                         whose combined uncompressed size fits within this limit.
+#                         0 = no limit (all row groups in one pass).
+#   chunk-bytes           Maximum size in bytes of a single output cuDF Table chunk within a pass.
+#                         Controls how much decoded GPU memory is used at once per chunk.
+#                         0 = no limit (entire pass materialised as one Table).
+mvn exec:java \
+  -Dexec.mainClass=ai.rapids.cudf.examples.HybridScanPipelineExample \
+  -Dexec.args="/tmp/sample.parquet 67108864 16777216"
+```
+
+## Notes on filters
+
+Because the Parquet schema may not be known to the application at AST construction time,
+filter expressions for the hybrid scan reader use
+`ai.rapids.cudf.ast.ColumnNameReference` to refer to columns by name (see the example
+source). The reader resolves the names against the file schema during materialization.

--- a/java/examples/hybrid_scan_io/pom.xml
+++ b/java/examples/hybrid_scan_io/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+  SPDX-License-Identifier: Apache-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ai.rapids</groupId>
+    <artifactId>cudf-hybrid-scan-io-example</artifactId>
+    <version>26.06.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>cudf hybrid_scan_io examples</name>
+    <description>
+        Java examples for the experimental cudf Parquet hybrid-scan reader. Requires
+        that the parent `ai.rapids:cudf` artifact has been built and installed
+        locally (e.g. via `mvn install` from the `java/` directory).
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.rapids</groupId>
+            <artifactId>cudf</artifactId>
+            <version>${project.version}</version>
+            <!-- The parent jar is installed with a CUDA classifier (computed from
+                 the local nvcc release by gmaven-plugin in java/pom.xml). Override
+                 with -Dcuda.classifier=cudaXX if your install uses a different one. -->
+            <classifier>${cuda.classifier}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <slf4j.version>1.7.30</slf4j.version>
+        <!-- Default to CUDA 12. Override on the command line with
+             `mvn ... -Dcuda.classifier=cuda11` if your local libcudf/cudf-java
+             install was built for a different CUDA major version. -->
+        <cuda.classifier>cuda12</cuda.classifier>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <!-- No default mainClass: callers must pass -Dexec.mainClass on the CLI.
+                     A hard-coded <mainClass> here would shadow -Dexec.mainClass because
+                     Maven plugin XML literals take precedence over user properties.
+                     Examples:
+                       mvn exec:java \
+                         -Dexec.mainClass=ai.rapids.cudf.examples.HybridScanIoExample \
+                         -Dexec.args="/path/to/file.parquet zip 50000"
+                       mvn exec:java \
+                         -Dexec.mainClass=ai.rapids.cudf.examples.HybridScanPipelineExample \
+                         -Dexec.args="/path/to/file.parquet 0 0"
+                -->
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/examples/hybrid_scan_io/run_examples.sh
+++ b/java/examples/hybrid_scan_io/run_examples.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+#
+# run_examples.sh — generates sample Parquet data, runs both hybrid-scan
+# examples, then cleans up.  Safe to invoke from any working directory;
+# the script cds into its own directory before running mvn.
+#
+# Behaviour:
+#   * Prechecks that the parent ai.rapids:cudf jar (with a CUDA classifier)
+#     is installed in the local Maven repository (~/.m2/repository) and
+#     fails fast with a clear remediation message if it isn't.
+#   * Builds the example module on first run (no compiled *.class files
+#     under target/classes/ai/rapids/cudf/examples/). Pass -b/--build to
+#     force a rebuild even when classes are present.
+#   * Runs the three example stages: data generation, two-step IO, chunked
+#     pipeline.
+
+set -e
+
+usage() {
+    cat <<'USAGE'
+run_examples.sh -- runs all hybrid-scan Java examples end-to-end
+
+USAGE:
+  run_examples.sh [OPTIONS]
+
+OPTIONS:
+  -h, --help    Show this help and exit.
+  -b, --build   Force `mvn package -DskipTests` even when target/classes
+                already contains compiled .class files. Without this flag,
+                the script auto-builds only when target/classes is empty.
+
+PRECHECK:
+  The script verifies that ai.rapids:cudf:<version>-<cuda.classifier> is
+  installed in ~/.m2/repository before doing anything else; if not, it
+  prints the expected jar path and the `mvn install -DskipTests` command
+  to install it.
+
+STAGES:
+  0. Build the example module (only when needed).
+  1. Generate a deterministic sample Parquet file.
+  2. HybridScanIoExample (legacy reader vs hybrid-scan two-step).
+  3. HybridScanPipelineExample (chunked all-columns pipeline).
+
+  Stage 0 is skipped when target/classes already has *.class files and
+  -b/--build was not passed.
+USAGE
+}
+
+FORCE_BUILD=0
+while (( $# > 0 )); do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -b|--build)
+            FORCE_BUILD=1
+            shift
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            echo >&2
+            usage >&2
+            exit 64
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Anchor every subsequent `mvn` call to the example module's pom regardless
+# of where the user invoked us from. Without this, `mvn exec:java` in stages
+# 1-3 would inherit the caller's cwd and fail with "no POM in this directory".
+cd "${SCRIPT_DIR}"
+
+DATA_FILE="${SCRIPT_DIR}/test_data.parquet"
+MVN_FLAGS="-q"   # remove -q to see full Maven output
+
+# ── helpers ────────────────────────────────────────────────────────────────
+banner() {
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════════"
+    echo "  $*"
+    echo "═══════════════════════════════════════════════════════════════════"
+}
+
+step() { echo "▶  $*"; }
+
+# ── cleanup ────────────────────────────────────────────────────────────────
+cleanup() {
+    if [[ -f "${DATA_FILE}" ]]; then
+        step "Cleaning up: removing ${DATA_FILE}"
+        rm -f "${DATA_FILE}"
+    fi
+}
+trap cleanup EXIT
+
+# ── preflight: ai.rapids:cudf jar must be present in the local Maven repo ──
+# Field-split each pom line on '<' and '>'; the first <version> tag in the
+# pom is the project's <version> (Maven puts it in the identification block
+# at the top of the file). <modelVersion> doesn't match the /<version>/
+# regex because its '<' is followed by 'm', not 'v'.
+POM="${SCRIPT_DIR}/pom.xml"
+proj_version=$(awk    -F'[<>]' '/<version>/        {print $3; exit}' "${POM}")
+cuda_classifier=$(awk -F'[<>]' '/<cuda.classifier>/{print $3; exit}' "${POM}")
+cuda_classifier="${cuda_classifier:-cuda12}"
+
+mvn_repo="${HOME}/.m2/repository"
+expected_jar="${mvn_repo}/ai/rapids/cudf/${proj_version}/cudf-${proj_version}-${cuda_classifier}.jar"
+
+if [[ ! -f "${expected_jar}" ]]; then
+    cat >&2 <<EOF
+ERROR: ai.rapids:cudf:${proj_version} (classifier ${cuda_classifier}) is not
+       installed in your local Maven repository.
+
+       Expected jar:
+         ${expected_jar}
+
+       Searched local Maven repo:
+         ${mvn_repo}
+
+       To install it, build the parent cuDF Java module from the cuDF tree:
+         cd <cudf-repo>/java && mvn install -DskipTests
+
+       If your libcudf was built for a different CUDA major version, set the
+       classifier when you run that build, e.g.:
+         cd <cudf-repo>/java && mvn install -DskipTests -Dcuda.classifier=cuda11
+       and then re-run this script.
+EOF
+    exit 2
+fi
+step "Found ${expected_jar#${mvn_repo}/}"
+
+# ── stage 0: build (optional) ─────────────────────────────────────────────
+CLASSES_DIR="${SCRIPT_DIR}/target/classes/ai/rapids/cudf/examples"
+NEED_BUILD=0
+# `compgen -G` is a bash builtin that exits 0 iff at least one path matches
+# the glob — no nullglob toggle, no array, no `ls 2>/dev/null` dance.
+if [[ "${FORCE_BUILD}" -eq 1 ]]; then
+    step "Build forced via -b/--build"
+    NEED_BUILD=1
+elif ! compgen -G "${CLASSES_DIR}/*.class" > /dev/null; then
+    step "No *.class files under ${CLASSES_DIR#${SCRIPT_DIR}/} -- building"
+    NEED_BUILD=1
+else
+    step "Reusing existing *.class files (pass -b to force rebuild)"
+fi
+if [[ "${NEED_BUILD}" -eq 1 ]]; then
+    banner "Stage 0 — mvn package -DskipTests"
+    ( cd "${SCRIPT_DIR}" && mvn ${MVN_FLAGS} package -DskipTests )
+    echo "✔  Build complete."
+fi
+
+# ── stage 1: generate sample data ─────────────────────────────────────────
+banner "Stage 1 — Generate sample Parquet file"
+step "Output: ${DATA_FILE}"
+step "Schema: id INT, zip_code INT, num_units INT  |  5 row groups x 50,000 rows"
+mvn ${MVN_FLAGS} exec:java \
+    -Dexec.mainClass=ai.rapids.cudf.examples.GenerateSampleParquetFileMain \
+    -Dexec.args="${DATA_FILE}"
+echo "✔  Sample data written."
+
+# ── stage 2: HybridScanIoExample ──────────────────────────────────────────
+banner "Stage 2 — HybridScanIoExample (legacy vs hybrid-scan two-step)"
+step "Filter: zip_code > 145000"
+step "Compares the legacy Table.readParquet path against the two-step hybrid scan."
+step "Includes a [Hybrid: PageIndex Filtering] variant that prunes pages via the page index."
+mvn ${MVN_FLAGS} exec:java \
+    -Dexec.mainClass=ai.rapids.cudf.examples.HybridScanIoExample \
+    -Dexec.args="${DATA_FILE} zip_code 145000"
+echo "✔  HybridScanIoExample complete."
+
+# ── stage 3: HybridScanPipelineExample ────────────────────────────────────
+banner "Stage 3 — HybridScanPipelineExample (chunked pipeline, no filter)"
+step "Row group batch size: 0 (no limit — one pass for all row groups)"
+step "Chunk size:           0 (no limit — one cuDF Table chunk per pass)"
+step "Demonstrates the streaming/chunked all-columns API."
+mvn ${MVN_FLAGS} exec:java \
+    -Dexec.mainClass=ai.rapids.cudf.examples.HybridScanPipelineExample \
+    -Dexec.args="${DATA_FILE} 0 0"
+echo "✔  HybridScanPipelineExample complete."
+
+# ── done ──────────────────────────────────────────────────────────────────
+banner "All examples finished successfully"
+# cleanup() runs automatically via trap EXIT

--- a/java/examples/hybrid_scan_io/src/main/java/ai/rapids/cudf/examples/GenerateSampleParquetFileMain.java
+++ b/java/examples/hybrid_scan_io/src/main/java/ai/rapids/cudf/examples/GenerateSampleParquetFileMain.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf.examples;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.ParquetWriterOptions;
+import ai.rapids.cudf.Rmm;
+import ai.rapids.cudf.RmmAllocationMode;
+import ai.rapids.cudf.Table;
+import ai.rapids.cudf.TableWriter;
+
+import java.io.File;
+import java.util.stream.IntStream;
+
+/**
+ * Writes a deterministic Parquet file that the hybrid-scan examples can consume.
+ *
+ * <p>Five row groups of 50,000 rows each with three int columns ({@code id}, {@code zip_code},
+ * {@code num_units}) and COLUMN-level statistics (page index). The zip_code values are assigned
+ * per-group from deliberate base offsets so that the filter threshold used by
+ * {@link HybridScanIoExample} falls at predictable page boundaries — enabling 1 row group to
+ * be pruned entirely by row-group statistics, 2 others to have individual pages pruned by the
+ * page index, and 2 to survive without any pruning.
+ *
+ * <p>Usage:
+ * <pre>
+ * mvn -pl java/examples/hybrid_scan_io exec:java \
+ *     -Dexec.mainClass=ai.rapids.cudf.examples.GenerateSampleParquetFileMain \
+ *     -Dexec.args="/tmp/sample.parquet"
+ * </pre>
+ */
+public final class GenerateSampleParquetFileMain {
+  private GenerateSampleParquetFileMain() {}
+
+  public static void main(String[] args) {
+    if (args.length < 1) {
+      System.err.println("Usage: GenerateSampleParquetFileMain /output/parquet/file/path");
+      System.exit(1);
+    }
+    File out = new File(args[0]);
+    File parent = out.getAbsoluteFile().getParentFile();
+    if (parent != null && !parent.exists() && !parent.mkdirs()) {
+      System.err.println("Could not create parent directory: " + parent);
+      System.exit(2);
+    }
+
+    // Row-group count and size are chosen to exercise two distinct pruning levels:
+    //   - 5 row groups with deliberately placed value ranges: 1 group is pruned
+    //     entirely by row-group statistics, 2 groups are partially pruned at the page
+    //     level (2 pages in one, 1 page in the other), and 2 groups fully survive.
+    //   - 50,000 rows per group: cuDF's default max_page_size_rows is ~20,000 rows, so
+    //     each column chunk splits into ~3 pages (20K + 20K + 10K rows), giving the
+    //     page-index filter room to skip whole pages within partially-overlapping groups.
+    int rowsPerGroup = 50_000;
+    int numGroups    = 5;
+    int totalRows    = rowsPerGroup * numGroups;
+
+    // zip_code base values per group — each group gets its own contiguous sorted range so
+    // per-page min/max statistics are tight and the filter threshold (145,000) falls at
+    // predictable page boundaries within groups 1 and 2.
+    int[] zipBases = {0, 100_000, 125_000, 175_000, 250_000};
+
+    boolean isRmmInitializedByApp = false;
+    try {
+      if (!Rmm.isInitialized()) {
+        System.out.println("[Generate] Initialising RMM (256 MB POOL)...");
+        Rmm.initialize(RmmAllocationMode.POOL, null, 256L * 1024L * 1024L);
+        isRmmInitializedByApp = true;
+      }
+
+      ParquetWriterOptions opts = ParquetWriterOptions.builder()
+          .withNonNullableColumns("id", "zip_code", "num_units")
+          .withRowGroupSizeRows(rowsPerGroup)
+          .withStatisticsFrequency(ParquetWriterOptions.StatisticsFrequency.COLUMN)
+          .build();
+
+      System.out.printf(
+          "[Generate] Writing %d row groups of %,d rows each (COLUMN-level statistics / page index)...%n",
+          numGroups, rowsPerGroup);
+      long t0 = System.nanoTime();
+      try (TableWriter writer = Table.writeParquetChunked(opts, out)) {
+        for (int g = 0; g < numGroups; g++) {
+          int start   = g * rowsPerGroup;  // id stays globally sequential
+          int zipBase = zipBases[g];
+          try (ColumnVector id = ColumnVector.fromInts(
+                   IntStream.range(start, start + rowsPerGroup).toArray());
+               ColumnVector zipCode = ColumnVector.fromInts(
+                   IntStream.range(0, rowsPerGroup).map(i -> zipBase + i).toArray());
+               ColumnVector numUnits = ColumnVector.fromInts(
+                   IntStream.range(0, rowsPerGroup).map(i -> 1 + (i % 3)).toArray());
+               Table t = new Table(id, zipCode, numUnits)) {
+            writer.write(t);
+          }
+        }
+      }
+      long ms = (System.nanoTime() - t0) / 1_000_000L;
+      System.out.printf("[Generate] Wrote %,d rows to %s in %d ms.%n", totalRows, out, ms);
+    } finally {
+      if (isRmmInitializedByApp && Rmm.isInitialized()) {
+        Rmm.shutdown();
+      }
+    }
+  }
+}

--- a/java/examples/hybrid_scan_io/src/main/java/ai/rapids/cudf/examples/HybridScanIoExample.java
+++ b/java/examples/hybrid_scan_io/src/main/java/ai/rapids/cudf/examples/HybridScanIoExample.java
@@ -1,0 +1,324 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf.examples;
+
+import ai.rapids.cudf.ByteRange;
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DeviceMemoryBuffer;
+import ai.rapids.cudf.HostMemoryBuffer;
+import ai.rapids.cudf.HybridScanReader;
+import ai.rapids.cudf.ParquetOptions;
+import ai.rapids.cudf.Rmm;
+import ai.rapids.cudf.RmmAllocationMode;
+import ai.rapids.cudf.Table;
+import ai.rapids.cudf.UseDataPageMask;
+import ai.rapids.cudf.ast.BinaryOperation;
+import ai.rapids.cudf.ast.BinaryOperator;
+import ai.rapids.cudf.ast.ColumnNameReference;
+import ai.rapids.cudf.ast.ColumnReference;
+import ai.rapids.cudf.ast.CompiledExpression;
+import ai.rapids.cudf.ast.Literal;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Reads a Parquet file three times for a comparison of the legacy reader
+ * and two flavours of the experimental {@link HybridScanReader}:
+ * <ol>
+ *   <li>{@link Table#readParquet(ParquetOptions, File)} (legacy) — read all projected
+ *       columns then apply the filter on the result;</li>
+ *   <li>{@code HybridScanReader} two-step with {@code RowMaskKind.ALL_TRUE} — row-group
+ *       stats pruning + filter materialisation, but no page-index pruning;</li>
+ *   <li>{@code HybridScanReader} two-step with {@code RowMaskKind.PAGE_INDEX_STATS} —
+ *       same as (2) plus a page-index-seeded row mask consumed via
+ *       {@code UseDataPageMask.YES}.</li>
+ * </ol>
+ * Each scenario is implemented in its own helper method and tagged with a labelled-bullet
+ * prefix in stdout: {@code [Setup]}, {@code [Legacy]}, {@code [Hybrid]}, and
+ * {@code [Hybrid: PageIndex Filtering]}.
+ *
+ * <p>Usage:
+ * <pre>
+ * mvn -pl java/examples/hybrid_scan_io exec:java \
+ *     -Dexec.mainClass=ai.rapids.cudf.examples.HybridScanIoExample \
+ *     -Dexec.args="/path/to/file.parquet col_name int_value"
+ * </pre>
+ */
+public final class HybridScanIoExample {
+  private HybridScanIoExample() {}
+
+  public static void main(String[] args) throws IOException {
+    if (args.length < 3) {
+      System.err.println(
+          "Usage: HybridScanIoExample <parquet-file> <column-name> <int-literal>\n" +
+          "  parquet-file   Path to a Parquet file" +
+              " (use GenerateSampleParquetFileMain to create one)\n" +
+          "  column-name    Name of an integer column to filter on (e.g. zip_code)\n" +
+          "  int-literal    Integer threshold; rows where column-name > int-literal are kept");
+      System.exit(1);
+    }
+    File path = new File(args[0]);
+    String columnName = args[1];
+    int literalValue = Integer.parseInt(args[2]);
+
+    if (!path.isFile()) {
+      System.err.println("Input file not found: " + path);
+      System.exit(2);
+    }
+
+    // Projected columns, in the order they will appear in every materialised Table.
+    // Used to build ParquetOptions and to validate that the user-supplied column name
+    // is in the projected set. The legacy path also resolves the name to an index
+    // because computeColumn on a plain Table requires positional ColumnReference.
+    java.util.List<String> projected = java.util.Arrays.asList("id", "zip_code", "num_units");
+    int columnIndex = projected.indexOf(columnName);
+    if (columnIndex < 0) {
+      System.err.println("Column must be one of " + projected + ", got: " + columnName);
+      System.exit(3);
+    }
+
+    try {
+      if (!Rmm.isInitialized()) {
+        System.out.println("[Setup] Initialising RMM (512 MB POOL)...");
+        Rmm.initialize(RmmAllocationMode.POOL, null, 512L * 1024L * 1024L);
+      }
+
+      // Legacy filter: positional ColumnReference required by computeColumn on a plain Table.
+      BinaryOperation legacyExpr = new BinaryOperation(BinaryOperator.GREATER,
+          new ColumnReference(columnIndex), Literal.ofInt(literalValue));
+
+      // Hybrid filter: ColumnNameReference — the recommended API for HybridScanReader,
+      // which resolves column names against the Parquet schema during materialization.
+      BinaryOperation hybridExpr = new BinaryOperation(BinaryOperator.GREATER,
+          new ColumnNameReference(columnName), Literal.ofInt(literalValue));
+
+      try (CompiledExpression legacyFilter = legacyExpr.compile();
+           CompiledExpression hybridFilter = hybridExpr.compile()) {
+        // The hybrid scan reader splits the projected columns into two sets internally:
+        //   * "filter columns"  — columns referenced by the filter expression
+        //   * "payload columns" — projected columns that are NOT in the filter
+        // To exercise both materialize calls, we include all columns from the fixture
+        // (`id`, `zip_code`, `num_units`); the filter column is `zip_code`, leaving `id` and
+        // `num_units` as the payload set. Adjust this if you point the example at
+        // a different file.
+        ParquetOptions.Builder optsBuilder = ParquetOptions.builder();
+        for (String col : projected) {
+          optsBuilder.includeColumn(col);
+        }
+        ParquetOptions readOpts = optsBuilder.build();
+
+        long legacyTotal = runLegacy(path, readOpts, legacyFilter, columnName, literalValue);
+        System.out.println();
+        runHybridTwoStep(path, readOpts, hybridFilter, columnName, literalValue, legacyTotal);
+        System.out.println();
+        runHybridWithPageIndex(path, readOpts, hybridFilter, columnName, literalValue, legacyTotal);
+      }
+    } finally {
+      if (Rmm.isInitialized()) {
+        Rmm.shutdown();
+      }
+    }
+  }
+
+  /**
+   * Scenario 1: legacy reader path. Reads all projected columns then applies the filter on
+   * the materialised result. We deliberately do NOT push the filter into
+   * {@link Table#readParquet(ParquetOptions, File, CompiledExpression)} -- the legacy
+   * reader's row-group pruning is therefore not exercised. The hybrid scenarios below DO
+   * prune row groups via {@code filterRowGroupsWithStats}, so the comparison is biased
+   * toward hybrid by exactly one row-group's worth of decode + I/O. Treat the legacy
+   * timing as an upper bound on what the two-step / page-index variants replace.
+   *
+   * @return the unfiltered row count of the file (reused as the {@code / N} denominator
+   *         in the hybrid scenarios so all three paths print "{filtered} / {total}").
+   */
+  private static long runLegacy(File path, ParquetOptions readOpts, CompiledExpression filter,
+                                String columnName, int literalValue) {
+    System.out.println(
+        "[Legacy] Reading entire file via Table.readParquet (no filter pushdown)...");
+    long legacyRows;
+    long legacyTotal;
+    long t0 = System.nanoTime();
+    try (Table legacyTable = Table.readParquet(readOpts, path);
+         ColumnVector mask = filter.computeColumn(legacyTable);
+         Table filtered = legacyTable.filter(mask)) {
+      legacyTotal = legacyTable.getRowCount();
+      legacyRows = filtered.getRowCount();
+    }
+    long legacyMs = (System.nanoTime() - t0) / 1_000_000L;
+    System.out.printf("[Legacy] Applied filter '%s > %,d' on materialised table.%n",
+        columnName, literalValue);
+    System.out.printf("[Legacy] %,d / %,d rows survive.%n", legacyRows, legacyTotal);
+    System.out.printf("[Legacy] Processing time: %d ms.%n", legacyMs);
+    return legacyTotal;
+  }
+
+  /**
+   * Scenario 2: hybrid scan two-step with an all-true row mask. Reads only the footer up
+   * front, prunes row groups via column-chunk statistics, then copies just the surviving
+   * filter + payload column chunks to the device. {@code RowMaskKind.ALL_TRUE} +
+   * {@code UseDataPageMask.NO} means no page-index pruning happens here -- that's what
+   * scenario 3 below adds.
+   */
+  private static void runHybridTwoStep(File path, ParquetOptions readOpts,
+                                       CompiledExpression filter, String columnName,
+                                       int literalValue, long legacyTotal) throws IOException {
+    System.out.println("[Hybrid] Reading just the Parquet footer (no full-file IO)...");
+    long t1 = System.nanoTime();
+    try (HostMemoryBuffer footer = Util.readFooterOnly(path);
+         HybridScanReader reader = new HybridScanReader(footer, readOpts, filter)) {
+      System.out.printf("[Hybrid] Opened HybridScanReader; footer is %d bytes.%n",
+          footer.getLength());
+      int[] all = reader.allRowGroups();
+      int[] survived = reader.filterRowGroupsWithStats(all);
+      System.out.printf(
+          "[Hybrid] Stats-based row-group pruning: %d / %d row groups survive.%n",
+          survived.length, all.length);
+
+      if (survived.length == 0) {
+        System.out.println(
+            "[Hybrid] All row groups pruned by statistics; nothing to read.");
+        return;
+      }
+
+      ByteRange[] filterRanges = reader.filterColumnChunksByteRanges(survived);
+      ByteRange[] payloadRanges = reader.payloadColumnChunksByteRanges(survived);
+      System.out.printf(
+          "[Hybrid] Copying %d filter column byte range(s) (%s) to device.%n",
+          filterRanges.length, columnName);
+      System.out.printf(
+          "[Hybrid] Copying %d payload column byte range(s) to device.%n",
+          payloadRanges.length);
+
+      DeviceMemoryBuffer[] filterCols = null;
+      DeviceMemoryBuffer[] payloadCols = null;
+      long hybridRows;
+      try (HostMemoryBuffer file = Util.readFileToHostBuffer(path)) {
+        filterCols = Util.copyRangesToDevice(file, filterRanges);
+        payloadCols = Util.copyRangesToDevice(file, payloadRanges);
+      }
+      try (HybridScanReader.FilterMaterializationResult fr =
+               reader.materializeFilterColumns(survived, filterCols, UseDataPageMask.NO,
+                   HybridScanReader.RowMaskKind.ALL_TRUE);
+           Table pTable = reader.materializePayloadColumns(survived, payloadCols,
+               fr.rowMask(), UseDataPageMask.NO)) {
+        hybridRows = pTable.getRowCount();
+        System.out.printf(
+            "[Hybrid] Materialised filter columns: %,d rows survive %s > %,d.%n",
+            fr.table().getRowCount(), columnName, literalValue);
+        System.out.printf(
+            "[Hybrid] Materialised payload columns aligned to row mask: %,d rows.%n",
+            hybridRows);
+      } finally {
+        Util.closeAll(filterCols);
+        Util.closeAll(payloadCols);
+      }
+      long hybridMs = (System.nanoTime() - t1) / 1_000_000L;
+      System.out.printf("[Hybrid] Total: %,d / %,d rows survive.%n", hybridRows, legacyTotal);
+      System.out.printf("[Hybrid] Processing time: %d ms.%n", hybridMs);
+    }
+  }
+
+  /**
+   * Scenario 3: hybrid scan two-step with a page-index-seeded row mask. Differs from
+   * scenario 2 in two ways:
+   * <ul>
+   *   <li>Uses staged targeted reads: footer only up front, then the page-index byte range,
+   *       then only the surviving filter + payload column-chunk byte ranges. No full-file
+   *       read is performed at any point.</li>
+   *   <li>Materialises filter + payload columns with
+   *       {@code RowMaskKind.PAGE_INDEX_STATS} + {@code UseDataPageMask.YES}, so the row
+   *       mask is seeded from page-level statistics and the materialise calls actually
+   *       consume the resulting data-page mask (skipping pages whose stats can't satisfy
+   *       the filter).</li>
+   * </ul>
+   * If the file has no page index (e.g. tiny fixtures, even with PAGE statistics enabled),
+   * the variant prints a notice and returns -- mirroring the hedge in
+   * {@code testPageIndexByteRangeAndSetup}.
+   */
+  private static void runHybridWithPageIndex(File path, ParquetOptions readOpts,
+                                             CompiledExpression filter, String columnName,
+                                             int literalValue, long legacyTotal)
+      throws IOException {
+    System.out.println(
+        "[Hybrid: PageIndex Filtering] Reading just the Parquet footer"
+            + " (page index and chunks fetched on demand)...");
+    long t = System.nanoTime();
+    try (HostMemoryBuffer footer = Util.readFooterOnly(path);
+         HybridScanReader reader = new HybridScanReader(footer, readOpts, filter)) {
+      System.out.printf(
+          "[Hybrid: PageIndex Filtering] Opened HybridScanReader; footer is %d bytes.%n",
+          footer.getLength());
+
+      ByteRange piRange = reader.pageIndexByteRange();
+      if (piRange.size() == 0) {
+        System.out.println(
+            "[Hybrid: PageIndex Filtering] File has no page index; skipping this variant.");
+        return;
+      }
+      try (HostMemoryBuffer pi = Util.readByteRange(path, piRange)) {
+        reader.setupPageIndex(pi);
+      }
+      System.out.printf(
+          "[Hybrid: PageIndex Filtering] Loaded page index (%d bytes).%n", piRange.size());
+
+      int[] all = reader.allRowGroups();
+      int[] survived = reader.filterRowGroupsWithStats(all);
+      System.out.printf(
+          "[Hybrid: PageIndex Filtering] Stats-based row-group pruning:"
+              + " %d / %d row groups survive.%n",
+          survived.length, all.length);
+      if (survived.length == 0) {
+        System.out.println(
+            "[Hybrid: PageIndex Filtering] All row groups pruned by statistics; nothing to read.");
+        return;
+      }
+
+      ByteRange[] filterRanges  = reader.filterColumnChunksByteRanges(survived);
+      ByteRange[] payloadRanges = reader.payloadColumnChunksByteRanges(survived);
+      System.out.printf(
+          "[Hybrid: PageIndex Filtering] Reading %d filter column byte range(s) (%s) to device.%n",
+          filterRanges.length, columnName);
+      System.out.printf(
+          "[Hybrid: PageIndex Filtering] Reading %d payload column byte range(s) to device.%n",
+          payloadRanges.length);
+
+      DeviceMemoryBuffer[] filterCols = null;
+      DeviceMemoryBuffer[] payloadCols = null;
+      long hybridRows;
+      try {
+        filterCols  = Util.copyRangesToDevice(path, filterRanges);
+        payloadCols = Util.copyRangesToDevice(path, payloadRanges);
+        try (HybridScanReader.FilterMaterializationResult fr =
+                 reader.materializeFilterColumns(survived, filterCols, UseDataPageMask.YES,
+                     HybridScanReader.RowMaskKind.PAGE_INDEX_STATS);
+             Table pTable = reader.materializePayloadColumns(survived, payloadCols,
+                 fr.rowMask(), UseDataPageMask.YES)) {
+          hybridRows = pTable.getRowCount();
+          long rowsInSurvivedGroups = fr.rowMask().getRowCount();
+          long rowsSkipped = rowsInSurvivedGroups - hybridRows;
+          System.out.printf(
+              "[Hybrid: PageIndex Filtering] Row-group survivors: %,d rows available"
+                  + " (%d group(s) × rows).%n",
+              rowsInSurvivedGroups, survived.length);
+          System.out.printf(
+              "[Hybrid: PageIndex Filtering] Page-index + filter: %,d rows skipped,"
+                  + " %,d rows survive %s > %,d.%n",
+              rowsSkipped, hybridRows, columnName, literalValue);
+        }
+      } finally {
+        Util.closeAll(filterCols);
+        Util.closeAll(payloadCols);
+      }
+      long ms = (System.nanoTime() - t) / 1_000_000L;
+      System.out.printf(
+          "[Hybrid: PageIndex Filtering] Total: %,d / %,d rows survive.%n",
+          hybridRows, legacyTotal);
+      System.out.printf("[Hybrid: PageIndex Filtering] Processing time: %d ms.%n", ms);
+    }
+  }
+}

--- a/java/examples/hybrid_scan_io/src/main/java/ai/rapids/cudf/examples/HybridScanPipelineExample.java
+++ b/java/examples/hybrid_scan_io/src/main/java/ai/rapids/cudf/examples/HybridScanPipelineExample.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf.examples;
+
+import ai.rapids.cudf.ByteRange;
+import ai.rapids.cudf.DeviceMemoryBuffer;
+import ai.rapids.cudf.HostMemoryBuffer;
+import ai.rapids.cudf.HybridScanReader;
+import ai.rapids.cudf.ParquetOptions;
+import ai.rapids.cudf.Rmm;
+import ai.rapids.cudf.RmmAllocationMode;
+import ai.rapids.cudf.Table;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Demonstrates memory-bounded streaming reads of a Parquet file by splitting row groups into
+ * passes (bounded by {@code passReadLimit} bytes) and each pass into output {@link Table} chunks
+ * (bounded by {@code chunkReadLimit} bytes). No filter is applied — all columns and all rows are
+ * materialised.
+ *
+ * <p>This illustrates how to bound GPU memory usage for very large files: the pass read limit caps
+ * total row-group bytes copied to device per pass, and the chunk read limit caps decoded output Table
+ * bytes per {@link HybridScanReader#materializeAllColumnsChunk()} call. Set either limit to
+ * {@code 0} to remove that bound.
+ *
+ * <p>Usage:
+ * <pre>
+ * mvn -pl java/examples/hybrid_scan_io exec:java \
+ *     -Dexec.mainClass=ai.rapids.cudf.examples.HybridScanPipelineExample \
+ *     -Dexec.args="/path/to/file.parquet [pass-bytes [chunk-bytes]]"
+ * </pre>
+ *
+ * <p>Both byte limits default to {@code 0} (no limit).
+ */
+public final class HybridScanPipelineExample {
+  private HybridScanPipelineExample() {}
+
+  public static void main(String[] args) throws IOException {
+    if (args.length < 1) {
+      System.err.println(
+          "Usage: HybridScanPipelineExample <parquet-file> [row-group-batch-bytes [chunk-bytes]]\n" +
+          "  parquet-file          Path to a Parquet file" +
+              " (use GenerateSampleParquetFileMain to create one)\n" +
+          "  row-group-batch-bytes Row group batch size in bytes: maximum total uncompressed size\n" +
+          "                        of the row groups in a single pass (batch). A pass is a batch\n" +
+          "                        of row groups whose combined uncompressed size fits within this\n" +
+          "                        limit. 0 = no limit (all row groups in one pass).\n" +
+          "  chunk-bytes           Maximum size in bytes of a single output cuDF Table chunk\n" +
+          "                        within a pass. Controls how much decoded GPU memory is used\n" +
+          "                        at once per chunk. 0 = no limit (entire pass as one Table).");
+      System.exit(1);
+    }
+    File path = new File(args[0]);
+    // Row group batch size in bytes: caps the total uncompressed size of row groups
+    // processed in a single pass (batch). 0 = no limit.
+    long passReadLimit  = (args.length >= 2) ? Long.parseLong(args[1]) : 0L;
+    // Maximum size in bytes of a single output cuDF Table chunk within a pass.
+    // Controls how much decoded GPU table memory is used at once. 0 = no limit.
+    long chunkReadLimit = (args.length >= 3) ? Long.parseLong(args[2]) : 0L;
+
+    if (!path.isFile()) {
+      System.err.println("Input file not found: " + path);
+      System.exit(2);
+    }
+
+    try {
+      if (!Rmm.isInitialized()) {
+        System.out.println("[Setup] Initialising RMM (512 MB POOL)...");
+        Rmm.initialize(RmmAllocationMode.POOL, null, 512L * 1024L * 1024L);
+      }
+
+      System.out.println("[Pipeline] Scenario: memory-bounded streaming read"
+          + " \u2014 no filter, all columns.");
+      System.out.println("[Pipeline]   Purpose : illustrates GPU memory bounding for large files"
+          + " via two limits:");
+      System.out.println("[Pipeline]             pass read limit caps total row group bytes"
+          + " copied to device per pass;");
+      System.out.println("[Pipeline]             chunk read limit caps decoded output Table bytes"
+          + " per materialize call.");
+      System.out.println("[Pipeline]             Set either to 0 to remove that limit.");
+      System.out.printf("[Pipeline]   Pass read limit : %,d bytes%s%n",
+          passReadLimit,
+          passReadLimit == 0 ? "  (0 = all row groups in one pass)" : "");
+      System.out.printf("[Pipeline]   Chunk read limit: %,d bytes%s%n",
+          chunkReadLimit,
+          chunkReadLimit == 0 ? "  (0 = entire pass as one Table chunk)" : "");
+
+      System.out.println("[Pipeline] Step 1 \u2014 Loading full file to host buffer;"
+          + " slicing footer...");
+      try (HostMemoryBuffer file = Util.readFileToHostBuffer(path);
+           HostMemoryBuffer footer = Util.extractFooter(file);
+           HybridScanReader reader = new HybridScanReader(footer, ParquetOptions.DEFAULT, null)) {
+        int[] allRowGroups = reader.allRowGroups();
+        System.out.printf(
+            "[Pipeline] Opened reader on %d row group(s)  (no filter; projecting all columns).%n",
+            allRowGroups.length);
+
+        // Partition row groups into passes (batches) so each pass's total uncompressed
+        // size stays within the row group batch size in bytes (passReadLimit).
+        int[][] passes = reader.constructRowGroupPasses(allRowGroups, passReadLimit);
+        System.out.printf(
+            "[Pipeline] Step 2 \u2014 Partitioning %d row group(s) into %d pass(es)"
+                + " (pass-read-limit=%,d bytes).%n",
+            allRowGroups.length, passes.length, passReadLimit);
+
+        long totalRows = 0;
+        long t0 = System.nanoTime();
+        // Each pass is a batch of row groups. Within a pass, materialise in chunks
+        // of at most chunkReadLimit decoded bytes.
+        for (int p = 0; p < passes.length; p++) {
+          int[] pass = passes[p];
+          // Ask the reader which byte ranges in the file hold the column chunks for
+          // this pass's row groups. Each ByteRange is a (offset, size) pair pointing
+          // into the raw Parquet file bytes — no data has been read to the GPU yet.
+          ByteRange[] ranges = reader.allColumnChunksByteRanges(pass);
+          System.out.printf(
+              "[Pipeline] Step 3 \u2014 Pass %d of %d: %d row group(s),"
+                  + " copying %d byte range(s) to device...%n",
+              p + 1, passes.length, pass.length, ranges.length);
+          // Copy only the needed byte ranges from host memory to GPU device memory.
+          // One DeviceMemoryBuffer is allocated per range; together they hold the
+          // compressed column chunk data for every column in this pass.
+          DeviceMemoryBuffer[] devs = Util.copyRangesToDevice(file, ranges);
+          try {
+            System.out.printf("[Pipeline]   Draining chunks (chunk-read-limit=%,d bytes)...%n",
+                chunkReadLimit);
+            // Register the compressed column chunk data with the reader and set up
+            // the chunking state. The reader decompresses and decodes page headers
+            // but does not yet produce any output rows. chunkReadLimit caps the size
+            // in bytes of each output cuDF Table chunk (i.e. how much decoded GPU
+            // table memory is used at once); passReadLimit is the row group batch
+            // size in bytes used to bound GPU memory for this pass.
+            reader.setupChunkingForAllColumns(chunkReadLimit, passReadLimit, pass, devs);
+            int chunks = 0;
+            long passRows = 0;
+            // Drain the reader one output chunk at a time. Each call to
+            // materializeAllColumnsChunk() decodes the next slice of pages into a
+            // Table and returns it. The loop ends when all pages in this pass have
+            // been decoded.
+            while (reader.hasNextTableChunk()) {
+              try (Table chunk = reader.materializeAllColumnsChunk()) {
+                passRows += chunk.getRowCount();
+                chunks++;
+              }
+            }
+            totalRows += passRows;
+            System.out.printf(
+                "[Pipeline]   Pass %d complete: %d chunk(s), %,d row(s).%n",
+                p + 1, chunks, passRows);
+          } finally {
+            Util.closeAll(devs);
+          }
+        }
+        long ms = (System.nanoTime() - t0) / 1_000_000L;
+        System.out.printf("[Pipeline] Total: %,d row(s) across %d pass(es).%n",
+            totalRows, passes.length);
+        System.out.printf("[Pipeline] Processing time: %d ms.%n", ms);
+      }
+    } finally {
+      if (Rmm.isInitialized()) {
+        Rmm.shutdown();
+      }
+    }
+  }
+}

--- a/java/examples/hybrid_scan_io/src/main/java/ai/rapids/cudf/examples/Util.java
+++ b/java/examples/hybrid_scan_io/src/main/java/ai/rapids/cudf/examples/Util.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf.examples;
+
+import ai.rapids.cudf.ByteRange;
+import ai.rapids.cudf.DeviceMemoryBuffer;
+import ai.rapids.cudf.HostMemoryBuffer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+
+/**
+ * Shared helpers for the hybrid-scan Java examples. Mirrors the lightweight pieces of
+ * {@code cpp/examples/hybrid_scan_io/io_utils.hpp}.
+ */
+public final class Util {
+  private Util() {}
+
+  /** Magic + length suffix at the end of every Parquet file. */
+  private static final int FOOTER_TAIL_BYTES = 8;
+
+  /**
+   * Copy the entire file contents into a {@link HostMemoryBuffer}.
+   */
+  public static HostMemoryBuffer readFileToHostBuffer(File file) throws IOException {
+    byte[] bytes = Files.readAllBytes(file.toPath());
+    HostMemoryBuffer buf = HostMemoryBuffer.allocate(bytes.length);
+    buf.setBytes(0, bytes, 0, bytes.length);
+    return buf;
+  }
+
+  /**
+   * Slice the Parquet footer out of a host buffer that holds the full file.
+   */
+  public static HostMemoryBuffer extractFooter(HostMemoryBuffer file) {
+    long fileLen = file.getLength();
+    int footerLen = file.getInt(fileLen - FOOTER_TAIL_BYTES);
+    long footerStart = fileLen - FOOTER_TAIL_BYTES - footerLen;
+    return file.slice(footerStart, footerLen);
+  }
+
+  /**
+   * Reads the 4-byte little-endian footer length field from the tail of an open Parquet file.
+   * Leaves the file position undefined after returning.
+   */
+  private static int getFooterLength(RandomAccessFile raf) throws IOException {
+    raf.seek(raf.length() - FOOTER_TAIL_BYTES);
+    byte[] tail = new byte[4];
+    raf.readFully(tail);
+    return ByteBuffer.wrap(tail).order(ByteOrder.LITTLE_ENDIAN).getInt();
+  }
+
+  /**
+   * Reads only the Parquet footer bytes from {@code file} without loading the rest of the
+   * file into memory.
+   */
+  public static HostMemoryBuffer readFooterOnly(File file) throws IOException {
+    try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+      int footerLen = getFooterLength(raf);
+      byte[] bytes = new byte[footerLen];
+      raf.seek(raf.length() - FOOTER_TAIL_BYTES - footerLen);
+      raf.readFully(bytes);   // guaranteed complete read — no while loop needed
+      HostMemoryBuffer footer = HostMemoryBuffer.allocate(footerLen);
+      try {
+        footer.setBytes(0, bytes, 0, footerLen);
+        return footer;
+      } catch (RuntimeException e) {
+        footer.close();
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Reads the bytes described by {@code range} directly from {@code file} into a
+   * new {@link HostMemoryBuffer}. Uses a single {@link RandomAccessFile} seek.
+   * Caller owns the returned buffer and must close it.
+   */
+  public static HostMemoryBuffer readByteRange(File file, ByteRange range) throws IOException {
+    try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+      byte[] bytes = new byte[(int) range.size()];
+      raf.seek(range.offset());
+      raf.readFully(bytes);
+      HostMemoryBuffer buf = HostMemoryBuffer.allocate(range.size());
+      try {
+        buf.setBytes(0, bytes, 0, bytes.length);
+        return buf;
+      } catch (RuntimeException e) {
+        buf.close();
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Copy each {@link ByteRange} from a host buffer into its own {@link DeviceMemoryBuffer}.
+   * Caller owns the returned buffers and must close them.
+   */
+  public static DeviceMemoryBuffer[] copyRangesToDevice(HostMemoryBuffer file,
+                                                        ByteRange[] ranges) {
+    DeviceMemoryBuffer[] out = new DeviceMemoryBuffer[ranges.length];
+    try {
+      for (int i = 0; i < ranges.length; i++) {
+        ByteRange r = ranges[i];
+        DeviceMemoryBuffer dev = DeviceMemoryBuffer.allocate(r.size());
+        try (HostMemoryBuffer slice = file.slice(r.offset(), r.size())) {
+          dev.copyFromHostBuffer(slice);
+        }
+        out[i] = dev;
+      }
+      return out;
+    } catch (Throwable t) {
+      closeAll(out);
+      throw t;
+    }
+  }
+
+  /**
+   * Reads each {@link ByteRange} from {@code file} directly (one seek per range using a
+   * single open {@link RandomAccessFile}) and copies it into its own
+   * {@link DeviceMemoryBuffer}. Caller owns the returned buffers and must close them.
+   */
+  public static DeviceMemoryBuffer[] copyRangesToDevice(File file, ByteRange[] ranges)
+      throws IOException {
+    DeviceMemoryBuffer[] out = new DeviceMemoryBuffer[ranges.length];
+    try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+      for (int i = 0; i < ranges.length; i++) {
+        ByteRange r = ranges[i];
+        byte[] bytes = new byte[(int) r.size()];
+        raf.seek(r.offset());
+        raf.readFully(bytes);
+        DeviceMemoryBuffer dev = DeviceMemoryBuffer.allocate(r.size());
+        try (HostMemoryBuffer host = HostMemoryBuffer.allocate(r.size())) {
+          host.setBytes(0, bytes, 0, bytes.length);
+          dev.copyFromHostBuffer(host);
+        }
+        out[i] = dev;
+      }
+      return out;
+    } catch (Throwable t) {
+      closeAll(out);
+      throw t;
+    }
+  }
+
+  /** Best-effort close-all for an array of {@link DeviceMemoryBuffer}; ignores nulls. */
+  public static void closeAll(DeviceMemoryBuffer[] buffers) {
+    if (buffers == null) return;
+    for (DeviceMemoryBuffer b : buffers) {
+      if (b != null) b.close();
+    }
+  }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -385,11 +385,8 @@
                 <filtering>true</filtering>
             </resource>
             <resource>
-                <directory>${basedir}/..</directory>
-                <targetPath>META-INF</targetPath>
-                <includes>
-                    <include>LICENSE</include>
-                </includes>
+                <!-- Populated by the copy-license execution of maven-resources-plugin. -->
+                <directory>${project.build.directory}/license-resources</directory>
             </resource>
         </resources>
         <pluginManagement>
@@ -590,6 +587,24 @@
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>copy-license</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/license-resources/META-INF</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/..</directory>
+                                    <includes>
+                                        <include>LICENSE</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>copy-native-libs</id>
                         <phase>generate-resources</phase>

--- a/java/src/main/java/ai/rapids/cudf/ByteRange.java
+++ b/java/src/main/java/ai/rapids/cudf/ByteRange.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf;
+
+import java.util.Objects;
+
+/**
+ * Immutable byte range describing an offset and size within a file or buffer.
+ *
+ * <p>Mirrors {@code cudf::io::text::byte_range_info}.
+ *
+ * <p>The APIs in this file are experimental and subject to change.
+ */
+@Experimental
+public final class ByteRange {
+  private final long offset;
+  private final long size;
+
+  /**
+   * @param offset starting offset, in bytes, from the beginning of the source
+   * @param size   length of the range, in bytes
+   */
+  public ByteRange(long offset, long size) {
+    if (offset < 0) {
+      throw new IllegalArgumentException("offset must be >= 0, got " + offset);
+    }
+    if (size < 0) {
+      throw new IllegalArgumentException("size must be >= 0, got " + size);
+    }
+    this.offset = offset;
+    this.size = size;
+  }
+
+  /** @return starting byte offset within the source. */
+  public long offset() {
+    return offset;
+  }
+
+  /** @return length of the byte range, in bytes. */
+  public long size() {
+    return size;
+  }
+
+  /** @return {@code true} when the range has zero size. */
+  public boolean isEmpty() {
+    return size == 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ByteRange)) return false;
+    ByteRange other = (ByteRange) o;
+    return offset == other.offset && size == other.size;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(offset, size);
+  }
+
+  @Override
+  public String toString() {
+    return "ByteRange{offset=" + offset + ", size=" + size + "}";
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/Experimental.java
+++ b/java/src/main/java/ai/rapids/cudf/Experimental.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a public type whose API is still considered experimental and may change
+ * without notice. Code annotated with {@code @Experimental} is not subject to
+ * cuDF Java compatibility guarantees.
+ *
+ * <p>Public nested types of an annotated type inherit the experimental status by
+ * association and do not need a separate marker.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface Experimental {
+}

--- a/java/src/main/java/ai/rapids/cudf/HybridScanReader.java
+++ b/java/src/main/java/ai/rapids/cudf/HybridScanReader.java
@@ -334,9 +334,14 @@ public class HybridScanReader implements AutoCloseable {
     long[] handles = materializeFilterColumnsWithKind(cleaner.nativeHandle, rowGroupIndices,
         addrs, lens, mode.getNativeValue(), allTrue);
     ColumnVector rowMask = new ColumnVector(handles[0]);
-    long[] tableHandles = Arrays.copyOfRange(handles, 1, handles.length);
-    Table table = new Table(tableHandles);
-    return new FilterMaterializationResult(table, rowMask);
+    try {
+      long[] tableHandles = Arrays.copyOfRange(handles, 1, handles.length);
+      Table table = new Table(tableHandles);
+      return new FilterMaterializationResult(table, rowMask);
+    } catch (Throwable t) {
+      rowMask.close();
+      throw t;
+    }
   }
 
   /**
@@ -393,6 +398,9 @@ public class HybridScanReader implements AutoCloseable {
    * <p>Calling this method again before {@link #takeFilterRowMask()} discards the previous
    * chunked-filter row mask.
    *
+   * <p>Caller must keep {@code columnChunkData} open until {@link #takeFilterRowMask()} (or
+   * a re-setup); the native reader holds references to it across chunk calls.
+   *
    * @param chunkReadLimit  per-chunk byte limit, or 0 for no limit
    * @param passReadLimit   per-pass byte limit, or 0 for no limit
    * @param kind            how to initialise the row mask
@@ -445,6 +453,9 @@ public class HybridScanReader implements AutoCloseable {
   /**
    * Set up chunking state for payload-column materialization. Subsequent calls to
    * {@link #materializePayloadColumnsChunk(ColumnVector)} will yield successive chunks.
+   *
+   * <p>Caller must keep {@code columnChunkData} open until {@link #hasNextTableChunk()}
+   * returns {@code false}; the native reader holds references to it across chunk calls.
    */
   public void setupChunkingForPayloadColumns(long chunkReadLimit,
                                              long passReadLimit,
@@ -473,6 +484,9 @@ public class HybridScanReader implements AutoCloseable {
   /**
    * Set up chunking state for all-column materialization (single-pass mode). Subsequent calls
    * to {@link #materializeAllColumnsChunk()} will yield successive chunks.
+   *
+   * <p>Caller must keep {@code columnChunkData} open until {@link #hasNextTableChunk()}
+   * returns {@code false}; the native reader holds references to it across chunk calls.
    */
   public void setupChunkingForAllColumns(long chunkReadLimit,
                                          long passReadLimit,

--- a/java/src/main/java/ai/rapids/cudf/HybridScanReader.java
+++ b/java/src/main/java/ai/rapids/cudf/HybridScanReader.java
@@ -1,0 +1,669 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf;
+
+import ai.rapids.cudf.ast.CompiledExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * Experimental Parquet hybrid-scan reader.
+ *
+ * <p>This class is the Java binding for
+ * {@code cudf::io::parquet::experimental::hybrid_scan_reader}. It is designed for highly
+ * selective filter expressions over Parquet files and exposes the multi-step pipeline that
+ * the C++ reader uses internally:
+ * <ol>
+ *   <li>Read the Parquet footer (and optional page index) to drive row-group / page-level
+ *       pruning.</li>
+ *   <li>Filter the row groups using statistics, bloom filters, and dictionary pages.</li>
+ *   <li>Materialize the <em>filter</em> columns; the reader builds an initial row mask from
+ *       the chosen {@link RowMaskKind} and then mutates it down to only the rows that
+ *       survive the AST filter.</li>
+ *   <li>Materialize the <em>payload</em> columns using the surviving row mask.</li>
+ * </ol>
+ *
+ * <p>Single-shot convenience methods are provided for the common cases
+ * ({@link #materializeFilterColumns(int[], DeviceMemoryBuffer[], UseDataPageMask, RowMaskKind)}
+ * and {@link #materializeAllColumns(int[], DeviceMemoryBuffer[])}).
+ *
+ * <p>Chunked / streaming materialization is also supported via the
+ * {@code setupChunkingFor*} + {@code materialize*Chunk} family of methods, mirroring the C++
+ * chunked reader pipeline.
+ *
+ * <p>The APIs in this file are experimental and subject to change.
+ */
+@Experimental
+public class HybridScanReader implements AutoCloseable {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  /**
+   * Selects which row mask is built internally by
+   * {@link #materializeFilterColumns(int[], DeviceMemoryBuffer[], UseDataPageMask, RowMaskKind)}
+   * and
+   * {@link #setupChunkingForFilterColumns(long, long, int[], UseDataPageMask, RowMaskKind, DeviceMemoryBuffer[])}.
+   */
+  public enum RowMaskKind {
+    /** All rows initially visible — no page-level pruning. */
+    ALL_TRUE,
+    /**
+     * Row visibility seeded from page-index statistics. Requires that
+     * {@link #setupPageIndex(HostMemoryBuffer)} has already been called.
+     */
+    PAGE_INDEX_STATS
+  }
+
+  /**
+   * The result of a combined row-mask-build + filter-column-materialization call.
+   *
+   * <p>Both the filter {@link Table} and the mutated row {@link ColumnVector} mask are
+   * owned by this object. Close via try-with-resources to release both.
+   */
+  public static final class FilterMaterializationResult implements AutoCloseable {
+    private final Table table;
+    private final ColumnVector rowMask;
+    private boolean closed = false;
+
+    FilterMaterializationResult(Table table, ColumnVector rowMask) {
+      this.table = table;
+      this.rowMask = rowMask;
+    }
+
+    /** @return the materialized filter column table. */
+    public Table table() { return table; }
+
+    /** @return the (mutated) row mask after the filter expression was applied. */
+    public ColumnVector rowMask() { return rowMask; }
+
+    @Override
+    public synchronized void close() {
+      if (closed) return;
+      try { table.close(); } finally {
+        try { rowMask.close(); } finally { closed = true; }
+      }
+    }
+  }
+
+  private static final Logger log = LoggerFactory.getLogger(HybridScanReader.class);
+
+  private static final class HybridScanReaderCleaner extends MemoryCleaner.Cleaner {
+    private long nativeHandle;
+
+    HybridScanReaderCleaner(long nativeHandle) {
+      this.nativeHandle = nativeHandle;
+    }
+
+    @Override
+    protected synchronized boolean cleanImpl(boolean logErrorIfNotClean) {
+      long origAddress = nativeHandle;
+      boolean neededCleanup = nativeHandle != 0;
+      if (neededCleanup) {
+        try {
+          destroy(nativeHandle);
+        } finally {
+          nativeHandle = 0;
+        }
+        if (logErrorIfNotClean) {
+          log.error("A HYBRID SCAN READER WAS LEAKED (ID: {} {})", id,
+              Long.toHexString(origAddress));
+        }
+      }
+      return neededCleanup;
+    }
+
+    @Override
+    public boolean isClean() {
+      return nativeHandle == 0;
+    }
+  }
+
+  private final HybridScanReaderCleaner cleaner;
+  private boolean isClosed = false;
+
+  /**
+   * Create a hybrid scan reader from the bytes of a Parquet file footer.
+   *
+   * <p>The {@code footerBuffer} can be obtained by reading the last few bytes of a Parquet
+   * file. See the {@code hybrid_scan_io} example for a helper that does exactly that.
+   *
+   * @param footerBuffer host-resident footer bytes (must remain valid until this constructor
+   *                     returns; the JNI reads the bytes synchronously)
+   * @param opts         Parquet reader options. {@link ParquetOptions#DEFAULT} by default.
+   * @param filter       optional compiled AST filter expression. May be {@code null}.
+   *                     The expression typically uses {@link ai.rapids.cudf.ast.ColumnNameReference}
+   *                     to refer to columns by name.
+   */
+  public HybridScanReader(HostMemoryBuffer footerBuffer,
+                          ParquetOptions opts,
+                          CompiledExpression filter) {
+    if (footerBuffer == null) {
+      throw new IllegalArgumentException("footerBuffer must not be null");
+    }
+    if (opts == null) {
+      opts = ParquetOptions.DEFAULT;
+    }
+    long filterHandle = (filter != null) ? filter.getNativeHandle() : 0;
+    String[] columnNames = opts.getIncludeColumnNames();
+    boolean[] readBinaryAsString = opts.getReadBinaryAsString();
+    DType timeUnit = opts.timeUnit();
+    long handle = createFromFooter(
+        footerBuffer.getAddress(),
+        footerBuffer.getLength(),
+        filterHandle,
+        columnNames,
+        readBinaryAsString,
+        timeUnit.getTypeId().getNativeId());
+    this.cleaner = new HybridScanReaderCleaner(handle);
+    MemoryCleaner.register(this, cleaner);
+    cleaner.addRef();
+  }
+
+  // ----------------------------------------------------------------------
+  // Metadata
+  // ----------------------------------------------------------------------
+
+  /** @return the byte range of the page index in the Parquet file. */
+  public ByteRange pageIndexByteRange() {
+    assertNotClosed();
+    long[] offsetSize = pageIndexByteRange(cleaner.nativeHandle);
+    return new ByteRange(offsetSize[0], offsetSize[1]);
+  }
+
+  /**
+   * Materialize the {@code ColumnIndex} / {@code OffsetIndex} structs (collectively, the page
+   * index) from the supplied bytes so that subsequent calls using
+   * {@link RowMaskKind#PAGE_INDEX_STATS} can use them.
+   *
+   * @param pageIndexBuffer host-resident page index bytes
+   */
+  public void setupPageIndex(HostMemoryBuffer pageIndexBuffer) {
+    assertNotClosed();
+    if (pageIndexBuffer == null) {
+      throw new IllegalArgumentException("pageIndexBuffer must not be null");
+    }
+    setupPageIndex(cleaner.nativeHandle,
+        pageIndexBuffer.getAddress(),
+        pageIndexBuffer.getLength());
+  }
+
+  // ----------------------------------------------------------------------
+  // Row group enumeration
+  // ----------------------------------------------------------------------
+
+  /** @return all row group indices in the Parquet file. */
+  public int[] allRowGroups() {
+    assertNotClosed();
+    return allRowGroups(cleaner.nativeHandle);
+  }
+
+  /** @return the total number of top-level rows in the supplied row groups. */
+  public long totalRowsInRowGroups(int[] rowGroupIndices) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    return totalRowsInRowGroups(cleaner.nativeHandle, rowGroupIndices);
+  }
+
+  // ----------------------------------------------------------------------
+  // Row group filtering
+  // ----------------------------------------------------------------------
+
+  /** Filter row groups using column-chunk statistics from the file footer. */
+  public int[] filterRowGroupsWithStats(int[] rowGroupIndices) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    return filterRowGroupsWithStats(cleaner.nativeHandle, rowGroupIndices);
+  }
+
+  /**
+   * Get the byte ranges in the source file that hold the bloom filter and dictionary page
+   * data needed for the next round of row-group pruning.
+   */
+  public SecondaryFilterRanges secondaryFiltersByteRanges(int[] rowGroupIndices) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    long[] packed = secondaryFiltersByteRanges(cleaner.nativeHandle, rowGroupIndices);
+    // Layout: [numBloomRanges, bloom_o0, bloom_s0, ..., dict_o0, dict_s0, ...]
+    int numBloom = (int) packed[0];
+    int totalRanges = (packed.length - 1) / 2;
+    int numDict = totalRanges - numBloom;
+    ByteRange[] bloom = new ByteRange[numBloom];
+    ByteRange[] dict = new ByteRange[numDict];
+    int idx = 1;
+    for (int i = 0; i < numBloom; i++) {
+      bloom[i] = new ByteRange(packed[idx], packed[idx + 1]);
+      idx += 2;
+    }
+    for (int i = 0; i < numDict; i++) {
+      dict[i] = new ByteRange(packed[idx], packed[idx + 1]);
+      idx += 2;
+    }
+    return new SecondaryFilterRanges(bloom, dict);
+  }
+
+  // TODO: add filterRowGroupsWithBloomFilters(int[] rowGroups) once the Java Parquet
+  //       writer can emit bloom filter blocks. The C++ writer exposes this via
+  //       parquet_writer_options::set_column_chunks_bloom_filter_params, which has not
+  //       yet been surfaced in ParquetWriterOptions / TableJni.cpp. Until then, any
+  //       file written from Java contains no bloom filter blocks and the method would
+  //       always return the input row groups unchanged.
+
+  /** Filter row groups using column-chunk dictionary pages loaded into device memory. */
+  public int[] filterRowGroupsWithDictionaryPages(DeviceMemoryBuffer[] dictionaryPageData,
+                                                  int[] rowGroupIndices) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    if (dictionaryPageData == null) {
+      throw new IllegalArgumentException("dictionaryPageData must not be null");
+    }
+    long[] addrs = new long[dictionaryPageData.length];
+    long[] lens = new long[dictionaryPageData.length];
+    for (int i = 0; i < dictionaryPageData.length; i++) {
+      addrs[i] = dictionaryPageData[i].getAddress();
+      lens[i] = dictionaryPageData[i].getLength();
+    }
+    return filterRowGroupsWithDictionaryPages(cleaner.nativeHandle, addrs, lens,
+        rowGroupIndices);
+  }
+
+  // ----------------------------------------------------------------------
+  // Byte ranges
+  // ----------------------------------------------------------------------
+
+  /** @return byte ranges for the column chunks of <em>filter</em> columns. */
+  public ByteRange[] filterColumnChunksByteRanges(int[] rowGroupIndices) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    return decodeRanges(filterColumnChunksByteRanges(cleaner.nativeHandle, rowGroupIndices));
+  }
+
+  /** @return byte ranges for the column chunks of <em>payload</em> columns. */
+  public ByteRange[] payloadColumnChunksByteRanges(int[] rowGroupIndices) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    return decodeRanges(payloadColumnChunksByteRanges(cleaner.nativeHandle, rowGroupIndices));
+  }
+
+  /** @return byte ranges for all column chunks (filter + payload) of the selected columns. */
+  public ByteRange[] allColumnChunksByteRanges(int[] rowGroupIndices) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    return decodeRanges(allColumnChunksByteRanges(cleaner.nativeHandle, rowGroupIndices));
+  }
+
+  // ----------------------------------------------------------------------
+  // Single-shot materialize
+  // ----------------------------------------------------------------------
+
+  /**
+   * Build a row mask according to {@code kind} and materialize the filter columns, applying
+   * the compiled filter expression. The row mask and the resulting filter table are returned
+   * together as a {@link FilterMaterializationResult}; close it via try-with-resources.
+   *
+   * <p>Pass {@link RowMaskKind#ALL_TRUE} when no page-index-based pruning is needed.
+   * Pass {@link RowMaskKind#PAGE_INDEX_STATS} to seed the mask from page-level statistics
+   * (requires {@link #setupPageIndex(HostMemoryBuffer)} to have been called first).
+   *
+   * @param rowGroupIndices  row groups to read
+   * @param columnChunkData  device buffers holding the filter column chunks, in the order
+   *                         returned by {@link #filterColumnChunksByteRanges(int[])}
+   * @param mode             whether to compute and use a data page mask
+   * @param kind             how to initialise the row mask
+   * @return combined filter table and mutated row mask; caller must close this result
+   */
+  public FilterMaterializationResult materializeFilterColumns(int[] rowGroupIndices,
+                                                              DeviceMemoryBuffer[] columnChunkData,
+                                                              UseDataPageMask mode,
+                                                              RowMaskKind kind) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    long[] addrs = bufferAddrs(columnChunkData);
+    long[] lens = bufferLens(columnChunkData);
+    boolean allTrue = (kind == RowMaskKind.ALL_TRUE);
+    long[] handles = materializeFilterColumnsWithKind(cleaner.nativeHandle, rowGroupIndices,
+        addrs, lens, mode.getNativeValue(), allTrue);
+    ColumnVector rowMask = new ColumnVector(handles[0]);
+    long[] tableHandles = Arrays.copyOfRange(handles, 1, handles.length);
+    Table table = new Table(tableHandles);
+    return new FilterMaterializationResult(table, rowMask);
+  }
+
+  /**
+   * Materialize only the payload columns, applying the supplied row mask to the output.
+   *
+   * @param rowGroupIndices  row groups to read
+   * @param columnChunkData  device buffers holding the payload column chunks, in the order
+   *                         returned by {@link #payloadColumnChunksByteRanges(int[])}
+   * @param rowMask          row mask (read-only)
+   * @param mode             whether to compute and use a data page mask
+   * @return the materialized payload column table
+   */
+  public Table materializePayloadColumns(int[] rowGroupIndices,
+                                         DeviceMemoryBuffer[] columnChunkData,
+                                         ColumnVector rowMask,
+                                         UseDataPageMask mode) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    requireNonNullRowMask(rowMask);
+    long[] addrs = bufferAddrs(columnChunkData);
+    long[] lens = bufferLens(columnChunkData);
+    long[] handles = materializePayloadColumns(cleaner.nativeHandle, rowGroupIndices,
+        addrs, lens, rowMask.getNativeView(), mode.getNativeValue());
+    return new Table(handles);
+  }
+
+  /**
+   * Materialize all (or selected) columns in a single pass. The filter expression is applied
+   * <em>after</em> reading, so this is most efficient for small files or when most rows
+   * survive the filter. For highly-selective filters, prefer the explicit two-step flow.
+   */
+  public Table materializeAllColumns(int[] rowGroupIndices,
+                                     DeviceMemoryBuffer[] columnChunkData) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    long[] addrs = bufferAddrs(columnChunkData);
+    long[] lens = bufferLens(columnChunkData);
+    long[] handles = materializeAllColumns(cleaner.nativeHandle, rowGroupIndices, addrs, lens);
+    return new Table(handles);
+  }
+
+  // ----------------------------------------------------------------------
+  // Chunked materialize
+  // ----------------------------------------------------------------------
+
+  /**
+   * Build a row mask according to {@code kind} and set up chunking state for filter-column
+   * materialization. The row mask is owned internally by the reader for the duration of
+   * the chunked filter pipeline; subsequent calls to {@link #materializeFilterColumnsChunk()}
+   * mutate it in place. After all chunks are drained, call {@link #takeFilterRowMask()} to
+   * transfer ownership of the row mask to the caller (typically to feed it into
+   * {@link #materializePayloadColumns(int[], DeviceMemoryBuffer[], ColumnVector, UseDataPageMask)}).
+   *
+   * <p>Calling this method again before {@link #takeFilterRowMask()} discards the previous
+   * chunked-filter row mask.
+   *
+   * @param chunkReadLimit  per-chunk byte limit, or 0 for no limit
+   * @param passReadLimit   per-pass byte limit, or 0 for no limit
+   * @param kind            how to initialise the row mask
+   */
+  public void setupChunkingForFilterColumns(long chunkReadLimit,
+                                            long passReadLimit,
+                                            int[] rowGroupIndices,
+                                            UseDataPageMask mode,
+                                            RowMaskKind kind,
+                                            DeviceMemoryBuffer[] columnChunkData) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    long[] addrs = bufferAddrs(columnChunkData);
+    long[] lens = bufferLens(columnChunkData);
+    boolean allTrue = (kind == RowMaskKind.ALL_TRUE);
+    setupChunkingForFilterColumnsWithKind(cleaner.nativeHandle,
+        chunkReadLimit, passReadLimit, rowGroupIndices, mode.getNativeValue(), allTrue,
+        addrs, lens);
+  }
+
+  /**
+   * @return the next filter-column chunk; throws if no chunk is available or if no chunked
+   *         filter pipeline is active. The internal row mask owned by this reader is
+   *         updated in place.
+   */
+  public Table materializeFilterColumnsChunk() {
+    assertNotClosed();
+    long[] handles = materializeFilterColumnsChunk(cleaner.nativeHandle);
+    return new Table(handles);
+  }
+
+  /**
+   * Transfer ownership of the row mask produced by the chunked filter-column materialization
+   * to the caller. Typically called after all {@link #materializeFilterColumnsChunk()} calls
+   * complete and immediately before
+   * {@link #materializePayloadColumns(int[], DeviceMemoryBuffer[], ColumnVector, UseDataPageMask)}.
+   *
+   * <p>After this call the reader has no chunked-filter row mask; subsequent
+   * {@link #materializeFilterColumnsChunk()} calls will fail until
+   * {@link #setupChunkingForFilterColumns(long, long, int[], UseDataPageMask, RowMaskKind, DeviceMemoryBuffer[])}
+   * is invoked again. If never called, the row mask is freed when the reader is closed.
+   *
+   * @return the owned row mask {@link ColumnVector}; caller must close it.
+   */
+  public ColumnVector takeFilterRowMask() {
+    assertNotClosed();
+    return new ColumnVector(takeFilterRowMask(cleaner.nativeHandle));
+  }
+
+  /**
+   * Set up chunking state for payload-column materialization. Subsequent calls to
+   * {@link #materializePayloadColumnsChunk(ColumnVector)} will yield successive chunks.
+   */
+  public void setupChunkingForPayloadColumns(long chunkReadLimit,
+                                             long passReadLimit,
+                                             int[] rowGroupIndices,
+                                             ColumnVector rowMask,
+                                             UseDataPageMask mode,
+                                             DeviceMemoryBuffer[] columnChunkData) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    requireNonNullRowMask(rowMask);
+    long[] addrs = bufferAddrs(columnChunkData);
+    long[] lens = bufferLens(columnChunkData);
+    setupChunkingForPayloadColumns(cleaner.nativeHandle, chunkReadLimit, passReadLimit,
+        rowGroupIndices, rowMask.getNativeView(), mode.getNativeValue(), addrs, lens);
+  }
+
+  /** @return the next payload-column chunk; throws if no chunk is available. */
+  public Table materializePayloadColumnsChunk(ColumnVector rowMask) {
+    assertNotClosed();
+    requireNonNullRowMask(rowMask);
+    long[] handles = materializePayloadColumnsChunk(cleaner.nativeHandle,
+        rowMask.getNativeView());
+    return new Table(handles);
+  }
+
+  /**
+   * Set up chunking state for all-column materialization (single-pass mode). Subsequent calls
+   * to {@link #materializeAllColumnsChunk()} will yield successive chunks.
+   */
+  public void setupChunkingForAllColumns(long chunkReadLimit,
+                                         long passReadLimit,
+                                         int[] rowGroupIndices,
+                                         DeviceMemoryBuffer[] columnChunkData) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    long[] addrs = bufferAddrs(columnChunkData);
+    long[] lens = bufferLens(columnChunkData);
+    setupChunkingForAllColumns(cleaner.nativeHandle, chunkReadLimit, passReadLimit,
+        rowGroupIndices, addrs, lens);
+  }
+
+  /** @return the next all-columns chunk; throws if no chunk is available. */
+  public Table materializeAllColumnsChunk() {
+    assertNotClosed();
+    long[] handles = materializeAllColumnsChunk(cleaner.nativeHandle);
+    return new Table(handles);
+  }
+
+  /** @return {@code true} when a subsequent {@code materialize*Chunk} call would return data. */
+  public boolean hasNextTableChunk() {
+    assertNotClosed();
+    return hasNextTableChunk(cleaner.nativeHandle);
+  }
+
+  /**
+   * Partition the supplied row groups into passes whose total uncompressed size respects the
+   * given limit. The returned array contains one inner array per pass.
+   *
+   * @param rowGroupIndices row groups to partition
+   * @param passReadLimit   limit on the amount of memory used by a single pass, or 0 for no limit
+   * @return an array of arrays of row group indices, one per pass
+   */
+  public int[][] constructRowGroupPasses(int[] rowGroupIndices, long passReadLimit) {
+    assertNotClosed();
+    requireNonNullRowGroups(rowGroupIndices);
+    return constructRowGroupPasses(cleaner.nativeHandle, rowGroupIndices, passReadLimit);
+  }
+
+  // ----------------------------------------------------------------------
+  // Lifecycle
+  // ----------------------------------------------------------------------
+
+  @Override
+  public synchronized void close() {
+    if (isClosed) {
+      return;
+    }
+    cleaner.delRef();
+    cleaner.clean(false);
+    isClosed = true;
+  }
+
+  // ----------------------------------------------------------------------
+  // Helpers
+  // ----------------------------------------------------------------------
+
+  private void assertNotClosed() {
+    if (isClosed) {
+      throw new IllegalStateException("HybridScanReader has been closed");
+    }
+  }
+
+  private static void requireNonNullRowGroups(int[] rowGroupIndices) {
+    if (rowGroupIndices == null) {
+      throw new IllegalArgumentException("rowGroupIndices must not be null");
+    }
+  }
+
+  private static void requireNonNullRowMask(ColumnVector rowMask) {
+    if (rowMask == null) {
+      throw new IllegalArgumentException("rowMask must not be null");
+    }
+  }
+
+  private static long[] bufferAddrs(DeviceMemoryBuffer[] buffers) {
+    if (buffers == null) {
+      return new long[0];
+    }
+    long[] addrs = new long[buffers.length];
+    for (int i = 0; i < buffers.length; i++) {
+      addrs[i] = buffers[i].getAddress();
+    }
+    return addrs;
+  }
+
+  private static long[] bufferLens(DeviceMemoryBuffer[] buffers) {
+    if (buffers == null) {
+      return new long[0];
+    }
+    long[] lens = new long[buffers.length];
+    for (int i = 0; i < buffers.length; i++) {
+      lens[i] = buffers[i].getLength();
+    }
+    return lens;
+  }
+
+  private static ByteRange[] decodeRanges(long[] packed) {
+    if (packed == null || packed.length == 0) {
+      return new ByteRange[0];
+    }
+    int n = packed.length / 2;
+    ByteRange[] out = new ByteRange[n];
+    for (int i = 0; i < n; i++) {
+      out[i] = new ByteRange(packed[2 * i], packed[2 * i + 1]);
+    }
+    return out;
+  }
+
+  // ----------------------------------------------------------------------
+  // Native methods
+  // ----------------------------------------------------------------------
+
+  private static native long createFromFooter(long footerAddress,
+                                              long footerLength,
+                                              long filterHandle,
+                                              String[] columnNames,
+                                              boolean[] readBinaryAsString,
+                                              int timeUnitTypeId);
+
+  private static native void destroy(long handle);
+
+  // Metadata
+  private static native long[] pageIndexByteRange(long handle);
+  private static native void setupPageIndex(long handle, long bufferAddress, long bufferLength);
+
+  // Row group enumeration
+  private static native int[] allRowGroups(long handle);
+  private static native long totalRowsInRowGroups(long handle, int[] rowGroupIndices);
+
+  // Filtering
+  private static native int[] filterRowGroupsWithStats(long handle, int[] rowGroupIndices);
+  private static native long[] secondaryFiltersByteRanges(long handle, int[] rowGroupIndices);
+  private static native int[] filterRowGroupsWithDictionaryPages(long handle,
+                                                                 long[] bufferAddresses,
+                                                                 long[] bufferLengths,
+                                                                 int[] rowGroupIndices);
+
+  // Byte ranges
+  private static native long[] filterColumnChunksByteRanges(long handle, int[] rowGroupIndices);
+  private static native long[] payloadColumnChunksByteRanges(long handle, int[] rowGroupIndices);
+  private static native long[] allColumnChunksByteRanges(long handle, int[] rowGroupIndices);
+
+  // Single-shot materialize
+  // Returns: [row_mask_col_handle, table_col0_handle, ..., table_colN_handle]
+  private static native long[] materializeFilterColumnsWithKind(long handle,
+                                                                int[] rowGroupIndices,
+                                                                long[] bufferAddresses,
+                                                                long[] bufferLengths,
+                                                                boolean useDataPageMask,
+                                                                boolean allTrue);
+  private static native long[] materializePayloadColumns(long handle,
+                                                         int[] rowGroupIndices,
+                                                         long[] bufferAddresses,
+                                                         long[] bufferLengths,
+                                                         long rowMaskViewHandle,
+                                                         boolean useDataPageMask);
+  private static native long[] materializeAllColumns(long handle,
+                                                     int[] rowGroupIndices,
+                                                     long[] bufferAddresses,
+                                                     long[] bufferLengths);
+
+  // Chunked
+  // Builds the row mask, sets up chunking state, and stores the owned row mask column on
+  // the C++ wrapper. Subsequent materializeFilterColumnsChunk calls mutate that column in
+  // place; takeFilterRowMask transfers it out to Java.
+  private static native void setupChunkingForFilterColumnsWithKind(long handle,
+                                                                   long chunkReadLimit,
+                                                                   long passReadLimit,
+                                                                   int[] rowGroupIndices,
+                                                                   boolean useDataPageMask,
+                                                                   boolean allTrue,
+                                                                   long[] bufferAddresses,
+                                                                   long[] bufferLengths);
+  private static native long[] materializeFilterColumnsChunk(long handle);
+  private static native long takeFilterRowMask(long handle);
+  private static native void setupChunkingForPayloadColumns(long handle,
+                                                            long chunkReadLimit,
+                                                            long passReadLimit,
+                                                            int[] rowGroupIndices,
+                                                            long rowMaskViewHandle,
+                                                            boolean useDataPageMask,
+                                                            long[] bufferAddresses,
+                                                            long[] bufferLengths);
+  private static native long[] materializePayloadColumnsChunk(long handle,
+                                                              long rowMaskViewHandle);
+  private static native void setupChunkingForAllColumns(long handle,
+                                                        long chunkReadLimit,
+                                                        long passReadLimit,
+                                                        int[] rowGroupIndices,
+                                                        long[] bufferAddresses,
+                                                        long[] bufferLengths);
+  private static native long[] materializeAllColumnsChunk(long handle);
+  private static native boolean hasNextTableChunk(long handle);
+  private static native int[][] constructRowGroupPasses(long handle,
+                                                        int[] rowGroupIndices,
+                                                        long passReadLimit);
+}

--- a/java/src/main/java/ai/rapids/cudf/HybridScanReader.java
+++ b/java/src/main/java/ai/rapids/cudf/HybridScanReader.java
@@ -125,6 +125,9 @@ public class HybridScanReader implements AutoCloseable {
   }
 
   private final HybridScanReaderCleaner cleaner;
+  // Strong ref so the native options' raw pointer to the AST is not collected
+  // while this reader is alive.
+  private final CompiledExpression filter;
   private boolean isClosed = false;
 
   /**
@@ -138,7 +141,8 @@ public class HybridScanReader implements AutoCloseable {
    * @param opts         Parquet reader options. {@link ParquetOptions#DEFAULT} by default.
    * @param filter       optional compiled AST filter expression. May be {@code null}.
    *                     The expression typically uses {@link ai.rapids.cudf.ast.ColumnNameReference}
-   *                     to refer to columns by name.
+   *                     to refer to columns by name. If non-{@code null}, it must remain
+   *                     unclosed for the entire lifetime of this reader.
    */
   public HybridScanReader(HostMemoryBuffer footerBuffer,
                           ParquetOptions opts,
@@ -149,6 +153,7 @@ public class HybridScanReader implements AutoCloseable {
     if (opts == null) {
       opts = ParquetOptions.DEFAULT;
     }
+    this.filter = filter;
     long filterHandle = (filter != null) ? filter.getNativeHandle() : 0;
     String[] columnNames = opts.getIncludeColumnNames();
     boolean[] readBinaryAsString = opts.getReadBinaryAsString();

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -371,7 +371,8 @@ public final class MemoryCleaner {
   }
 
   public static void register(HybridScanReader reader, Cleaner cleaner) {
-    all.put(cleaner.id, new CleanerWeakReference(reader, cleaner, collected, false));
+    // RMM blocker: wrapper can hold device memory (chunked_filter_row_mask).
+    all.put(cleaner.id, new CleanerWeakReference(reader, cleaner, collected, true));
   }
 
   static void register(HashJoin hashJoin, Cleaner cleaner) {

--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -370,6 +370,10 @@ public final class MemoryCleaner {
     all.put(cleaner.id, new CleanerWeakReference(expr, cleaner, collected, false));
   }
 
+  public static void register(HybridScanReader reader, Cleaner cleaner) {
+    all.put(cleaner.id, new CleanerWeakReference(reader, cleaner, collected, false));
+  }
+
   static void register(HashJoin hashJoin, Cleaner cleaner) {
     all.put(cleaner.id, new CleanerWeakReference(hashJoin, cleaner, collected, true));
   }

--- a/java/src/main/java/ai/rapids/cudf/ParquetWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ParquetWriterOptions.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -31,7 +31,13 @@ public final class ParquetWriterOptions extends CompressionMetadataWriterOptions
     ROWGROUP(1),
 
     /** Generate column statistics for each page */
-    PAGE(2);
+    PAGE(2),
+
+    /**
+     * Generate full column and offset indices (page index). Implies ROWGROUP statistics.
+     * Required for page-level pruning in {@link HybridScanReader}.
+     */
+    COLUMN(3);
 
     final int nativeId;
 

--- a/java/src/main/java/ai/rapids/cudf/SecondaryFilterRanges.java
+++ b/java/src/main/java/ai/rapids/cudf/SecondaryFilterRanges.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Pair of byte-range arrays returned by
+ * {@link HybridScanReader#secondaryFiltersByteRanges(int[])}.
+ *
+ * <p>The two arrays describe, for the input row groups:
+ * <ul>
+ *   <li>bloom-filter ranges — file byte ranges containing per-column-chunk Parquet bloom
+ *       filter blobs (no getter yet; see constructor parameter TODO);</li>
+ *   <li>{@link #dictionaryPageRanges()} — file byte ranges of the column-chunk
+ *       dictionary pages used for row-group pruning of (in)equality predicates.</li>
+ * </ul>
+ *
+ * <p>Both arrays may be empty. The ordering follows the C++ reader's ordering and is
+ * meaningful: the i-th entry corresponds to the i-th column-chunk needing the
+ * respective filter.
+ *
+ * <p>Mirrors the {@code std::pair<std::vector<byte_range_info>, std::vector<byte_range_info>>}
+ * returned by {@code hybrid_scan_reader::secondary_filters_byte_ranges}.
+ *
+ * <p>The APIs in this file are experimental and subject to change.
+ */
+@Experimental
+public final class SecondaryFilterRanges {
+  private final ByteRange[] bloomFilterRanges;
+  private final ByteRange[] dictionaryPageRanges;
+
+  /**
+   * @param bloomFilterRanges   bloom-filter byte ranges (stored but not yet exposed via a getter;
+   *                            TODO: add {@code bloomFilterRanges()} once bloom filter writing is
+   *                            supported in {@link ParquetWriterOptions})
+   * @param dictionaryPageRanges dictionary-page byte ranges
+   */
+  public SecondaryFilterRanges(ByteRange[] bloomFilterRanges,
+                               ByteRange[] dictionaryPageRanges) {
+    this.bloomFilterRanges =
+        bloomFilterRanges == null ? new ByteRange[0] : bloomFilterRanges.clone();
+    this.dictionaryPageRanges =
+        dictionaryPageRanges == null ? new ByteRange[0] : dictionaryPageRanges.clone();
+  }
+
+  /** @return a defensive copy of the dictionary-page byte ranges. */
+  public ByteRange[] dictionaryPageRanges() {
+    return dictionaryPageRanges.clone();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof SecondaryFilterRanges)) return false;
+    SecondaryFilterRanges other = (SecondaryFilterRanges) o;
+    return Arrays.equals(bloomFilterRanges, other.bloomFilterRanges) &&
+           Arrays.equals(dictionaryPageRanges, other.dictionaryPageRanges);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(Arrays.hashCode(bloomFilterRanges),
+                        Arrays.hashCode(dictionaryPageRanges));
+  }
+
+  @Override
+  public String toString() {
+    return "SecondaryFilterRanges{bloom=" + bloomFilterRanges.length +
+           " ranges, dict=" + dictionaryPageRanges.length + " ranges}";
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/UseDataPageMask.java
+++ b/java/src/main/java/ai/rapids/cudf/UseDataPageMask.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf;
+
+/**
+ * Whether to compute and use a data page mask using the row mask to skip decompression
+ * and decoding of the masked pages.
+ *
+ * <p>Mirrors {@code cudf::io::parquet::experimental::use_data_page_mask}.
+ *
+ * <p>The APIs in this file are experimental and subject to change.
+ */
+@Experimental
+public enum UseDataPageMask {
+  /** Compute and use a data page mask. */
+  YES(true),
+  /** Do not compute or use a data page mask. */
+  NO(false);
+
+  private final boolean nativeValue;
+
+  UseDataPageMask(boolean nativeValue) {
+    this.nativeValue = nativeValue;
+  }
+
+  /**
+   * @return the underlying native boolean value of the C++ {@code use_data_page_mask} enum.
+   *         Intended for internal cudf use only.
+   */
+  public boolean getNativeValue() {
+    return nativeValue;
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/ast/AstExpression.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/AstExpression.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,8 @@ public abstract class AstExpression {
     NULL_LITERAL(1),
     COLUMN_REFERENCE(2),
     UNARY_EXPRESSION(3),
-    BINARY_EXPRESSION(4);
+    BINARY_EXPRESSION(4),
+    COLUMN_NAME_REFERENCE(5);
 
     private final byte nativeId;
 

--- a/java/src/main/java/ai/rapids/cudf/ast/ColumnNameReference.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/ColumnNameReference.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf.ast;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A reference to a column in an input table by name.
+ *
+ * <p>Unlike {@link ColumnReference}, which references a column by its integer position
+ * within the input table, this node carries the column name as a string. The name is
+ * resolved to an actual column when the AST is evaluated. This is useful in contexts
+ * where the column index is not known at AST-construction time, e.g. when the filter
+ * expression is built before the file's schema has been read. The Parquet hybrid scan
+ * reader relies on this node for filter expressions.
+ */
+public final class ColumnNameReference extends AstExpression {
+  private final String columnName;
+
+  /**
+   * Construct a column reference using the column name.
+   *
+   * @param columnName the name of the column to reference. Must not be null or empty.
+   */
+  public ColumnNameReference(String columnName) {
+    if (columnName == null) {
+      throw new IllegalArgumentException("Column name cannot be null");
+    }
+    if (columnName.isEmpty()) {
+      throw new IllegalArgumentException("Column name cannot be empty");
+    }
+    this.columnName = columnName;
+  }
+
+  /** @return the column name */
+  public String getColumnName() {
+    return columnName;
+  }
+
+  @Override
+  int getSerializedSize() {
+    byte[] nameBytes = columnName.getBytes(StandardCharsets.UTF_8);
+    // node type + string length (int) + string bytes
+    return ExpressionType.COLUMN_NAME_REFERENCE.getSerializedSize() +
+        Integer.BYTES +
+        nameBytes.length;
+  }
+
+  @Override
+  void serialize(ByteBuffer bb) {
+    ExpressionType.COLUMN_NAME_REFERENCE.serialize(bb);
+
+    byte[] nameBytes = columnName.getBytes(StandardCharsets.UTF_8);
+    bb.putInt(nameBytes.length);
+    bb.put(nameBytes);
+  }
+
+  @Override
+  public String toString() {
+    return "COLUMN(\"" + columnName + "\")";
+  }
+}

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -164,6 +164,9 @@ add_library(
   src/DeletionVectorJni.cpp
   src/HashJoinJni.cpp
   src/HostMemoryBufferNativeUtilsJni.cpp
+  src/HybridScanReaderJni.cpp
+  src/HybridScanReaderJniInternal.cpp
+  src/HybridScanReaderJniMaterialize.cpp
   src/KeyRemappingJni.cpp
   src/HostUDFWrapperJni.cpp
   src/NvcompJni.cpp

--- a/java/src/main/native/include/hybrid_scan_jni_internal.hpp
+++ b/java/src/main/native/include/hybrid_scan_jni_internal.hpp
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "jni_utils.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/parquet.hpp>
+#include <cudf/io/text/byte_range_info.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <jni.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace cudf {
+namespace jni {
+namespace hybrid_scan {
+
+namespace exp_pq = cudf::io::parquet::experimental;
+using cudf::io::text::byte_range_info;
+
+/**
+ * @brief Wrapper that owns the C++ hybrid_scan_reader plus the parquet_reader_options that
+ *        most reader methods need to be supplied alongside the call. Keeping them together
+ *        avoids the need for the caller (Java) to round-trip the options across JNI on each
+ *        call.
+ */
+struct hybrid_scan_reader_wrapper {
+  cudf::io::parquet_reader_options options;
+  std::unique_ptr<exp_pq::hybrid_scan_reader> reader;
+  // Owns the row mask for the duration of a chunked filter-column pipeline.
+  // Set by setup_chunking_for_filter_columns_with_kind, mutated in place by each
+  // materialize_filter_columns_chunk call, and transferred to Java by take_filter_row_mask.
+  // nullptr outside of an active chunked-filter session.
+  std::unique_ptr<cudf::column> chunked_filter_row_mask;
+
+  hybrid_scan_reader_wrapper(cudf::host_span<uint8_t const> footer_bytes,
+                             cudf::io::parquet_reader_options opts)
+    : options(std::move(opts)),
+      reader(std::make_unique<exp_pq::hybrid_scan_reader>(footer_bytes, options))
+  {
+  }
+};
+
+/**
+ * @brief Holds the result of a planned host-to-device copy: the actual device memory and a
+ *        list of device spans into that memory matching the requested byte ranges.
+ */
+struct planned_copy_result {
+  std::vector<rmm::device_buffer> device_buffers;
+  std::vector<cudf::device_span<uint8_t const>> spans;
+};
+
+/**
+ * @brief Convert a Java int[] of row group indices into a host_span<size_type const>. The
+ *        wrapper owns a vector that backs the span; capture it as a value to avoid dangling.
+ */
+struct row_group_span_holder {
+  std::vector<cudf::size_type> storage;
+  cudf::host_span<cudf::size_type const> span() const { return {storage.data(), storage.size()}; }
+};
+
+bool are_ranges_contiguous(std::vector<byte_range_info> const& ranges);
+
+planned_copy_result plan_and_copy_ranges(uint8_t const* host_ptr,
+                                         std::vector<byte_range_info> const& ranges,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr);
+
+/**
+ * @brief Build a parquet_reader_options from the supplied JNI args. The footer is provided
+ *        separately because the hybrid_scan_reader does not consume it via the options.
+ */
+cudf::io::parquet_reader_options build_options(JNIEnv* env,
+                                               jlong filter_handle,
+                                               jobjectArray j_column_names,
+                                               jbooleanArray j_read_binary_as_string,
+                                               jint time_unit_type_id);
+
+row_group_span_holder make_row_group_span(JNIEnv* env, jintArray j_row_groups);
+
+/**
+ * @brief Convert a vector<byte_range_info> into a packed jlongArray laid out as
+ *        [off0, len0, off1, len1, ...].
+ */
+jlongArray ranges_to_jlong_array(JNIEnv* env, std::vector<byte_range_info> const& ranges);
+
+jintArray sizes_to_jint_array(JNIEnv* env, std::vector<cudf::size_type> const& vals);
+
+std::vector<cudf::device_span<uint8_t const>> make_device_spans(JNIEnv* env,
+                                                                jlongArray j_addrs,
+                                                                jlongArray j_lens);
+
+}  // namespace hybrid_scan
+}  // namespace jni
+}  // namespace cudf

--- a/java/src/main/native/include/hybrid_scan_jni_internal.hpp
+++ b/java/src/main/native/include/hybrid_scan_jni_internal.hpp
@@ -102,6 +102,10 @@ std::vector<cudf::device_span<uint8_t const>> make_device_spans(JNIEnv* env,
                                                                 jlongArray j_addrs,
                                                                 jlongArray j_lens);
 
+/** @brief Convert a jlong to size_t; throws Java IllegalArgumentException if @p value is negative
+ * (@p name is embedded in the message). */
+std::size_t checked_size_t(JNIEnv* env, jlong value, char const* name);
+
 }  // namespace hybrid_scan
 }  // namespace jni
 }  // namespace cudf

--- a/java/src/main/native/src/CompiledExpression.cpp
+++ b/java/src/main/native/src/CompiledExpression.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -112,11 +112,12 @@ class jni_serialized_ast {
  * NOTE: This must be kept in sync with the NodeType enumeration in AstNode.java!
  */
 enum class jni_serialized_expression_type : int8_t {
-  VALID_LITERAL    = 0,
-  NULL_LITERAL     = 1,
-  COLUMN_REFERENCE = 2,
-  UNARY_OPERATION  = 3,
-  BINARY_OPERATION = 4
+  VALID_LITERAL         = 0,
+  NULL_LITERAL          = 1,
+  COLUMN_REFERENCE      = 2,
+  UNARY_OPERATION       = 3,
+  BINARY_OPERATION      = 4,
+  COLUMN_NAME_REFERENCE = 5
 };
 
 /**
@@ -323,6 +324,15 @@ cudf::ast::column_reference& compile_column_reference(cudf::jni::ast::compiled_e
     std::make_unique<cudf::ast::column_reference>(column_index, table_ref));
 }
 
+/** Decode a serialized AST column name reference */
+cudf::ast::column_name_reference& compile_column_name_reference(
+  cudf::jni::ast::compiled_expr& compiled_expr, jni_serialized_ast& jni_ast)
+{
+  std::string column_name = jni_ast.read<std::string>();
+  return compiled_expr.add_column_name_ref(
+    std::make_unique<cudf::ast::column_name_reference>(std::move(column_name)));
+}
+
 // forward declaration
 cudf::ast::expression& compile_expression(cudf::jni::ast::compiled_expr& compiled_expr,
                                           jni_serialized_ast& jni_ast);
@@ -360,6 +370,8 @@ cudf::ast::expression& compile_expression(cudf::jni::ast::compiled_expr& compile
       return compile_literal(false, compiled_expr, jni_ast);
     case jni_serialized_expression_type::COLUMN_REFERENCE:
       return compile_column_reference(compiled_expr, jni_ast);
+    case jni_serialized_expression_type::COLUMN_NAME_REFERENCE:
+      return compile_column_name_reference(compiled_expr, jni_ast);
     case jni_serialized_expression_type::UNARY_OPERATION:
       return compile_unary_expression(compiled_expr, jni_ast);
     case jni_serialized_expression_type::BINARY_OPERATION:

--- a/java/src/main/native/src/HybridScanReaderJni.cpp
+++ b/java/src/main/native/src/HybridScanReaderJni.cpp
@@ -40,10 +40,11 @@ Java_ai_rapids_cudf_HybridScanReader_createFromFooter(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
+    auto const len = checked_size_t(env, footer_length, "footerLength");
     auto opts =
       build_options(env, filter_handle, j_column_names, j_binary_as_str, time_unit_type_id);
     auto const* footer_ptr = reinterpret_cast<uint8_t const*>(footer_address);
-    cudf::host_span<uint8_t const> footer_bytes{footer_ptr, static_cast<size_t>(footer_length)};
+    cudf::host_span<uint8_t const> footer_bytes{footer_ptr, len};
     auto wrapper = std::make_unique<hybrid_scan_reader_wrapper>(footer_bytes, std::move(opts));
     return reinterpret_cast<jlong>(wrapper.release());
   }
@@ -93,9 +94,10 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_HybridScanReader_setupPageIndex(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
+    auto const len       = checked_size_t(env, buffer_length, "pageIndexBufferLength");
     auto* wrapper        = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
     auto const* host_ptr = reinterpret_cast<uint8_t const*>(buffer_address);
-    cudf::host_span<uint8_t const> bytes{host_ptr, static_cast<size_t>(buffer_length)};
+    cudf::host_span<uint8_t const> bytes{host_ptr, len};
     wrapper->reader->setup_page_index(bytes);
   }
   JNI_CATCH(env, );

--- a/java/src/main/native/src/HybridScanReaderJni.cpp
+++ b/java/src/main/native/src/HybridScanReaderJni.cpp
@@ -1,0 +1,265 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cudf_jni_apis.hpp"
+#include "hybrid_scan_jni_internal.hpp"
+#include "jni_utils.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/io/parquet.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+using namespace cudf::jni::hybrid_scan;
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL
+Java_ai_rapids_cudf_HybridScanReader_createFromFooter(JNIEnv* env,
+                                                      jclass,
+                                                      jlong footer_address,
+                                                      jlong footer_length,
+                                                      jlong filter_handle,
+                                                      jobjectArray j_column_names,
+                                                      jbooleanArray j_binary_as_str,
+                                                      jint time_unit_type_id)
+{
+  JNI_NULL_CHECK(env, footer_address, "footer address is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto opts =
+      build_options(env, filter_handle, j_column_names, j_binary_as_str, time_unit_type_id);
+    auto const* footer_ptr = reinterpret_cast<uint8_t const*>(footer_address);
+    cudf::host_span<uint8_t const> footer_bytes{footer_ptr, static_cast<size_t>(footer_length)};
+    auto wrapper = std::make_unique<hybrid_scan_reader_wrapper>(footer_bytes, std::move(opts));
+    return reinterpret_cast<jlong>(wrapper.release());
+  }
+  JNI_CATCH(env, 0);
+}
+
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_HybridScanReader_destroy(JNIEnv* env,
+                                                                    jclass,
+                                                                    jlong handle)
+{
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    delete reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+  }
+  JNI_CATCH(env, );
+}
+
+// ----------------------------------------------------------------------
+// Metadata
+// ----------------------------------------------------------------------
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_HybridScanReader_pageIndexByteRange(JNIEnv* env,
+                                                                                     jclass,
+                                                                                     jlong handle)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto range    = wrapper->reader->page_index_byte_range();
+    jlong vals[2] = {static_cast<jlong>(range.offset()), static_cast<jlong>(range.size())};
+    auto result   = env->NewLongArray(2);
+    if (result == nullptr) { return nullptr; }
+    env->SetLongArrayRegion(result, 0, 2, vals);
+    return result;
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_HybridScanReader_setupPageIndex(
+  JNIEnv* env, jclass, jlong handle, jlong buffer_address, jlong buffer_length)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", );
+  JNI_NULL_CHECK(env, buffer_address, "page index buffer is null", );
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper        = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto const* host_ptr = reinterpret_cast<uint8_t const*>(buffer_address);
+    cudf::host_span<uint8_t const> bytes{host_ptr, static_cast<size_t>(buffer_length)};
+    wrapper->reader->setup_page_index(bytes);
+  }
+  JNI_CATCH(env, );
+}
+
+// ----------------------------------------------------------------------
+// Row group enumeration
+// ----------------------------------------------------------------------
+
+JNIEXPORT jintArray JNICALL Java_ai_rapids_cudf_HybridScanReader_allRowGroups(JNIEnv* env,
+                                                                              jclass,
+                                                                              jlong handle)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto rgs      = wrapper->reader->all_row_groups(wrapper->options);
+    return sizes_to_jint_array(env, rgs);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_HybridScanReader_totalRowsInRowGroups(
+  JNIEnv* env, jclass, jlong handle, jintArray j_row_groups)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", 0);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto total    = wrapper->reader->total_rows_in_row_groups(holder.span());
+    return static_cast<jlong>(total);
+  }
+  JNI_CATCH(env, 0);
+}
+
+// ----------------------------------------------------------------------
+// Filtering
+// ----------------------------------------------------------------------
+
+JNIEXPORT jintArray JNICALL Java_ai_rapids_cudf_HybridScanReader_filterRowGroupsWithStats(
+  JNIEnv* env, jclass, jlong handle, jintArray j_row_groups)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto filtered = wrapper->reader->filter_row_groups_with_stats(
+      holder.span(), wrapper->options, cudf::get_default_stream());
+    return sizes_to_jint_array(env, filtered);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_HybridScanReader_secondaryFiltersByteRanges(
+  JNIEnv* env, jclass, jlong handle, jintArray j_row_groups)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto [bloom, dict] =
+      wrapper->reader->secondary_filters_byte_ranges(holder.span(), wrapper->options);
+    // Pack as [numBloom, bloom_o0, bloom_s0, ..., dict_o0, dict_s0, ...]
+    auto const total_len = 1 + (bloom.size() + dict.size()) * 2;
+    auto result          = env->NewLongArray(total_len);
+    if (result == nullptr) { return nullptr; }
+    std::vector<jlong> data;
+    data.reserve(total_len);
+    data.push_back(static_cast<jlong>(bloom.size()));
+    for (auto const& r : bloom) {
+      data.push_back(static_cast<jlong>(r.offset()));
+      data.push_back(static_cast<jlong>(r.size()));
+    }
+    for (auto const& r : dict) {
+      data.push_back(static_cast<jlong>(r.offset()));
+      data.push_back(static_cast<jlong>(r.size()));
+    }
+    env->SetLongArrayRegion(result, 0, data.size(), data.data());
+    return result;
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT jintArray JNICALL Java_ai_rapids_cudf_HybridScanReader_filterRowGroupsWithDictionaryPages(
+  JNIEnv* env, jclass, jlong handle, jlongArray j_addrs, jlongArray j_lens, jintArray j_row_groups)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto spans    = make_device_spans(env, j_addrs, j_lens);
+    auto filtered = wrapper->reader->filter_row_groups_with_dictionary_pages(
+      spans, holder.span(), wrapper->options, cudf::get_default_stream());
+    return sizes_to_jint_array(env, filtered);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+// ----------------------------------------------------------------------
+// Byte ranges
+// ----------------------------------------------------------------------
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_HybridScanReader_filterColumnChunksByteRanges(
+  JNIEnv* env, jclass, jlong handle, jintArray j_row_groups)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto ranges =
+      wrapper->reader->filter_column_chunks_byte_ranges(holder.span(), wrapper->options);
+    return ranges_to_jlong_array(env, ranges);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_HybridScanReader_payloadColumnChunksByteRanges(
+  JNIEnv* env, jclass, jlong handle, jintArray j_row_groups)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto ranges =
+      wrapper->reader->payload_column_chunks_byte_ranges(holder.span(), wrapper->options);
+    return ranges_to_jlong_array(env, ranges);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_HybridScanReader_allColumnChunksByteRanges(
+  JNIEnv* env, jclass, jlong handle, jintArray j_row_groups)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto ranges   = wrapper->reader->all_column_chunks_byte_ranges(holder.span(), wrapper->options);
+    return ranges_to_jlong_array(env, ranges);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+}  // extern "C"

--- a/java/src/main/native/src/HybridScanReaderJniInternal.cpp
+++ b/java/src/main/native/src/HybridScanReaderJniInternal.cpp
@@ -1,0 +1,173 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "hybrid_scan_jni_internal.hpp"
+#include "jni_compiled_expr.hpp"
+
+#include <cudf/utilities/error.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <cstring>
+#include <utility>
+
+namespace cudf {
+namespace jni {
+namespace hybrid_scan {
+
+bool are_ranges_contiguous(std::vector<byte_range_info> const& ranges)
+{
+  if (ranges.size() <= 1) { return true; }
+  for (size_t i = 1; i < ranges.size(); ++i) {
+    if (ranges[i - 1].offset() + ranges[i - 1].size() != ranges[i].offset()) { return false; }
+  }
+  return true;
+}
+
+planned_copy_result plan_and_copy_ranges(uint8_t const* host_ptr,
+                                         std::vector<byte_range_info> const& ranges,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr)
+{
+  planned_copy_result result;
+  if (ranges.empty()) { return result; }
+
+  if (are_ranges_contiguous(ranges)) {
+    auto const first_offset = ranges.front().offset();
+    auto const last_range   = ranges.back();
+    auto const total_size   = (last_range.offset() + last_range.size()) - first_offset;
+    rmm::device_buffer coalesced_buf(total_size, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(coalesced_buf.data(),
+                                  host_ptr + first_offset,
+                                  total_size,
+                                  cudaMemcpyHostToDevice,
+                                  stream.value()));
+    result.spans.reserve(ranges.size());
+    auto const* base_ptr = static_cast<uint8_t const*>(coalesced_buf.data());
+    for (auto const& range : ranges) {
+      auto const offset_in_buffer = range.offset() - first_offset;
+      result.spans.emplace_back(base_ptr + offset_in_buffer, range.size());
+    }
+    result.device_buffers.emplace_back(std::move(coalesced_buf));
+  } else {
+    result.device_buffers.reserve(ranges.size());
+    for (auto const& range : ranges) {
+      rmm::device_buffer dev_buf(range.size(), stream, mr);
+      CUDF_CUDA_TRY(cudaMemcpyAsync(dev_buf.data(),
+                                    host_ptr + range.offset(),
+                                    range.size(),
+                                    cudaMemcpyHostToDevice,
+                                    stream.value()));
+      result.device_buffers.emplace_back(std::move(dev_buf));
+    }
+    result.spans.reserve(result.device_buffers.size());
+    for (auto const& buf : result.device_buffers) {
+      result.spans.emplace_back(static_cast<uint8_t const*>(buf.data()), buf.size());
+    }
+  }
+  return result;
+}
+
+cudf::io::parquet_reader_options build_options(JNIEnv* env,
+                                               jlong filter_handle,
+                                               jobjectArray j_column_names,
+                                               jbooleanArray j_read_binary_as_string,
+                                               jint time_unit_type_id)
+{
+  // The hybrid_scan_reader's options builder is constructed without a source_info because
+  // the reader works on already-parsed footer bytes (and on byte ranges fetched separately).
+  cudf::io::parquet_reader_options_builder builder;
+
+  cudf::jni::native_jstringArray names(env, j_column_names);
+  if (!names.is_null() && names.size() > 0) {
+    builder = builder.column_names(names.as_cpp_vector());
+  }
+
+  // Translate Java's per-column "read binary as string" flags into the C++ schema override
+  // hooks. The reader_column_schema mechanism lets callers force binary→string conversion
+  // for the i-th projected column.
+  cudf::jni::native_jbooleanArray binary_as_str(env, j_read_binary_as_string);
+  if (!binary_as_str.is_null() && binary_as_str.size() > 0) {
+    std::vector<cudf::io::reader_column_schema> schemas;
+    schemas.reserve(binary_as_str.size());
+    for (int i = 0; i < binary_as_str.size(); ++i) {
+      cudf::io::reader_column_schema s;
+      s.set_convert_binary_to_strings(static_cast<bool>(binary_as_str[i]));
+      schemas.emplace_back(std::move(s));
+    }
+    builder = builder.set_column_schema(std::move(schemas));
+    binary_as_str.cancel();
+  }
+
+  auto opts = builder.convert_strings_to_categories(false)
+                .timestamp_type(cudf::data_type(static_cast<cudf::type_id>(time_unit_type_id)))
+                .ignore_missing_columns(true)
+                .build();
+
+  if (filter_handle != 0) {
+    auto const* filter_expr = reinterpret_cast<cudf::jni::ast::compiled_expr const*>(filter_handle);
+    opts.set_filter(filter_expr->get_top_expression());
+  }
+
+  return opts;
+}
+
+row_group_span_holder make_row_group_span(JNIEnv* env, jintArray j_row_groups)
+{
+  row_group_span_holder h;
+  cudf::jni::native_jintArray arr(env, j_row_groups);
+  h.storage.reserve(arr.size());
+  for (int i = 0; i < arr.size(); ++i) {
+    h.storage.push_back(static_cast<cudf::size_type>(arr[i]));
+  }
+  arr.cancel();
+  return h;
+}
+
+jlongArray ranges_to_jlong_array(JNIEnv* env, std::vector<byte_range_info> const& ranges)
+{
+  auto result = env->NewLongArray(ranges.size() * 2);
+  if (result == nullptr) { return nullptr; }
+  if (ranges.empty()) { return result; }
+  std::vector<jlong> data;
+  data.reserve(ranges.size() * 2);
+  for (auto const& r : ranges) {
+    data.push_back(static_cast<jlong>(r.offset()));
+    data.push_back(static_cast<jlong>(r.size()));
+  }
+  env->SetLongArrayRegion(result, 0, data.size(), data.data());
+  return result;
+}
+
+jintArray sizes_to_jint_array(JNIEnv* env, std::vector<cudf::size_type> const& vals)
+{
+  auto result = env->NewIntArray(vals.size());
+  if (result == nullptr) { return nullptr; }
+  if (vals.empty()) { return result; }
+  // jint is int32_t; size_type is also int32_t. Static-cast just to be explicit.
+  std::vector<jint> j(vals.begin(), vals.end());
+  env->SetIntArrayRegion(result, 0, j.size(), j.data());
+  return result;
+}
+
+std::vector<cudf::device_span<uint8_t const>> make_device_spans(JNIEnv* env,
+                                                                jlongArray j_addrs,
+                                                                jlongArray j_lens)
+{
+  cudf::jni::native_jlongArray addrs(env, j_addrs);
+  cudf::jni::native_jlongArray lens(env, j_lens);
+  std::vector<cudf::device_span<uint8_t const>> out;
+  out.reserve(addrs.size());
+  for (int i = 0; i < addrs.size(); ++i) {
+    out.emplace_back(reinterpret_cast<uint8_t const*>(addrs[i]), static_cast<size_t>(lens[i]));
+  }
+  addrs.cancel();
+  lens.cancel();
+  return out;
+}
+
+}  // namespace hybrid_scan
+}  // namespace jni
+}  // namespace cudf

--- a/java/src/main/native/src/HybridScanReaderJniInternal.cpp
+++ b/java/src/main/native/src/HybridScanReaderJniInternal.cpp
@@ -11,6 +11,7 @@
 #include <cuda_runtime_api.h>
 
 #include <cstring>
+#include <string>
 #include <utility>
 
 namespace cudf {
@@ -158,14 +159,25 @@ std::vector<cudf::device_span<uint8_t const>> make_device_spans(JNIEnv* env,
 {
   cudf::jni::native_jlongArray addrs(env, j_addrs);
   cudf::jni::native_jlongArray lens(env, j_lens);
+  CUDF_EXPECTS(addrs.size() == lens.size(), "addrs and lens arrays must have the same length");
   std::vector<cudf::device_span<uint8_t const>> out;
   out.reserve(addrs.size());
   for (int i = 0; i < addrs.size(); ++i) {
-    out.emplace_back(reinterpret_cast<uint8_t const*>(addrs[i]), static_cast<size_t>(lens[i]));
+    out.emplace_back(reinterpret_cast<uint8_t const*>(addrs[i]),
+                     checked_size_t(env, lens[i], "byte range length"));
   }
   addrs.cancel();
   lens.cancel();
   return out;
+}
+
+std::size_t checked_size_t(JNIEnv* env, jlong value, char const* name)
+{
+  if (value < 0) {
+    auto const msg = std::string(name) + " must be non-negative, got " + std::to_string(value);
+    cudf::jni::throw_java_exception(env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, msg.c_str());
+  }
+  return static_cast<std::size_t>(value);
 }
 
 }  // namespace hybrid_scan

--- a/java/src/main/native/src/HybridScanReaderJniMaterialize.cpp
+++ b/java/src/main/native/src/HybridScanReaderJniMaterialize.cpp
@@ -58,14 +58,18 @@ Java_ai_rapids_cudf_HybridScanReader_materializeFilterColumnsWithKind(JNIEnv* en
     auto result = wrapper->reader->materialize_filter_columns(
       holder.span(), spans, mut_view, mode, wrapper->options, stream, mr);
     // Pack: [row_mask_handle, table_col0, ..., table_colN]
-    auto table_handles = cudf::jni::convert_table_for_return(env, result.tbl);
-    cudf::jni::native_jlongArray table_arr(env, table_handles);
-    jsize n_table_cols = table_arr.size();
+    // Hold row_mask_col owned until after convert_table_for_return + the table-cols
+    // SetLongArrayRegion succeed; if either throws, the unique_ptr's destructor frees the
+    // row mask normally. Release only at the final SetLongArrayRegion, which has known-valid
+    // bounds and is the last possible throw point.
+    jsize n_table_cols = static_cast<jsize>(result.tbl->num_columns());
     jlongArray out     = env->NewLongArray(1 + n_table_cols);
     if (out == nullptr) { return nullptr; }
+    auto table_handles = cudf::jni::convert_table_for_return(env, result.tbl);
+    cudf::jni::native_jlongArray table_arr(env, table_handles);
+    env->SetLongArrayRegion(out, 1, n_table_cols, table_arr.data());
     jlong row_mask_handle = cudf::jni::release_as_jlong(std::move(row_mask_col));
     env->SetLongArrayRegion(out, 0, 1, &row_mask_handle);
-    env->SetLongArrayRegion(out, 1, n_table_cols, table_arr.data());
     return out;
   }
   JNI_CATCH(env, nullptr);

--- a/java/src/main/native/src/HybridScanReaderJniMaterialize.cpp
+++ b/java/src/main/native/src/HybridScanReaderJniMaterialize.cpp
@@ -152,11 +152,15 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_HybridScanReader_setupChunkingForFilt
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
-    auto holder   = make_row_group_span(env, j_row_groups);
-    auto spans    = make_device_spans(env, j_addrs, j_lens);
-    auto stream   = cudf::get_default_stream();
-    auto mr       = cudf::get_current_device_resource_ref();
+    // Validate read limits up-front so we don't allocate the row mask column on the GPU
+    // before throwing on bad input.
+    auto const chunk_limit = checked_size_t(env, chunk_read_limit, "chunk_read_limit");
+    auto const pass_limit  = checked_size_t(env, pass_read_limit, "pass_read_limit");
+    auto* wrapper          = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder            = make_row_group_span(env, j_row_groups);
+    auto spans             = make_device_spans(env, j_addrs, j_lens);
+    auto stream            = cudf::get_default_stream();
+    auto mr                = cudf::get_current_device_resource_ref();
     // Discard any prior chunked-filter row mask: starting a new chunked filter pipeline
     // implicitly ends the previous one.
     wrapper->chunked_filter_row_mask.reset();
@@ -170,8 +174,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_HybridScanReader_setupChunkingForFilt
     }
     auto mode =
       use_data_page_mask ? exp_pq::use_data_page_mask::YES : exp_pq::use_data_page_mask::NO;
-    wrapper->reader->setup_chunking_for_filter_columns(static_cast<std::size_t>(chunk_read_limit),
-                                                       static_cast<std::size_t>(pass_read_limit),
+    wrapper->reader->setup_chunking_for_filter_columns(chunk_limit,
+                                                       pass_limit,
                                                        holder.span(),
                                                        row_mask_col->view(),
                                                        mode,
@@ -248,14 +252,16 @@ Java_ai_rapids_cudf_HybridScanReader_setupChunkingForPayloadColumns(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto* wrapper  = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
-    auto holder    = make_row_group_span(env, j_row_groups);
-    auto spans     = make_device_spans(env, j_addrs, j_lens);
-    auto* row_mask = reinterpret_cast<cudf::column_view const*>(row_mask_view_handle);
+    auto const chunk_limit = checked_size_t(env, chunk_read_limit, "chunk_read_limit");
+    auto const pass_limit  = checked_size_t(env, pass_read_limit, "pass_read_limit");
+    auto* wrapper          = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder            = make_row_group_span(env, j_row_groups);
+    auto spans             = make_device_spans(env, j_addrs, j_lens);
+    auto* row_mask         = reinterpret_cast<cudf::column_view const*>(row_mask_view_handle);
     auto mode =
       use_data_page_mask ? exp_pq::use_data_page_mask::YES : exp_pq::use_data_page_mask::NO;
-    wrapper->reader->setup_chunking_for_payload_columns(static_cast<std::size_t>(chunk_read_limit),
-                                                        static_cast<std::size_t>(pass_read_limit),
+    wrapper->reader->setup_chunking_for_payload_columns(chunk_limit,
+                                                        pass_limit,
                                                         holder.span(),
                                                         *row_mask,
                                                         mode,
@@ -298,11 +304,13 @@ Java_ai_rapids_cudf_HybridScanReader_setupChunkingForAllColumns(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
-    auto holder   = make_row_group_span(env, j_row_groups);
-    auto spans    = make_device_spans(env, j_addrs, j_lens);
-    wrapper->reader->setup_chunking_for_all_columns(static_cast<std::size_t>(chunk_read_limit),
-                                                    static_cast<std::size_t>(pass_read_limit),
+    auto const chunk_limit = checked_size_t(env, chunk_read_limit, "chunk_read_limit");
+    auto const pass_limit  = checked_size_t(env, pass_read_limit, "pass_read_limit");
+    auto* wrapper          = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder            = make_row_group_span(env, j_row_groups);
+    auto spans             = make_device_spans(env, j_addrs, j_lens);
+    wrapper->reader->setup_chunking_for_all_columns(chunk_limit,
+                                                    pass_limit,
                                                     holder.span(),
                                                     spans,
                                                     wrapper->options,
@@ -348,11 +356,11 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_HybridScanReader_constructRow
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
-    auto holder   = make_row_group_span(env, j_row_groups);
-    auto passes   = wrapper->reader->construct_row_group_passes(
-      holder.span(), static_cast<std::size_t>(pass_read_limit));
-    jclass int_array_cls = env->FindClass("[I");
+    auto const pass_limit = checked_size_t(env, pass_read_limit, "pass_read_limit");
+    auto* wrapper         = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder           = make_row_group_span(env, j_row_groups);
+    auto passes           = wrapper->reader->construct_row_group_passes(holder.span(), pass_limit);
+    jclass int_array_cls  = env->FindClass("[I");
     if (int_array_cls == nullptr) { return nullptr; }
     auto outer = env->NewObjectArray(passes.size(), int_array_cls, nullptr);
     if (outer == nullptr) { return nullptr; }

--- a/java/src/main/native/src/HybridScanReaderJniMaterialize.cpp
+++ b/java/src/main/native/src/HybridScanReaderJniMaterialize.cpp
@@ -1,0 +1,370 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cudf_jni_apis.hpp"
+#include "hybrid_scan_jni_internal.hpp"
+#include "jni_utils.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <memory>
+#include <utility>
+
+using namespace cudf::jni::hybrid_scan;
+
+extern "C" {
+
+// ----------------------------------------------------------------------
+// Single-shot materialize
+// ----------------------------------------------------------------------
+
+// Returns: [row_mask_col_handle, filter_table_col0_handle, ..., filter_table_colN_handle]
+JNIEXPORT jlongArray JNICALL
+Java_ai_rapids_cudf_HybridScanReader_materializeFilterColumnsWithKind(JNIEnv* env,
+                                                                      jclass,
+                                                                      jlong handle,
+                                                                      jintArray j_row_groups,
+                                                                      jlongArray j_addrs,
+                                                                      jlongArray j_lens,
+                                                                      jboolean use_data_page_mask,
+                                                                      jboolean all_true)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto spans    = make_device_spans(env, j_addrs, j_lens);
+    auto stream   = cudf::get_default_stream();
+    auto mr       = cudf::get_current_device_resource_ref();
+    // Build the owned row mask according to the requested kind.
+    std::unique_ptr<cudf::column> row_mask_col;
+    if (all_true) {
+      row_mask_col = wrapper->reader->build_all_true_row_mask(holder.span(), stream, mr);
+    } else {
+      row_mask_col = wrapper->reader->build_row_mask_with_page_index_stats(
+        holder.span(), wrapper->options, stream, mr);
+    }
+    auto mut_view = row_mask_col->mutable_view();
+    auto mode =
+      use_data_page_mask ? exp_pq::use_data_page_mask::YES : exp_pq::use_data_page_mask::NO;
+    auto result = wrapper->reader->materialize_filter_columns(
+      holder.span(), spans, mut_view, mode, wrapper->options, stream, mr);
+    // Pack: [row_mask_handle, table_col0, ..., table_colN]
+    auto table_handles = cudf::jni::convert_table_for_return(env, result.tbl);
+    cudf::jni::native_jlongArray table_arr(env, table_handles);
+    jsize n_table_cols = table_arr.size();
+    jlongArray out     = env->NewLongArray(1 + n_table_cols);
+    if (out == nullptr) { return nullptr; }
+    jlong row_mask_handle = cudf::jni::release_as_jlong(std::move(row_mask_col));
+    env->SetLongArrayRegion(out, 0, 1, &row_mask_handle);
+    env->SetLongArrayRegion(out, 1, n_table_cols, table_arr.data());
+    return out;
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_ai_rapids_cudf_HybridScanReader_materializePayloadColumns(JNIEnv* env,
+                                                               jclass,
+                                                               jlong handle,
+                                                               jintArray j_row_groups,
+                                                               jlongArray j_addrs,
+                                                               jlongArray j_lens,
+                                                               jlong row_mask_view_handle,
+                                                               jboolean use_data_page_mask)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_NULL_CHECK(env, row_mask_view_handle, "row mask view handle is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper  = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder    = make_row_group_span(env, j_row_groups);
+    auto spans     = make_device_spans(env, j_addrs, j_lens);
+    auto* row_mask = reinterpret_cast<cudf::column_view const*>(row_mask_view_handle);
+    auto mode =
+      use_data_page_mask ? exp_pq::use_data_page_mask::YES : exp_pq::use_data_page_mask::NO;
+    auto result =
+      wrapper->reader->materialize_payload_columns(holder.span(),
+                                                   spans,
+                                                   *row_mask,
+                                                   mode,
+                                                   wrapper->options,
+                                                   cudf::get_default_stream(),
+                                                   cudf::get_current_device_resource_ref());
+    return cudf::jni::convert_table_for_return(env, result.tbl);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_HybridScanReader_materializeAllColumns(
+  JNIEnv* env, jclass, jlong handle, jintArray j_row_groups, jlongArray j_addrs, jlongArray j_lens)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto spans    = make_device_spans(env, j_addrs, j_lens);
+    auto result   = wrapper->reader->materialize_all_columns(holder.span(),
+                                                           spans,
+                                                           wrapper->options,
+                                                           cudf::get_default_stream(),
+                                                           cudf::get_current_device_resource_ref());
+    return cudf::jni::convert_table_for_return(env, result.tbl);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+// ----------------------------------------------------------------------
+// Chunked materialize
+// ----------------------------------------------------------------------
+
+// Builds the row mask according to the requested kind, sets up chunking state in the
+// underlying reader, and stores the owned row mask in the wrapper. Subsequent
+// materializeFilterColumnsChunk calls mutate this column in place; takeFilterRowMask
+// transfers ownership of the mutated column out to Java.
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_HybridScanReader_setupChunkingForFilterColumnsWithKind(
+  JNIEnv* env,
+  jclass,
+  jlong handle,
+  jlong chunk_read_limit,
+  jlong pass_read_limit,
+  jintArray j_row_groups,
+  jboolean use_data_page_mask,
+  jboolean all_true,
+  jlongArray j_addrs,
+  jlongArray j_lens)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", );
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", );
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto spans    = make_device_spans(env, j_addrs, j_lens);
+    auto stream   = cudf::get_default_stream();
+    auto mr       = cudf::get_current_device_resource_ref();
+    // Discard any prior chunked-filter row mask: starting a new chunked filter pipeline
+    // implicitly ends the previous one.
+    wrapper->chunked_filter_row_mask.reset();
+    // Build the owned row mask according to the requested kind.
+    std::unique_ptr<cudf::column> row_mask_col;
+    if (all_true) {
+      row_mask_col = wrapper->reader->build_all_true_row_mask(holder.span(), stream, mr);
+    } else {
+      row_mask_col = wrapper->reader->build_row_mask_with_page_index_stats(
+        holder.span(), wrapper->options, stream, mr);
+    }
+    auto mode =
+      use_data_page_mask ? exp_pq::use_data_page_mask::YES : exp_pq::use_data_page_mask::NO;
+    wrapper->reader->setup_chunking_for_filter_columns(static_cast<std::size_t>(chunk_read_limit),
+                                                       static_cast<std::size_t>(pass_read_limit),
+                                                       holder.span(),
+                                                       row_mask_col->view(),
+                                                       mode,
+                                                       spans,
+                                                       wrapper->options,
+                                                       stream,
+                                                       mr);
+    // Store the owned column for the rest of the chunked filter pipeline.
+    wrapper->chunked_filter_row_mask = std::move(row_mask_col);
+  }
+  JNI_CATCH(env, );
+}
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_HybridScanReader_materializeFilterColumnsChunk(
+  JNIEnv* env, jclass, jlong handle)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    if (wrapper->chunked_filter_row_mask == nullptr) {
+      JNI_THROW_NEW(env,
+                    cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                    "no active chunked-filter pipeline; call setupChunkingForFilterColumns first",
+                    nullptr);
+    }
+    auto mut_view = wrapper->chunked_filter_row_mask->mutable_view();
+    auto result   = wrapper->reader->materialize_filter_columns_chunk(mut_view);
+    return cudf::jni::convert_table_for_return(env, result.tbl);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+// Transfer ownership of the chunked-filter row mask out of the wrapper to Java.
+// After this call the wrapper's slot is nullptr; subsequent chunk calls will fail until
+// setupChunkingForFilterColumns is invoked again.
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_HybridScanReader_takeFilterRowMask(JNIEnv* env,
+                                                                               jclass,
+                                                                               jlong handle)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    if (wrapper->chunked_filter_row_mask == nullptr) {
+      JNI_THROW_NEW(env,
+                    cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                    "no chunked-filter row mask present; call setupChunkingForFilterColumns first "
+                    "(or it has already been taken)",
+                    0);
+    }
+    return cudf::jni::release_as_jlong(std::move(wrapper->chunked_filter_row_mask));
+  }
+  JNI_CATCH(env, 0);
+}
+
+JNIEXPORT void JNICALL
+Java_ai_rapids_cudf_HybridScanReader_setupChunkingForPayloadColumns(JNIEnv* env,
+                                                                    jclass,
+                                                                    jlong handle,
+                                                                    jlong chunk_read_limit,
+                                                                    jlong pass_read_limit,
+                                                                    jintArray j_row_groups,
+                                                                    jlong row_mask_view_handle,
+                                                                    jboolean use_data_page_mask,
+                                                                    jlongArray j_addrs,
+                                                                    jlongArray j_lens)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", );
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", );
+  JNI_NULL_CHECK(env, row_mask_view_handle, "row mask view handle is null", );
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper  = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder    = make_row_group_span(env, j_row_groups);
+    auto spans     = make_device_spans(env, j_addrs, j_lens);
+    auto* row_mask = reinterpret_cast<cudf::column_view const*>(row_mask_view_handle);
+    auto mode =
+      use_data_page_mask ? exp_pq::use_data_page_mask::YES : exp_pq::use_data_page_mask::NO;
+    wrapper->reader->setup_chunking_for_payload_columns(static_cast<std::size_t>(chunk_read_limit),
+                                                        static_cast<std::size_t>(pass_read_limit),
+                                                        holder.span(),
+                                                        *row_mask,
+                                                        mode,
+                                                        spans,
+                                                        wrapper->options,
+                                                        cudf::get_default_stream(),
+                                                        cudf::get_current_device_resource_ref());
+  }
+  JNI_CATCH(env, );
+}
+
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_HybridScanReader_materializePayloadColumnsChunk(
+  JNIEnv* env, jclass, jlong handle, jlong row_mask_view_handle)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, row_mask_view_handle, "row mask view handle is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper  = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto* row_mask = reinterpret_cast<cudf::column_view const*>(row_mask_view_handle);
+    auto result    = wrapper->reader->materialize_payload_columns_chunk(*row_mask);
+    return cudf::jni::convert_table_for_return(env, result.tbl);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT void JNICALL
+Java_ai_rapids_cudf_HybridScanReader_setupChunkingForAllColumns(JNIEnv* env,
+                                                                jclass,
+                                                                jlong handle,
+                                                                jlong chunk_read_limit,
+                                                                jlong pass_read_limit,
+                                                                jintArray j_row_groups,
+                                                                jlongArray j_addrs,
+                                                                jlongArray j_lens)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", );
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", );
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto spans    = make_device_spans(env, j_addrs, j_lens);
+    wrapper->reader->setup_chunking_for_all_columns(static_cast<std::size_t>(chunk_read_limit),
+                                                    static_cast<std::size_t>(pass_read_limit),
+                                                    holder.span(),
+                                                    spans,
+                                                    wrapper->options,
+                                                    cudf::get_default_stream(),
+                                                    cudf::get_current_device_resource_ref());
+  }
+  JNI_CATCH(env, );
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_ai_rapids_cudf_HybridScanReader_materializeAllColumnsChunk(JNIEnv* env, jclass, jlong handle)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto result   = wrapper->reader->materialize_all_columns_chunk();
+    return cudf::jni::convert_table_for_return(env, result.tbl);
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_HybridScanReader_hasNextTableChunk(JNIEnv* env,
+                                                                                  jclass,
+                                                                                  jlong handle)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", JNI_FALSE);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    return wrapper->reader->has_next_table_chunk() ? JNI_TRUE : JNI_FALSE;
+  }
+  JNI_CATCH(env, JNI_FALSE);
+}
+
+JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_HybridScanReader_constructRowGroupPasses(
+  JNIEnv* env, jclass, jlong handle, jintArray j_row_groups, jlong pass_read_limit)
+{
+  JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
+  JNI_NULL_CHECK(env, j_row_groups, "row groups is null", nullptr);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto* wrapper = reinterpret_cast<hybrid_scan_reader_wrapper*>(handle);
+    auto holder   = make_row_group_span(env, j_row_groups);
+    auto passes   = wrapper->reader->construct_row_group_passes(
+      holder.span(), static_cast<std::size_t>(pass_read_limit));
+    jclass int_array_cls = env->FindClass("[I");
+    if (int_array_cls == nullptr) { return nullptr; }
+    auto outer = env->NewObjectArray(passes.size(), int_array_cls, nullptr);
+    if (outer == nullptr) { return nullptr; }
+    for (size_t i = 0; i < passes.size(); ++i) {
+      auto inner = sizes_to_jint_array(env, passes[i]);
+      if (inner == nullptr) { return nullptr; }
+      env->SetObjectArrayElement(outer, static_cast<jsize>(i), inner);
+      env->DeleteLocalRef(inner);
+    }
+    return outer;
+  }
+  JNI_CATCH(env, nullptr);
+}
+
+}  // extern "C"

--- a/java/src/main/native/src/jni_compiled_expr.hpp
+++ b/java/src/main/native/src/jni_compiled_expr.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,6 +45,13 @@ class compiled_expr {
   {
     expressions.push_back(std::move(ref_ptr));
     return static_cast<cudf::ast::column_reference&>(*expressions.back());
+  }
+
+  cudf::ast::column_name_reference& add_column_name_ref(
+    std::unique_ptr<cudf::ast::column_name_reference> ref_ptr)
+  {
+    expressions.push_back(std::move(ref_ptr));
+    return static_cast<cudf::ast::column_name_reference&>(*expressions.back());
   }
 
   cudf::ast::operation& add_operation(std::unique_ptr<cudf::ast::operation> expr_ptr)

--- a/java/src/main/native/src/jni_compiled_expr.hpp
+++ b/java/src/main/native/src/jni_compiled_expr.hpp
@@ -47,6 +47,8 @@ class compiled_expr {
     return static_cast<cudf::ast::column_reference&>(*expressions.back());
   }
 
+  /** @brief Take ownership of @p ref_ptr; returns a reference stable for the lifetime of this
+   * compiled_expr. */
   cudf::ast::column_name_reference& add_column_name_ref(
     std::unique_ptr<cudf::ast::column_name_reference> ref_ptr)
   {

--- a/java/src/test/java/ai/rapids/cudf/HybridScanReaderTest.java
+++ b/java/src/test/java/ai/rapids/cudf/HybridScanReaderTest.java
@@ -1,0 +1,1368 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import ai.rapids.cudf.ast.BinaryOperation;
+import ai.rapids.cudf.ast.BinaryOperator;
+import ai.rapids.cudf.ast.ColumnNameReference;
+import ai.rapids.cudf.ast.CompiledExpression;
+import ai.rapids.cudf.ast.Literal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Tests for {@link HybridScanReader}.
+ */
+public class HybridScanReaderTest extends CudfTestBase {
+
+  private static final String[] DEFAULT_COLS = {"id", "zip_code", "num_units"};
+  private static final int[] ALL_ROW_GROUPS = {0, 1, 2};
+
+  // --------------------------------------------------------------------
+  // Tests: HybridScanReader (constructor)
+  // --------------------------------------------------------------------
+
+  /** Verifies that passing a null footer buffer to the constructor throws IllegalArgumentException. */
+  @Test
+  void testNullFooterThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new HybridScanReader(null, optsForColumns("id"), null));
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: pageIndexByteRange()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies pageIndexByteRange() returns a structurally valid range for a COLUMN-stats file:
+   * non-zero size, positive offset, and ending exactly at the Parquet footer boundary
+   * (per the spec: the page index region is contiguous and immediately precedes the footer).
+   */
+  @Test
+  void testPageIndexByteRangeContiguousAndBeforeFooter(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp)) {
+      long fileLength = open.file.getLength();
+      int footerLength = open.file.getInt(fileLength - 8);
+      long footerStart = fileLength - 8 - footerLength;
+
+      ByteRange piRange = open.reader.pageIndexByteRange();
+      assertTrue(piRange.size() > 0,
+          "COLUMN-stats file must contain a non-empty page index");
+      assertTrue(piRange.offset() > 0,
+          "Page index region must start after byte 0 (which holds the PAR1 magic)");
+      assertEquals(footerStart, piRange.offset() + piRange.size(),
+          "Page index region must end exactly at the Parquet footer boundary");
+    }
+  }
+
+  /**
+   * Verifies pageIndexByteRange() returns an empty range for a file written with ROWGROUP
+   * statistics: such a file has no ColumnIndex/OffsetIndex structs and therefore no page
+   * index region.
+   */
+  @Test
+  void testPageIndexByteRangeEmptyForRowGroupStats(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.rowGroupStats(tmp)) {
+      ByteRange piRange = open.reader.pageIndexByteRange();
+      assertEquals(0L, piRange.size(),
+          "A ROWGROUP-stats file has no page index region");
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: setupPageIndex()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies setupPageIndex() correctly populates the page-index metadata: feed it the
+   * bytes returned by pageIndexByteRange(), then assert PAGE_INDEX_STATS produces the
+   * exact row count expected from the fixture (group 2 alone, 5,000 rows). All 5,000
+   * rows in group 2 satisfy the filter zip_code > 99,999 (zip_code 100,000–104,999).
+   */
+  @Test
+  void testSetupPageIndexPopulatesMetadata(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("zip_code", BinaryOperator.GREATER, 99999)) {
+      HybridScanReader reader = open.reader;
+      ByteRange piRange = reader.pageIndexByteRange();
+      try (HostMemoryBuffer pi = open.file.slice(piRange.offset(), piRange.size())) {
+        reader.setupPageIndex(pi);
+      }
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      try (HybridScanReader.FilterMaterializationResult fr =
+               reader.materializeFilterColumns(survived, filterCols, UseDataPageMask.YES,
+                   HybridScanReader.RowMaskKind.PAGE_INDEX_STATS)) {
+        assertEquals(5000L, fr.table().getRowCount(),
+            "Group 2 (zip_code 100,000–104,999) entirely satisfies zip_code > 99,999");
+      } finally {
+        closeAll(filterCols);
+      }
+    }
+  }
+
+  /**
+   * Verifies that materializeFilterColumns(..., PAGE_INDEX_STATS) throws when invoked
+   * without a prior setupPageIndex() call: the page-index metadata must be materialised
+   * before page-level row-mask construction can succeed.
+   */
+  @Test
+  void testPageIndexStatsRequiresSetupPageIndex(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("zip_code", BinaryOperator.GREATER, 99999)) {
+      HybridScanReader reader = open.reader;
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      try {
+        assertThrows(CudfException.class, () ->
+            reader.materializeFilterColumns(survived, filterCols, UseDataPageMask.YES,
+                HybridScanReader.RowMaskKind.PAGE_INDEX_STATS));
+      } finally {
+        closeAll(filterCols);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: allRowGroups()
+  // --------------------------------------------------------------------
+
+  /** Verifies allRowGroups() returns the exact contiguous indices {0, 1, 2} for a 3-group fixture. */
+  @Test
+  void testAllRowGroupsReturnsExactIndices(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      assertArrayEquals(ALL_ROW_GROUPS, open.reader.allRowGroups());
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: totalRowsInRowGroups()
+  // --------------------------------------------------------------------
+
+  /** Verifies totalRowsInRowGroups() returns 3000 for all 3 groups (1000 rows × 3 groups). */
+  @Test
+  void testTotalRowsInRowGroupsAllGroups(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      assertEquals(3000L, open.reader.totalRowsInRowGroups(ALL_ROW_GROUPS));
+    }
+  }
+
+  /** Verifies totalRowsInRowGroups() returns 1000 for a single row group. */
+  @Test
+  void testTotalRowsInRowGroupsSingleGroup(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      assertEquals(1000L, open.reader.totalRowsInRowGroups(new int[]{0}));
+    }
+  }
+
+  /** Verifies totalRowsInRowGroups() returns 0 for an empty input array (spec-defined edge case). */
+  @Test
+  void testTotalRowsInRowGroupsEmpty(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      assertEquals(0L, open.reader.totalRowsInRowGroups(new int[0]));
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: filterRowGroupsWithStats()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies filterRowGroupsWithStats() prunes the exact expected row groups: with filter
+   * zip_code > 150,000, group 0 (max zip_code 109,900) is pruned and groups 1, 2 survive.
+   */
+  @Test
+  void testFilterRowGroupsWithStatsExactSurvivors(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      int[] survived = open.reader.filterRowGroupsWithStats(open.reader.allRowGroups());
+      assertArrayEquals(new int[]{1, 2}, survived);
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: secondaryFiltersByteRanges()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies secondaryFiltersByteRanges() returns one non-empty dictionary-page range per
+   * row group when all three required conditions are met:
+   * <ul>
+   *   <li>The filter contains an (in)equality predicate (num_units == 2);
+   *       dictionary_literals_collector only collects literals from EQUAL/NOT_EQUAL AST nodes.</li>
+   *   <li>The fixture has a page index (COLUMN stats) and setupPageIndex() has been called.</li>
+   *   <li>The writer's ADAPTIVE dictionary policy emits dictionaries for the filter column;
+   *       num_units is low-cardinality in every row group, easily passing the
+   *       plain_data_size > dict_enc_size heuristic in writer_impl.cu.</li>
+   * </ul>
+   * Result: 3 row groups × 1 dict-eligible filter col = 3 non-empty ranges.
+   */
+  @Test
+  void testSecondaryFiltersByteRangesPresentForLowCardinality(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("num_units", BinaryOperator.EQUAL, 2)) {
+      open.withPageIndex();
+      HybridScanReader reader = open.reader;
+      SecondaryFilterRanges sfr = reader.secondaryFiltersByteRanges(reader.allRowGroups());
+      ByteRange[] dict = sfr.dictionaryPageRanges();
+      assertEquals(3, dict.length, "3 row groups × 1 dict-eligible filter column");
+      for (ByteRange r : dict) {
+        assertTrue(r.size() > 0, "Dictionary page range must be non-empty");
+      }
+    }
+  }
+
+  /**
+   * Verifies secondaryFiltersByteRanges() returns no dictionary-page ranges for a
+   * high-cardinality int filter column even when the conditions for dictionary lookup
+   * are otherwise satisfied: the fixture has a page index (COLUMN stats) and the
+   * predicate is EQUAL. The empty result must be attributable solely to the writer's
+   * ADAPTIVE dictionary policy skipping dictionary emission for high-cardinality columns
+   * (zip_code is unique per row).
+   */
+  @Test
+  void testSecondaryFiltersByteRangesEmptyForHighCardinalityInts(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("zip_code", BinaryOperator.EQUAL, 12345)) {
+      SecondaryFilterRanges sfr = open.reader.secondaryFiltersByteRanges(open.reader.allRowGroups());
+      assertEquals(0, sfr.dictionaryPageRanges().length,
+          "High-cardinality zip_code: ADAPTIVE policy skips dictionary emission "
+              + "even with page index present and an EQUAL predicate requesting it");
+    }
+  }
+
+  /**
+   * Verifies secondaryFiltersByteRanges() returns no dictionary page ranges when the file
+   * has no page index, even with all other conditions met (EQUAL predicate, low-cardinality
+   * column for which the writer's ADAPTIVE policy emits a dictionary). The C++ gate
+   * has_page_index_and_only_dict_encoded_pages requires both ColumnIndex and OffsetIndex
+   * to be present, which only COLUMN-stats files have. Without that, dict-based row-group
+   * pruning is unsound (cannot verify all pages are dict-encoded), so the function returns
+   * empty even though the dict pages physically exist in the file.
+   */
+  @Test
+  void testSecondaryFiltersByteRangesEmptyForRowGroupStats(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.rowGroupStats(tmp).withFilter("num_units", BinaryOperator.EQUAL, 2)) {
+      SecondaryFilterRanges sfr = open.reader.secondaryFiltersByteRanges(new int[]{0});
+      assertEquals(0, sfr.dictionaryPageRanges().length,
+          "ROWGROUP stats has no page index; the C++ gate skips dict-page discovery");
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: filterRowGroupsWithDictionaryPages()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies filterRowGroupsWithDictionaryPages() prunes all row groups when the equality
+   * literal is not present in any group's dictionary. With the pageIndex fixture, num_units
+   * dictionaries are {1,2} (g0), {2,3} (g1), {3,4} (g2); filtering on num_units == 5 must
+   * yield an empty surviving-group array.
+   * <p>setupPageIndex() must be called before secondaryFiltersByteRanges() so that
+   * has_page_index_and_only_dict_encoded_pages is true and dictionary page ranges are emitted.</p>
+   */
+  @Test
+  void testFilterRowGroupsWithDictionaryPagesPrunesAllGroups(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("num_units", BinaryOperator.EQUAL, 5)) {
+      open.withPageIndex();
+      HybridScanReader reader = open.reader;
+      int[] rgs = reader.allRowGroups();
+      SecondaryFilterRanges sfr = reader.secondaryFiltersByteRanges(rgs);
+      DeviceMemoryBuffer[] dictBufs = copyRangesToDevice(open.file, sfr.dictionaryPageRanges());
+      try {
+        int[] result = reader.filterRowGroupsWithDictionaryPages(dictBufs, rgs);
+        assertEquals(0, result.length,
+            "num_units == 5 is not in any group's dictionary ({1,2}, {2,3}, {3,4}); all pruned");
+      } finally {
+        closeAll(dictBufs);
+      }
+    }
+  }
+
+  /**
+   * Verifies filterRowGroupsWithDictionaryPages() returns a strict subset of input row
+   * groups when an EQUAL literal is present in some but not all groups' dictionaries. The
+   * pageIndex fixture's num_units dictionaries are {1,2} (g0), {2,3} (g1), {3,4} (g2); all
+   * three column chunks are dictionary-encoded under COLUMN stats. With filter
+   * num_units == 2, the literal is in g0 and g1 but not g2, so the result is exactly {0, 1}.
+   */
+  @Test
+  void testFilterRowGroupsWithDictionaryPagesPrunesSubsetOfGroups(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("num_units", BinaryOperator.EQUAL, 2)) {
+      open.withPageIndex();
+      HybridScanReader reader = open.reader;
+      int[] rgs = reader.allRowGroups();
+      SecondaryFilterRanges sfr = reader.secondaryFiltersByteRanges(rgs);
+      DeviceMemoryBuffer[] dictBufs = copyRangesToDevice(open.file, sfr.dictionaryPageRanges());
+      try {
+        int[] result = reader.filterRowGroupsWithDictionaryPages(dictBufs, rgs);
+        assertArrayEquals(new int[]{0, 1}, result,
+            "num_units == 2 ∈ g0 dict {1,2} and g1 dict {2,3}, ∉ g2 dict {3,4}");
+      } finally {
+        closeAll(dictBufs);
+      }
+    }
+  }
+
+  /**
+   * Verifies filterRowGroupsWithDictionaryPages() throws when the upstream
+   * secondaryFiltersByteRanges yields no dict ranges due to ADAPTIVE policy skipping dict
+   * emission on a high-cardinality column. With EQUAL on zip_code (5,000 distinct values
+   * per group), no dict pages exist, so no buffers can be supplied. The C++ CUDF_EXPECTS
+   * at prepare_dictionaries enforces buffers.size() == row_groups × dict-eligible cols.
+   */
+  @Test
+  void testFilterRowGroupsWithDictionaryPagesThrowsForHighCardinality(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("zip_code", BinaryOperator.EQUAL, 12345)) {
+      int[] rgs = open.reader.allRowGroups();
+      SecondaryFilterRanges sfr = open.reader.secondaryFiltersByteRanges(rgs);
+      DeviceMemoryBuffer[] dictBufs = copyRangesToDevice(open.file, sfr.dictionaryPageRanges());
+      try {
+        assertEquals(0, dictBufs.length, "ADAPTIVE skips dict for high-cardinality zip_code");
+        assertThrows(CudfException.class,
+            () -> open.reader.filterRowGroupsWithDictionaryPages(dictBufs, rgs),
+            "CUDF_EXPECTS at prepare_dictionaries: 0 buffers != 3 row groups × 1 dict-eligible col");
+      } finally {
+        closeAll(dictBufs);
+      }
+    }
+  }
+
+  /**
+   * Verifies filterRowGroupsWithDictionaryPages() throws when the upstream
+   * secondaryFiltersByteRanges yields no dict ranges due to a missing page index, even
+   * though the writer emitted dictionaries. With ROWGROUP-stats fixture + EQUAL on
+   * low-cardinality num_units, has_page_index_and_only_dict_encoded_pages is false (no
+   * ColumnIndex/OffsetIndex), so no buffers can be supplied. The C++ CUDF_EXPECTS at
+   * prepare_dictionaries fires for the same reason as the high-cardinality case but with
+   * a different upstream cause.
+   */
+  @Test
+  void testFilterRowGroupsWithDictionaryPagesThrowsWithoutPageIndex(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.rowGroupStats(tmp).withFilter("num_units", BinaryOperator.EQUAL, 2)) {
+      int[] rgs = new int[]{0};
+      SecondaryFilterRanges sfr = open.reader.secondaryFiltersByteRanges(rgs);
+      DeviceMemoryBuffer[] dictBufs = copyRangesToDevice(open.file, sfr.dictionaryPageRanges());
+      try {
+        assertEquals(0, dictBufs.length, "Without page index, no dict ranges discoverable");
+        assertThrows(CudfException.class,
+            () -> open.reader.filterRowGroupsWithDictionaryPages(dictBufs, rgs),
+            "CUDF_EXPECTS at prepare_dictionaries: 0 buffers != 1 row group × 1 dict-eligible col");
+      } finally {
+        closeAll(dictBufs);
+      }
+    }
+  }
+
+  // TODO: add testFilterRowGroupsWithBloomFilters once ParquetWriterOptions exposes
+  //       bloom filter writing (set_column_chunks_bloom_filter_params). See
+  //       HybridScanReader.java for details.
+
+  // --------------------------------------------------------------------
+  // Tests: filterColumnChunksByteRanges()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies filterColumnChunksByteRanges() returns one range per surviving row group for
+   * the single filter column ("zip_code"). With filter zip_code > 150,000, group 0 (max
+   * zip 109,900) is pruned by filterRowGroupsWithStats and groups 1, 2 survive:
+   * 1 filter column × 2 surviving groups = 2 non-empty ranges. The reduction from
+   * allRowGroups (3) to survived (2) demonstrates that the method's output tracks its
+   * row-group input.
+   */
+  @Test
+  void testFilterColumnChunksByteRangesOnePerSurvivingGroup(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      int[] survived = open.reader.filterRowGroupsWithStats(open.reader.allRowGroups());
+      ByteRange[] ranges = open.reader.filterColumnChunksByteRanges(survived);
+      assertEquals(2, ranges.length,
+          "1 filter column × 2 surviving row groups (group 0 pruned by filterRowGroupsWithStats)");
+      for (ByteRange r : ranges) {
+        assertTrue(r.size() > 0, "Each filter column-chunk range must be non-empty");
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: payloadColumnChunksByteRanges()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies payloadColumnChunksByteRanges() returns one range per projected column per row
+   * group when no filter is set: with 3 projected columns × 3 row groups, the result has
+   * 9 ranges.
+   */
+  @Test
+  void testPayloadColumnChunksByteRangesNoFilter(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      ByteRange[] ranges = open.reader.payloadColumnChunksByteRanges(open.reader.allRowGroups());
+      assertEquals(9, ranges.length, "3 payload columns × 3 row groups");
+      for (ByteRange r : ranges) {
+        assertTrue(r.size() > 0);
+      }
+    }
+  }
+
+  /**
+   * Verifies payloadColumnChunksByteRanges() returns ranges for all projected columns when
+   * called BEFORE any filter-column operation has populated the reader's filter
+   * column-name cache (_filter_columns_names in C++). In this pre-filter-pipeline state,
+   * the C++ select_payload_columns receives an empty filter-column set and skips the
+   * filter-column exclusion step. Result: 3 projected columns × 3 row groups = 9 ranges.
+   * See {@link #testPayloadColumnChunksByteRangesAfterFilterColumnsCall} for the
+   * post-pipeline contract (filter column excluded → 6 ranges).
+   */
+  @Test
+  void testPayloadColumnChunksByteRangesWithFilter(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 50000)) {
+      ByteRange[] ranges = open.reader.payloadColumnChunksByteRanges(open.reader.allRowGroups());
+      assertEquals(9, ranges.length, "3 projected columns × 3 row groups (filter column not excluded)");
+      for (ByteRange r : ranges) {
+        assertTrue(r.size() > 0);
+      }
+    }
+  }
+
+  /**
+   * Verifies payloadColumnChunksByteRanges() excludes the filter column when called AFTER
+   * filterColumnChunksByteRanges has populated _filter_columns_names. This is the typical
+   * pipeline order (filter columns resolved first, materialized, then payload columns
+   * resolved for the surviving rows). With filter zip_code > 50,000, _filter_columns_names
+   * = {"zip_code"} after the first call; payloadColumnChunksByteRanges then returns ranges
+   * for {id, num_units} only: 2 cols × 3 row groups = 6 non-empty ranges.
+   */
+  @Test
+  void testPayloadColumnChunksByteRangesAfterFilterColumnsCall(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 50000)) {
+      int[] rgs = open.reader.allRowGroups();
+      open.reader.filterColumnChunksByteRanges(rgs);
+      ByteRange[] ranges = open.reader.payloadColumnChunksByteRanges(rgs);
+      assertEquals(6, ranges.length,
+          "After filterColumnChunksByteRanges populates _filter_columns_names, "
+              + "the filter column zip_code is excluded: 2 cols × 3 row groups");
+      for (ByteRange r : ranges) {
+        assertTrue(r.size() > 0);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: allColumnChunksByteRanges()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies allColumnChunksByteRanges() includes all projected columns even after the
+   * filter pipeline has populated _filter_columns_names. The C++ select_columns(ALL_COLUMNS)
+   * never consults the filter-column cache, so the filter column zip_code is NOT excluded —
+   * a deliberate contrast with payloadColumnChunksByteRanges, which DOES exclude in the
+   * same state (see testPayloadColumnChunksByteRangesAfterFilterColumnsCall returning 6).
+   * Result: 3 cols × 3 row groups = 9 non-empty ranges; the post-pipeline state implies
+   * the no-filter state for this method.
+   */
+  @Test
+  void testAllColumnChunksByteRangesExactCount(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 50000)) {
+      HybridScanReader reader = open.reader;
+      int[] rgs = reader.allRowGroups();
+      reader.filterColumnChunksByteRanges(rgs);
+      ByteRange[] ranges = reader.allColumnChunksByteRanges(rgs);
+      assertEquals(9, ranges.length,
+          "All 3 columns × 3 row groups; filter column NOT excluded (unlike payload).");
+      for (ByteRange r : ranges) {
+        assertTrue(r.size() > 0);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: materializeFilterColumns()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies materializeFilterColumns() produces a filter table with the exact expected row
+   * count and column count: filter zip_code > 150,000 prunes group 0 (max 109,900) and
+   * keeps 599 + 1000 = 1599 rows from groups 1+2; the filter table contains the single
+   * filter column ("zip_code").
+   */
+  @Test
+  void testMaterializeFilterColumnsExactRowCount(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      HybridScanReader reader = open.reader;
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      try (HybridScanReader.FilterMaterializationResult fr =
+               reader.materializeFilterColumns(survived, filterCols, UseDataPageMask.NO,
+                   HybridScanReader.RowMaskKind.ALL_TRUE)) {
+        assertEquals(1599L, fr.table().getRowCount());
+        assertEquals(1, fr.table().getNumberOfColumns(), "filter table contains only zip_code");
+      } finally {
+        closeAll(filterCols);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: materializePayloadColumns()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies materializePayloadColumns() produces a payload table with the exact expected
+   * row count and column count: 1599 rows survive the filter; the payload table contains
+   * the two non-filter columns ("id", "num_units").
+   */
+  @Test
+  void testMaterializePayloadColumnsExactRowCount(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      HybridScanReader reader = open.reader;
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      DeviceMemoryBuffer[] payloadCols = copyRangesToDevice(
+          open.file, reader.payloadColumnChunksByteRanges(survived));
+      try (HybridScanReader.FilterMaterializationResult fr =
+               reader.materializeFilterColumns(survived, filterCols, UseDataPageMask.NO,
+                   HybridScanReader.RowMaskKind.ALL_TRUE);
+           Table payload = reader.materializePayloadColumns(survived, payloadCols,
+               fr.rowMask(), UseDataPageMask.NO)) {
+        assertEquals(1599L, payload.getRowCount());
+        assertEquals(2, payload.getNumberOfColumns(), "payload table contains id + num_units");
+      } finally {
+        closeAll(filterCols);
+        closeAll(payloadCols);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: materializeAllColumns()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies materializeAllColumns() returns a table with all 3 projected columns and the
+   * exact total row count (3,000) for the fixture.
+   */
+  @Test
+  void testMaterializeAllColumnsExactRowCount(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      HybridScanReader reader = open.reader;
+      int[] rgs = reader.allRowGroups();
+      ByteRange[] ranges = reader.allColumnChunksByteRanges(rgs);
+      DeviceMemoryBuffer[] devs = copyRangesToDevice(open.file, ranges);
+      try (Table t = reader.materializeAllColumns(rgs, devs)) {
+        assertEquals(3, t.getNumberOfColumns());
+        assertEquals(3000L, t.getRowCount());
+      } finally {
+        closeAll(devs);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: setupChunkingForFilterColumns()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies setupChunkingForFilterColumns() activates the filter-column chunked pipeline:
+   * hasNextTableChunk() reports true after setup. (Calling hasNextTableChunk() before any
+   * chunking has been set up is invalid in the C++ contract — see the dedicated
+   * hasNextTableChunk tests.)
+   */
+  @Test
+  void testSetupChunkingForFilterColumnsActivatesPipeline(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      HybridScanReader reader = open.reader;
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      try {
+        reader.setupChunkingForFilterColumns(0L, 0L, survived,
+            UseDataPageMask.NO, HybridScanReader.RowMaskKind.ALL_TRUE, filterCols);
+        assertTrue(reader.hasNextTableChunk(), "chunking active after setup");
+      } finally {
+        closeAll(filterCols);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: materializeFilterColumnsChunk()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies materializeFilterColumnsChunk() drains the exact expected row count when
+   * chained with setupChunkingForFilterColumns(): 1599 rows (filter zip_code > 150,000
+   * survives 599 + 1000 rows from groups 1+2). Also asserts the post-drain row mask:
+   * setup establishes length 2000 (preserved by drain), and drain refines per-row
+   * truth so the final true-count = 1599.
+   */
+  @Test
+  void testMaterializeFilterColumnsChunkExactTotal(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      HybridScanReader reader = open.reader;
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      try {
+        reader.setupChunkingForFilterColumns(0L, 0L, survived,
+            UseDataPageMask.NO, HybridScanReader.RowMaskKind.ALL_TRUE, filterCols);
+        long total = 0;
+        while (reader.hasNextTableChunk()) {
+          try (Table chunk = reader.materializeFilterColumnsChunk()) {
+            total += chunk.getRowCount();
+          }
+        }
+        assertEquals(1599L, total,
+            "Filter chunks contain only the rows that survive the filter expression");
+        try (ColumnVector rowMask = reader.takeFilterRowMask()) {
+          assertEquals(2000L, rowMask.getRowCount(),
+              "Drain does not change mask length");
+          assertEquals(1599L, countTrue(rowMask),
+              "After drain, true-count = surviving row count");
+        }
+      } finally {
+        closeAll(filterCols);
+      }
+    }
+  }
+
+  /**
+   * Verifies materializeFilterColumnsChunk() throws IllegalArgumentException when invoked
+   * without an active chunked filter pipeline. The JNI layer guards this state and rejects
+   * the call before reaching the C++ implementation.
+   */
+  @Test
+  void testMaterializeFilterColumnsChunkBeforeSetupThrows(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      assertThrows(IllegalArgumentException.class, open.reader::materializeFilterColumnsChunk);
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: takeFilterRowMask()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies takeFilterRowMask() exposes the all-true mask immediately after setup, before
+   * any chunks have been materialized. The mask is fully constructed by build_all_true_row_mask
+   * at setup time: length = total input rows in surviving row groups, all entries = true.
+   * For survived = {1, 2}: length = 2 × 1000 = 2000, true-count = 2000.
+   */
+  @Test
+  void testTakeFilterRowMaskAllTrueExposesPreallocatedMask(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      HybridScanReader reader = open.reader;
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      try {
+        reader.setupChunkingForFilterColumns(0L, 0L, survived,
+            UseDataPageMask.NO, HybridScanReader.RowMaskKind.ALL_TRUE, filterCols);
+        try (ColumnVector rowMask = reader.takeFilterRowMask()) {
+          assertEquals(2000L, rowMask.getRowCount(),
+              "Mask spans input rows of surviving row groups (groups 1+2)");
+          assertEquals(2000L, countTrue(rowMask),
+              "All entries true: ALL_TRUE seed, no filter evaluation has run");
+        }
+      } finally {
+        closeAll(filterCols);
+      }
+    }
+  }
+
+  /**
+   * Verifies takeFilterRowMask() exposes the page-index-stats-pre-evaluated mask after setup,
+   * before any chunks have been materialized. By passing all 3 row groups into setup (skipping
+   * the upstream filterRowGroupsWithStats step), the page-index pre-evaluation is observable:
+   * groups 0 and 1 (max zip 4,999 and 54,999) are pruned to false; group 2 (zip 100,000+) is
+   * preserved as true. Length = 3 × 5000 = 15,000; true-count = 5,000.
+   */
+  @Test
+  void testTakeFilterRowMaskPageIndexStatsExposesPagePrunedMask(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("zip_code", BinaryOperator.GREATER, 99999)) {
+      open.withPageIndex();
+      HybridScanReader reader = open.reader;
+      int[] allRgs = reader.allRowGroups();
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(allRgs));
+      try {
+        reader.setupChunkingForFilterColumns(0L, 0L, allRgs,
+            UseDataPageMask.YES, HybridScanReader.RowMaskKind.PAGE_INDEX_STATS, filterCols);
+        try (ColumnVector rowMask = reader.takeFilterRowMask()) {
+          assertEquals(15000L, rowMask.getRowCount(),
+              "Mask spans all 3 row groups: 3 × 5000 = 15,000");
+          assertEquals(5000L, countTrue(rowMask),
+              "Only group 2 (5000 rows) survives page-index pruning of zip_code > 99,999");
+        }
+      } finally {
+        closeAll(filterCols);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: setupChunkingForPayloadColumns()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies setupChunkingForPayloadColumns() activates payload-column chunking:
+   * hasNextTableChunk() reports true after setup.
+   */
+  @Test
+  void testSetupChunkingForPayloadColumnsActivatesPipeline(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      HybridScanReader reader = open.reader;
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      DeviceMemoryBuffer[] payloadCols = copyRangesToDevice(
+          open.file, reader.payloadColumnChunksByteRanges(survived));
+      try {
+        reader.setupChunkingForFilterColumns(0L, 0L, survived,
+            UseDataPageMask.NO, HybridScanReader.RowMaskKind.ALL_TRUE, filterCols);
+        try (ColumnVector rowMask = reader.takeFilterRowMask()) {
+          reader.setupChunkingForPayloadColumns(0L, 0L, survived,
+              rowMask, UseDataPageMask.NO, payloadCols);
+          assertTrue(reader.hasNextTableChunk(), "payload chunking active after setup");
+        }
+      } finally {
+        closeAll(filterCols);
+        closeAll(payloadCols);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: materializePayloadColumnsChunk()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies materializePayloadColumnsChunk() drains the exact expected row count when
+   * chained after setupChunkingForPayloadColumns(): 1599 rows surviving the filter
+   * zip_code > 150,000.
+   */
+  @Test
+  void testMaterializePayloadColumnsChunkExactTotal(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp).withFilter("zip_code", BinaryOperator.GREATER, 150000)) {
+      HybridScanReader reader = open.reader;
+      int[] survived = reader.filterRowGroupsWithStats(reader.allRowGroups());
+      DeviceMemoryBuffer[] filterCols = copyRangesToDevice(
+          open.file, reader.filterColumnChunksByteRanges(survived));
+      DeviceMemoryBuffer[] payloadCols = copyRangesToDevice(
+          open.file, reader.payloadColumnChunksByteRanges(survived));
+      try {
+        reader.setupChunkingForFilterColumns(0L, 0L, survived,
+            UseDataPageMask.NO, HybridScanReader.RowMaskKind.ALL_TRUE, filterCols);
+        while (reader.hasNextTableChunk()) {
+          reader.materializeFilterColumnsChunk().close();
+        }
+        try (ColumnVector rowMask = reader.takeFilterRowMask()) {
+          reader.setupChunkingForPayloadColumns(0L, 0L, survived,
+              rowMask, UseDataPageMask.NO, payloadCols);
+          long total = 0;
+          while (reader.hasNextTableChunk()) {
+            try (Table chunk = reader.materializePayloadColumnsChunk(rowMask)) {
+              total += chunk.getRowCount();
+            }
+          }
+          assertEquals(1599L, total);
+        }
+      } finally {
+        closeAll(filterCols);
+        closeAll(payloadCols);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: setupChunkingForAllColumns() / materializeAllColumnsChunk()
+  //
+  // These two methods are tightly coupled (every meaningful scenario calls them in
+  // sequence with hasNextTableChunk() driving the loop). One integration test below
+  // exercises both together. Their post-close and null-argument behaviors are
+  // covered by the parameterized tests at the end of the class.
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies the all-columns chunked pipeline drains the exact total row count (3,000)
+   * with all 3 projected columns in every chunk.
+   */
+  @Test
+  void testChunkedAllColumnsExactTotal(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      HybridScanReader reader = open.reader;
+      int[] rgs = reader.allRowGroups();
+      ByteRange[] ranges = reader.allColumnChunksByteRanges(rgs);
+      DeviceMemoryBuffer[] devs = copyRangesToDevice(open.file, ranges);
+      try {
+        reader.setupChunkingForAllColumns(0L, 0L, rgs, devs);
+        long totalRows = 0;
+        int chunks = 0;
+        while (reader.hasNextTableChunk()) {
+          try (Table chunk = reader.materializeAllColumnsChunk()) {
+            assertEquals(3, chunk.getNumberOfColumns());
+            totalRows += chunk.getRowCount();
+            chunks++;
+          }
+        }
+        assertTrue(chunks >= 1);
+        assertEquals(3000L, totalRows);
+      } finally {
+        closeAll(devs);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: hasNextTableChunk()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies hasNextTableChunk() reports the active lifecycle of a chunked pipeline: true
+   * after setup, then false once chunks have been drained. With (0L, 0L) read limits, the
+   * C++ contract guarantees a single chunk per pass, so the lifecycle is:
+   * setup → true → one materialize → false.
+   */
+  @Test
+  void testHasNextTableChunkActiveAndAfterDrain(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      HybridScanReader reader = open.reader;
+      int[] rgs = reader.allRowGroups();
+      DeviceMemoryBuffer[] devs = copyRangesToDevice(
+          open.file, reader.allColumnChunksByteRanges(rgs));
+      try {
+        reader.setupChunkingForAllColumns(0L, 0L, rgs, devs);
+        assertTrue(reader.hasNextTableChunk(), "chunking active after setup");
+        reader.materializeAllColumnsChunk().close();
+        assertFalse(reader.hasNextTableChunk(),
+            "(0,0) read limits emit a single chunk; iterator drained after one materialize call");
+      } finally {
+        closeAll(devs);
+      }
+    }
+  }
+
+  /**
+   * Verifies hasNextTableChunk() throws when called before any setupChunkingFor* method has
+   * established an active pipeline. The C++ guard (CUDF_EXPECTS at hybrid_scan_impl.cpp
+   * "Chunking not yet setup") propagates to Java as a CudfException.
+   */
+  @Test
+  void testHasNextTableChunkRequiresSetupChunkingFirst(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      assertThrows(CudfException.class, () -> open.reader.hasNextTableChunk(),
+          "Pre-setup hasNextTableChunk() must throw 'Chunking not yet setup'");
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: constructRowGroupPasses()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies constructRowGroupPasses() with no read-limit (passReadLimit = 0) packs all
+   * input row groups into a single pass that is structurally equal to the input.
+   */
+  @Test
+  void testConstructRowGroupPassesUnlimitedReturnsSinglePass(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      int[] all = open.reader.allRowGroups();
+      int[][] passes = open.reader.constructRowGroupPasses(all, 0L);
+      assertEquals(1, passes.length, "passReadLimit = 0 must return one pass");
+      assertArrayEquals(all, passes[0]);
+    }
+  }
+
+  /**
+   * Verifies constructRowGroupPasses() partitions input row groups across multiple passes,
+   * preserving order, when passReadLimit is small enough to force splitting. With
+   * passReadLimit = 1, comp_read_limit = floor(1 * 0.3) = 0, so compute_row_group_passes
+   * closes a pass at every row group boundary: {[0]}, {[1]}, {[2]}. The exact partition
+   * simultaneously verifies the multi-pass capability and that the result is covering,
+   * disjoint, and order-preserving.
+   */
+  @Test
+  void testConstructRowGroupPassesMultiPassPartition(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      int[] all = open.reader.allRowGroups();
+      int[][] passes = open.reader.constructRowGroupPasses(all, 1L);
+      assertEquals(3, passes.length, "passReadLimit = 1 forces each row group into its own pass");
+      assertArrayEquals(new int[]{0}, passes[0]);
+      assertArrayEquals(new int[]{1}, passes[1]);
+      assertArrayEquals(new int[]{2}, passes[2]);
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: close()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies close() flips the reader from operational to closed-and-rejecting state, and
+   * that subsequent close() calls are idempotent. The pre-close probe asserts the reader
+   * is usable (not just that the constructor succeeded); the post-close probe asserts that
+   * assertNotClosed() now fires; the second close() asserts the no-throw idempotency
+   * contract.
+   */
+  @Test
+  void testCloseTransitionsAndIsIdempotent(@TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      HybridScanReader reader = open.reader;
+      assertArrayEquals(new int[]{0, 1, 2}, reader.allRowGroups(),
+          "Reader operational pre-close");
+      reader.close();
+      assertThrows(IllegalStateException.class, reader::allRowGroups,
+          "close() flips state; further use throws");
+      reader.close();
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: null-argument rejection (parameterized)
+  //
+  // Every public method that accepts a non-null reference argument validates it with a
+  // Java-side null check before reaching native code. The check is uniform across the API
+  // (all throw IllegalArgumentException), so a single parameterized test exercises every
+  // method's null-arg contract. Discoverability is preserved via the {0}RejectsNull
+  // display name in the surefire report.
+  // --------------------------------------------------------------------
+
+  /** Verifies every public method rejects null arguments with IllegalArgumentException. */
+  @ParameterizedTest(name = "{0}RejectsNull")
+  @MethodSource("nullArgInvocations")
+  void testRejectsNullArg(String name, Consumer<HybridScanReader> action,
+                          @TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      assertThrows(IllegalArgumentException.class, () -> action.accept(open.reader));
+    }
+  }
+
+  static Stream<Arguments> nullArgInvocations() {
+    return Stream.of(
+        invocation("setupPageIndex", r -> r.setupPageIndex(null)),
+        invocation("totalRowsInRowGroups", r -> r.totalRowsInRowGroups(null)),
+        invocation("filterRowGroupsWithStats", r -> r.filterRowGroupsWithStats(null)),
+        invocation("secondaryFiltersByteRanges", r -> r.secondaryFiltersByteRanges(null)),
+        invocation("filterRowGroupsWithDictionaryPagesNullBuffers",
+            r -> r.filterRowGroupsWithDictionaryPages(null, new int[]{0})),
+        invocation("filterRowGroupsWithDictionaryPagesNullRowGroups",
+            r -> r.filterRowGroupsWithDictionaryPages(new DeviceMemoryBuffer[0], null)),
+        invocation("filterColumnChunksByteRanges", r -> r.filterColumnChunksByteRanges(null)),
+        invocation("payloadColumnChunksByteRanges", r -> r.payloadColumnChunksByteRanges(null)),
+        invocation("allColumnChunksByteRanges", r -> r.allColumnChunksByteRanges(null)),
+        invocation("materializeFilterColumns", r -> r.materializeFilterColumns(null,
+            new DeviceMemoryBuffer[0], UseDataPageMask.NO,
+            HybridScanReader.RowMaskKind.ALL_TRUE)),
+        invocation("materializePayloadColumnsNullRowGroups", r -> {
+          try (ColumnVector mask = ColumnVector.fromBooleans(true)) {
+            r.materializePayloadColumns(null, new DeviceMemoryBuffer[0],
+                mask, UseDataPageMask.NO);
+          }
+        }),
+        invocation("materializePayloadColumnsNullRowMask", r -> r.materializePayloadColumns(
+            new int[]{0}, new DeviceMemoryBuffer[0], null, UseDataPageMask.NO)),
+        invocation("materializeAllColumns", r -> r.materializeAllColumns(null,
+            new DeviceMemoryBuffer[0])),
+        invocation("setupChunkingForFilterColumns", r -> r.setupChunkingForFilterColumns(
+            0L, 0L, null, UseDataPageMask.NO, HybridScanReader.RowMaskKind.ALL_TRUE,
+            new DeviceMemoryBuffer[0])),
+        invocation("setupChunkingForPayloadColumnsNullRowGroups", r -> {
+          try (ColumnVector mask = ColumnVector.fromBooleans(true)) {
+            r.setupChunkingForPayloadColumns(0L, 0L, null, mask, UseDataPageMask.NO,
+                new DeviceMemoryBuffer[0]);
+          }
+        }),
+        invocation("setupChunkingForPayloadColumnsNullRowMask", r ->
+            r.setupChunkingForPayloadColumns(0L, 0L, new int[]{0}, null, UseDataPageMask.NO,
+                new DeviceMemoryBuffer[0])),
+        invocation("materializePayloadColumnsChunk", r -> r.materializePayloadColumnsChunk(null)),
+        invocation("setupChunkingForAllColumns", r -> r.setupChunkingForAllColumns(
+            0L, 0L, null, new DeviceMemoryBuffer[0])),
+        invocation("constructRowGroupPasses", r -> r.constructRowGroupPasses(null, 0L))
+    );
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: post-close behavior (parameterized)
+  //
+  // Every public method on HybridScanReader calls assertNotClosed() before reaching native
+  // code, which throws IllegalStateException when the reader has been closed. The contract
+  // is uniform across the API, so a single parameterized test exercises every method's
+  // post-close behavior. Discoverability is preserved via the {0}AfterCloseThrows display
+  // name in the surefire report.
+  // --------------------------------------------------------------------
+
+  /** Verifies every public method throws IllegalStateException after the reader is closed. */
+  @ParameterizedTest(name = "{0}AfterCloseThrows")
+  @MethodSource("postCloseInvocations")
+  void testAfterCloseThrows(String name, Consumer<HybridScanReader> action,
+                            @TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      open.reader.close();
+      assertThrows(IllegalStateException.class, () -> action.accept(open.reader));
+    }
+  }
+
+  static Stream<Arguments> postCloseInvocations() {
+    return Stream.of(
+        invocation("pageIndexByteRange", HybridScanReader::pageIndexByteRange),
+        invocation("setupPageIndex", r -> {
+          try (HostMemoryBuffer empty = HostMemoryBuffer.allocate(1)) {
+            r.setupPageIndex(empty);
+          }
+        }),
+        invocation("allRowGroups", HybridScanReader::allRowGroups),
+        invocation("totalRowsInRowGroups", r -> r.totalRowsInRowGroups(new int[]{0})),
+        invocation("filterRowGroupsWithStats", r -> r.filterRowGroupsWithStats(new int[]{0})),
+        invocation("secondaryFiltersByteRanges", r -> r.secondaryFiltersByteRanges(new int[]{0})),
+        invocation("filterRowGroupsWithDictionaryPages", r ->
+            r.filterRowGroupsWithDictionaryPages(new DeviceMemoryBuffer[0], new int[]{0})),
+        invocation("filterColumnChunksByteRanges", r -> r.filterColumnChunksByteRanges(new int[]{0})),
+        invocation("payloadColumnChunksByteRanges", r -> r.payloadColumnChunksByteRanges(new int[]{0})),
+        invocation("allColumnChunksByteRanges", r -> r.allColumnChunksByteRanges(new int[]{0})),
+        invocation("materializeFilterColumns", r -> r.materializeFilterColumns(new int[]{0},
+            new DeviceMemoryBuffer[0], UseDataPageMask.NO,
+            HybridScanReader.RowMaskKind.ALL_TRUE)),
+        invocation("materializePayloadColumns", r -> {
+          try (ColumnVector mask = ColumnVector.fromBooleans(true)) {
+            r.materializePayloadColumns(new int[]{0}, new DeviceMemoryBuffer[0],
+                mask, UseDataPageMask.NO);
+          }
+        }),
+        invocation("materializeAllColumns", r -> r.materializeAllColumns(new int[]{0},
+            new DeviceMemoryBuffer[0])),
+        invocation("setupChunkingForFilterColumns", r -> r.setupChunkingForFilterColumns(
+            0L, 0L, new int[]{0}, UseDataPageMask.NO,
+            HybridScanReader.RowMaskKind.ALL_TRUE, new DeviceMemoryBuffer[0])),
+        invocation("materializeFilterColumnsChunk", HybridScanReader::materializeFilterColumnsChunk),
+        invocation("takeFilterRowMask", HybridScanReader::takeFilterRowMask),
+        invocation("setupChunkingForPayloadColumns", r -> {
+          try (ColumnVector mask = ColumnVector.fromBooleans(true)) {
+            r.setupChunkingForPayloadColumns(0L, 0L, new int[]{0}, mask, UseDataPageMask.NO,
+                new DeviceMemoryBuffer[0]);
+          }
+        }),
+        invocation("materializePayloadColumnsChunk", r -> {
+          try (ColumnVector mask = ColumnVector.fromBooleans(true)) {
+            r.materializePayloadColumnsChunk(mask);
+          }
+        }),
+        invocation("setupChunkingForAllColumns", r -> r.setupChunkingForAllColumns(
+            0L, 0L, new int[]{0}, new DeviceMemoryBuffer[0])),
+        invocation("materializeAllColumnsChunk", HybridScanReader::materializeAllColumnsChunk),
+        invocation("hasNextTableChunk", HybridScanReader::hasNextTableChunk),
+        invocation("constructRowGroupPasses", r -> r.constructRowGroupPasses(new int[]{0}, 0L))
+    );
+  }
+
+  // --------------------------------------------------------------------
+  // Fixture helpers
+  // --------------------------------------------------------------------
+
+  /**
+   * Bundles a Parquet fixture (file bytes + extracted footer) with an open
+   * {@link HybridScanReader} and an optional compiled filter, all under one
+   * try-with-resources lifecycle. Use the {@link #standard(Path)},
+   * {@link #pageIndex(Path)}, or {@link #rowGroupStats(Path)} factories, optionally chained
+   * with {@link #withFilter(String, BinaryOperator, int)}.
+   */
+  private static final class OpenReader implements AutoCloseable {
+    final HostMemoryBuffer file;
+    final HostMemoryBuffer footer;
+    HybridScanReader reader;
+    CompiledExpression filter;
+
+    private OpenReader(HostMemoryBuffer file, HostMemoryBuffer footer,
+                       HybridScanReader reader, CompiledExpression filter) {
+      this.file = file;
+      this.footer = footer;
+      this.reader = reader;
+      this.filter = filter;
+    }
+
+    static OpenReader standard(Path tmp) throws IOException {
+      File pq = tmp.resolve("fixture.parquet").toFile();
+      writeFixtureParquet(pq);
+      return openFromFile(pq, DEFAULT_COLS);
+    }
+
+    static OpenReader pageIndex(Path tmp) throws IOException {
+      File pq = tmp.resolve("fixture.parquet").toFile();
+      writePageIndexParquet(pq);
+      return openFromFile(pq, DEFAULT_COLS);
+    }
+
+    static OpenReader rowGroupStats(Path tmp) throws IOException {
+      File pq = tmp.resolve("fixture.parquet").toFile();
+      writeRowGroupStatsParquet(pq);
+      return openFromFile(pq, DEFAULT_COLS);
+    }
+
+    private static OpenReader openFromFile(File pq, String[] cols) throws IOException {
+      HostMemoryBuffer file = readFileToHostBuffer(pq);
+      HostMemoryBuffer footer = null;
+      HybridScanReader reader = null;
+      try {
+        footer = extractFooter(file);
+        reader = new HybridScanReader(footer, optsForColumns(cols), null);
+      } catch (Throwable t) {
+        if (reader != null) reader.close();
+        if (footer != null) footer.close();
+        file.close();
+        throw t;
+      }
+      return new OpenReader(file, footer, reader, null);
+    }
+
+    /**
+     * Replace the inner reader with one constructed from the same buffers and the supplied
+     * filter expression. Closes the previous reader (and any previous filter) but keeps the
+     * file/footer buffers, so the caller's try-with-resources still owns the same lifetime.
+     */
+    OpenReader withFilter(String col, BinaryOperator op, int literal) {
+      CompiledExpression newFilter = null;
+      HybridScanReader newReader = null;
+      try {
+        newFilter = new BinaryOperation(op, new ColumnNameReference(col),
+            Literal.ofInt(literal)).compile();
+        newReader = new HybridScanReader(footer, optsForColumns(DEFAULT_COLS), newFilter);
+      } catch (Throwable t) {
+        if (newReader != null) newReader.close();
+        if (newFilter != null) newFilter.close();
+        throw t;
+      }
+      if (this.filter != null) this.filter.close();
+      this.reader.close();
+      this.reader = newReader;
+      this.filter = newFilter;
+      return this;
+    }
+
+    /** Loads the file's page-index region into the reader; returns {@code this} for chaining. */
+    OpenReader withPageIndex() throws IOException {
+      ByteRange piRange = reader.pageIndexByteRange();
+      try (HostMemoryBuffer pi = file.slice(piRange.offset(), piRange.size())) {
+        reader.setupPageIndex(pi);
+      }
+      return this;
+    }
+
+    @Override
+    public void close() {
+      Throwable err = null;
+      try { if (reader != null) reader.close(); } catch (Throwable t) { err = t; }
+      try { if (filter != null) filter.close(); } catch (Throwable t) { if (err == null) err = t; }
+      try { if (footer != null) footer.close(); } catch (Throwable t) { if (err == null) err = t; }
+      try { if (file != null) file.close(); } catch (Throwable t) { if (err == null) err = t; }
+      if (err instanceof RuntimeException) throw (RuntimeException) err;
+      if (err instanceof Error) throw (Error) err;
+      if (err != null) throw new RuntimeException(err);
+    }
+  }
+
+  private static Arguments invocation(String name, Consumer<HybridScanReader> action) {
+    return arguments(name, action);
+  }
+
+  /**
+   * Writes a 3-row-group Parquet file: int columns {@code id} (globally sequential),
+   * {@code zip_code} (10000 + id * 100), and {@code num_units} (1..3 cycle).
+   * Uses {@code PAGE} statistics; 1,000 rows per group (3,000 total).
+   *
+   * @return total row count (3,000)
+   */
+  private static int writeFixtureParquet(File path) {
+    int rowsPerGroup = 1000;
+    int numGroups = 3;
+    int rows = rowsPerGroup * numGroups;
+    ParquetWriterOptions opts = ParquetWriterOptions.builder()
+        .withNonNullableColumns("id", "zip_code", "num_units")
+        .withRowGroupSizeRows(rowsPerGroup)
+        .withStatisticsFrequency(ParquetWriterOptions.StatisticsFrequency.PAGE)
+        .build();
+    try (TableWriter writer = Table.writeParquetChunked(opts, path)) {
+      for (int g = 0; g < numGroups; g++) {
+        int start = g * rowsPerGroup;
+        try (ColumnVector id = ColumnVector.fromInts(
+                 IntStream.range(start, start + rowsPerGroup).toArray());
+             ColumnVector zipCode = ColumnVector.fromInts(
+                 IntStream.range(start, start + rowsPerGroup)
+                     .map(i -> 10000 + i * 100).toArray());
+             ColumnVector numUnits = ColumnVector.fromInts(
+                 IntStream.range(start, start + rowsPerGroup)
+                     .map(i -> 1 + (i % 3)).toArray());
+             Table t = new Table(id, zipCode, numUnits)) {
+          writer.write(t);
+        }
+      }
+    }
+    return rows;
+  }
+
+  /**
+   * Writes a small Parquet file with {@code ROWGROUP}-level statistics: row-group min/max
+   * are recorded but no page index (no {@code ColumnIndex}/{@code OffsetIndex}) is emitted.
+   * Includes a low-cardinality {@code num_units} column ({1, 2, 3} cycle) so the writer's
+   * ADAPTIVE dictionary policy emits a dictionary; this lets tests exercise the
+   * "no page index, dict exists" path (see
+   * {@link #testSecondaryFiltersByteRangesEmptyForRowGroupStats}).
+   */
+  private static void writeRowGroupStatsParquet(File path) {
+    int rows = 100;
+    ParquetWriterOptions opts = ParquetWriterOptions.builder()
+        .withNonNullableColumns("id", "zip_code", "num_units")
+        .withRowGroupSizeRows(rows)
+        .withStatisticsFrequency(ParquetWriterOptions.StatisticsFrequency.ROWGROUP)
+        .build();
+    try (TableWriter writer = Table.writeParquetChunked(opts, path);
+         ColumnVector id = ColumnVector.fromInts(IntStream.range(0, rows).toArray());
+         ColumnVector zipCode = ColumnVector.fromInts(
+             IntStream.range(0, rows).map(i -> 10000 + i).toArray());
+         ColumnVector numUnits = ColumnVector.fromInts(
+             IntStream.range(0, rows).map(i -> 1 + (i % 3)).toArray());
+         Table t = new Table(id, zipCode, numUnits)) {
+      writer.write(t);
+    }
+  }
+
+  /**
+   * Writes a 3-row-group Parquet file with {@code COLUMN}-level statistics, guaranteeing
+   * a non-empty page index. Each group gets a non-overlapping {@code zip_code} range
+   * (group {@code g}: base = g × 50,000):
+   * <ul>
+   *   <li>Group 0: zip_code 0–4,999</li>
+   *   <li>Group 1: zip_code 50,000–54,999</li>
+   *   <li>Group 2: zip_code 100,000–104,999</li>
+   * </ul>
+   * Each group also has a distinct low-cardinality {@code num_units} dictionary, enabling
+   * strict-subset row-group pruning tests for {@code filterRowGroupsWithDictionaryPages}:
+   * <ul>
+   *   <li>Group 0: num_units ∈ {1, 2}</li>
+   *   <li>Group 1: num_units ∈ {2, 3}</li>
+   *   <li>Group 2: num_units ∈ {3, 4}</li>
+   * </ul>
+   * 5,000 rows per group (15,000 total).
+   *
+   * @return total row count (15,000)
+   */
+  private static int writePageIndexParquet(File path) {
+    int rowsPerGroup = 5_000;
+    int numGroups = 3;
+    int rows = rowsPerGroup * numGroups;
+    int[] zipBases = {0, 50_000, 100_000};
+    int[][] numUnitsValues = {{1, 2}, {2, 3}, {3, 4}};
+    ParquetWriterOptions opts = ParquetWriterOptions.builder()
+        .withNonNullableColumns("id", "zip_code", "num_units")
+        .withRowGroupSizeRows(rowsPerGroup)
+        .withStatisticsFrequency(ParquetWriterOptions.StatisticsFrequency.COLUMN)
+        .build();
+    try (TableWriter writer = Table.writeParquetChunked(opts, path)) {
+      for (int g = 0; g < numGroups; g++) {
+        int start = g * rowsPerGroup;
+        int zipBase = zipBases[g];
+        int[] numUnitsVals = numUnitsValues[g];
+        try (ColumnVector id = ColumnVector.fromInts(
+                 IntStream.range(start, start + rowsPerGroup).toArray());
+             ColumnVector zipCode = ColumnVector.fromInts(
+                 IntStream.range(0, rowsPerGroup).map(i -> zipBase + i).toArray());
+             ColumnVector numUnits = ColumnVector.fromInts(
+                 IntStream.range(0, rowsPerGroup)
+                     .map(i -> numUnitsVals[i % numUnitsVals.length]).toArray());
+             Table t = new Table(id, zipCode, numUnits)) {
+          writer.write(t);
+        }
+      }
+    }
+    return rows;
+  }
+
+  /** Read the entire file into a {@link HostMemoryBuffer}. */
+  private static HostMemoryBuffer readFileToHostBuffer(File file) throws IOException {
+    byte[] fileBytes = Files.readAllBytes(file.toPath());
+    HostMemoryBuffer buffer = HostMemoryBuffer.allocate(fileBytes.length);
+    buffer.setBytes(0, fileBytes, 0, fileBytes.length);
+    return buffer;
+  }
+
+  /**
+   * Extract the Parquet file footer from a host buffer.
+   * Format: {@code [footer_bytes][4-byte LE footer_length][4-byte magic "PAR1"]}.
+   */
+  private static HostMemoryBuffer extractFooter(HostMemoryBuffer fileBuffer) {
+    long fileLen = fileBuffer.getLength();
+    int footerLength = fileBuffer.getInt(fileLen - 8);
+    long footerStart = fileLen - 8 - footerLength;
+    byte[] footerBytes = new byte[footerLength];
+    fileBuffer.getBytes(footerBytes, 0, footerStart, footerLength);
+    HostMemoryBuffer footer = HostMemoryBuffer.allocate(footerLength);
+    footer.setBytes(0, footerBytes, 0, footerLength);
+    return footer;
+  }
+
+  /** Copy byte ranges from a host buffer into device buffers (one per range). */
+  private static DeviceMemoryBuffer[] copyRangesToDevice(HostMemoryBuffer fileBuffer,
+                                                         ByteRange[] ranges) {
+    DeviceMemoryBuffer[] out = new DeviceMemoryBuffer[ranges.length];
+    try {
+      for (int i = 0; i < ranges.length; i++) {
+        ByteRange r = ranges[i];
+        DeviceMemoryBuffer dev = DeviceMemoryBuffer.allocate(r.size());
+        try (HostMemoryBuffer slice = fileBuffer.slice(r.offset(), r.size())) {
+          dev.copyFromHostBuffer(slice);
+        }
+        out[i] = dev;
+      }
+      return out;
+    } catch (Throwable t) {
+      for (DeviceMemoryBuffer b : out) {
+        if (b != null) b.close();
+      }
+      throw t;
+    }
+  }
+
+  private static void closeAll(DeviceMemoryBuffer[] buffers) {
+    if (buffers == null) return;
+    for (DeviceMemoryBuffer b : buffers) {
+      if (b != null) b.close();
+    }
+  }
+
+  /** Count true entries in a boolean ColumnVector by host-side iteration. */
+  private static long countTrue(ColumnVector mask) {
+    try (HostColumnVector host = mask.copyToHost()) {
+      long count = 0;
+      for (long i = 0; i < host.getRowCount(); i++) {
+        if (host.getBoolean(i)) count++;
+      }
+      return count;
+    }
+  }
+
+  private static ParquetOptions optsForColumns(String... cols) {
+    ParquetOptions.Builder b = ParquetOptions.builder();
+    for (String c : cols) {
+      b.includeColumn(c);
+    }
+    return b.build();
+  }
+}

--- a/java/src/test/java/ai/rapids/cudf/HybridScanReaderTest.java
+++ b/java/src/test/java/ai/rapids/cudf/HybridScanReaderTest.java
@@ -243,6 +243,7 @@ public class HybridScanReaderTest extends CudfTestBase {
   @Test
   void testSecondaryFiltersByteRangesEmptyForHighCardinalityInts(@TempDir Path tmp) throws IOException {
     try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("zip_code", BinaryOperator.EQUAL, 12345)) {
+      open.withPageIndex();
       SecondaryFilterRanges sfr = open.reader.secondaryFiltersByteRanges(open.reader.allRowGroups());
       assertEquals(0, sfr.dictionaryPageRanges().length,
           "High-cardinality zip_code: ADAPTIVE policy skips dictionary emission "
@@ -333,6 +334,7 @@ public class HybridScanReaderTest extends CudfTestBase {
   @Test
   void testFilterRowGroupsWithDictionaryPagesThrowsForHighCardinality(@TempDir Path tmp) throws IOException {
     try (OpenReader open = OpenReader.pageIndex(tmp).withFilter("zip_code", BinaryOperator.EQUAL, 12345)) {
+      open.withPageIndex();
       int[] rgs = open.reader.allRowGroups();
       SecondaryFilterRanges sfr = open.reader.secondaryFiltersByteRanges(rgs);
       DeviceMemoryBuffer[] dictBufs = copyRangesToDevice(open.file, sfr.dictionaryPageRanges());

--- a/java/src/test/java/ai/rapids/cudf/HybridScanReaderTest.java
+++ b/java/src/test/java/ai/rapids/cudf/HybridScanReaderTest.java
@@ -1002,6 +1002,43 @@ public class HybridScanReaderTest extends CudfTestBase {
   }
 
   // --------------------------------------------------------------------
+  // Tests: negative read-limit rejection (parameterized)
+  // --------------------------------------------------------------------
+
+  /** Verifies every setupChunking* / constructRowGroupPasses entry point rejects a negative chunkReadLimit or passReadLimit. */
+  @ParameterizedTest(name = "{0}RejectsNegativeReadLimits")
+  @MethodSource("negativeLimitInvocations")
+  void testRejectsNegativeReadLimits(String name, Consumer<HybridScanReader> action,
+                                     @TempDir Path tmp) throws IOException {
+    try (OpenReader open = OpenReader.standard(tmp)) {
+      assertThrows(IllegalArgumentException.class, () -> action.accept(open.reader));
+    }
+  }
+
+  static Stream<Arguments> negativeLimitInvocations() {
+    // Default cases use chunk=-1, pass=0; the swapped case (chunk=0, pass=-1) confirms
+    // both arguments are validated independently.
+    return Stream.of(
+        invocation("setupChunkingForFilterColumns", r -> r.setupChunkingForFilterColumns(
+            -1L, 0L, new int[]{0}, UseDataPageMask.NO,
+            HybridScanReader.RowMaskKind.ALL_TRUE, new DeviceMemoryBuffer[0])),
+        invocation("setupChunkingForPayloadColumns", r -> {
+          try (ColumnVector mask = ColumnVector.fromBooleans(true)) {
+            r.setupChunkingForPayloadColumns(-1L, 0L, new int[]{0}, mask,
+                UseDataPageMask.NO, new DeviceMemoryBuffer[0]);
+          }
+        }),
+        invocation("setupChunkingForAllColumns", r ->
+            r.setupChunkingForAllColumns(-1L, 0L, new int[]{0}, new DeviceMemoryBuffer[0])),
+        invocation("constructRowGroupPasses", r ->
+            r.constructRowGroupPasses(new int[]{0}, -1L)),
+        invocation("setupChunkingForFilterColumnsPassLimit", r ->
+            r.setupChunkingForFilterColumns(0L, -1L, new int[]{0}, UseDataPageMask.NO,
+                HybridScanReader.RowMaskKind.ALL_TRUE, new DeviceMemoryBuffer[0]))
+    );
+  }
+
+  // --------------------------------------------------------------------
   // Tests: post-close behavior (parameterized)
   //
   // Every public method on HybridScanReader calls assertNotClosed() before reaching native
@@ -1150,10 +1187,17 @@ public class HybridScanReaderTest extends CudfTestBase {
         if (newFilter != null) newFilter.close();
         throw t;
       }
-      if (this.filter != null) this.filter.close();
-      this.reader.close();
+      // Swap fields before closing the old resources so that close() will still see and
+      // release the new ones if any of the old closes throws.
+      HybridScanReader oldReader = this.reader;
+      CompiledExpression oldFilter = this.filter;
       this.reader = newReader;
       this.filter = newFilter;
+      try {
+        if (oldFilter != null) oldFilter.close();
+      } finally {
+        oldReader.close();
+      }
       return this;
     }
 

--- a/java/src/test/java/ai/rapids/cudf/ast/ColumnNameReferenceTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ast/ColumnNameReferenceTest.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package ai.rapids.cudf.ast;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.rapids.cudf.CudfTestBase;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Unit tests for {@link ColumnNameReference}.
+ */
+public class ColumnNameReferenceTest extends CudfTestBase {
+
+  // --------------------------------------------------------------------
+  // Tests: ColumnNameReference (constructor)
+  // --------------------------------------------------------------------
+
+  /** Verifies that passing null to the constructor throws IllegalArgumentException. */
+  @Test
+  void testNullNameRejected() {
+    assertThrows(IllegalArgumentException.class, () -> new ColumnNameReference(null));
+  }
+
+  /** Verifies that passing an empty string to the constructor throws IllegalArgumentException. */
+  @Test
+  void testEmptyNameRejected() {
+    assertThrows(IllegalArgumentException.class, () -> new ColumnNameReference(""));
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: getColumnName()
+  // --------------------------------------------------------------------
+
+  /** Verifies that getColumnName() returns the name supplied to the constructor. */
+  @Test
+  void testGetColumnName() {
+    ColumnNameReference colNameRef = new ColumnNameReference("my_col");
+    assertEquals("my_col", colNameRef.getColumnName());
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: toString()
+  // --------------------------------------------------------------------
+
+  /** Verifies that toString() produces the expected COLUMN("name") representation. */
+  @Test
+  void testToString() {
+    assertEquals("COLUMN(\"zip\")", new ColumnNameReference("zip").toString());
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: getSerializedSize()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies that getSerializedSize() equals 1 (node-type byte) + 4 (name-length int) +
+   * the number of UTF-8 bytes in the name.
+   */
+  @Test
+  void testGetSerializedSizeMatchesExpectedLayout() {
+    // "zip" = 3 UTF-8 bytes → 1 + 4 + 3 = 8
+    assertEquals(8, new ColumnNameReference("zip").getSerializedSize());
+  }
+
+  // --------------------------------------------------------------------
+  // Tests: serialize()
+  // --------------------------------------------------------------------
+
+  /**
+   * Verifies that serialize() writes the COLUMN_NAME_REFERENCE node-type byte (5), the
+   * name length as a 4-byte int, and the UTF-8 name bytes, in that order.
+   */
+  @Test
+  void testSerializeWritesNodeTypeIdNameLengthAndNameBytes() {
+    ColumnNameReference colNameRef = new ColumnNameReference("zip");
+    ByteBuffer buffer = ByteBuffer.allocate(colNameRef.getSerializedSize())
+                                  .order(ByteOrder.nativeOrder());
+    colNameRef.serialize(buffer);
+    buffer.flip();
+    assertEquals(5, buffer.get());       // COLUMN_NAME_REFERENCE nativeId
+    assertEquals(3, buffer.getInt());    // "zip" is 3 UTF-8 bytes
+    byte[] nameBytes = "zip".getBytes(StandardCharsets.UTF_8);
+    for (byte b : nameBytes) {
+      assertEquals(b, buffer.get());
+    }
+  }
+}

--- a/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
@@ -600,4 +600,25 @@ public class CompiledExpressionTest extends CudfTestBase {
       Assertions.assertThrows(CudfException.class, () -> compiledExpr.computeColumn(t).close());
     }
   }
+
+  /**
+   * Verifies that computeColumn throws CudfException when the expression contains a
+   * ColumnNameReference, since plain table views carry no column-name metadata —
+   * name resolution is only supported inside HybridScanReader.
+   */
+  @Test
+  void testColumnNameReferenceThrowsOnComputeColumn() {
+    BinaryOperation op = new BinaryOperation(BinaryOperator.GREATER,
+        new ColumnNameReference("col"), Literal.ofInt(42));
+    try (Table t = new Table.TestBuilder().column(1, 2, 3).build();
+         CompiledExpression compiled = op.compile()) {
+      Assertions.assertThrows(CudfException.class, () -> compiled.computeColumn(t).close());
+    }
+  }
+
+  /** Verifies that ExpressionType.COLUMN_NAME_REFERENCE has ordinal 5, matching the native plan's expected node-type ID. */
+  @Test
+  void testColumnNameReferenceTypeOrdinalMatchesPlan() {
+    Assertions.assertEquals(5, AstExpression.ExpressionType.COLUMN_NAME_REFERENCE.ordinal());
+  }
 }


### PR DESCRIPTION
## Description
Depends on #22456. **Do not merge before #22456 lands.** Once #22456 merges, this
branch will be rebased onto the new `main` and the diff here will shrink to only
the example sources.

* Add a standalone `java/examples/hybrid_scan_io/` Maven module that
  consumes the installed `ai.rapids:cudf` jar.

* `GenerateSampleParquetFileMain` writes a 5x50,000-row fixture with
  COLUMN-level statistics. `zip_code` bases chosen so a threshold of
  145,000 exercises row-group, page, and no-prune cases together.

* `HybridScanIoExample` compares legacy `Table.readParquet`, hybrid
  `ALL_TRUE`, and hybrid `PAGE_INDEX_STATS` on the same file with
  survival counts and timing.

* `HybridScanPipelineExample` drives the chunked all-columns path
  with row-group-batch and per-chunk byte limits (`0` for unlimited).

* Add a `run_examples.sh` script that runs data-gen + IO + pipeline,
  fails fast if the parent jar is missing from `~/.m2`, auto-builds
  on first run, and cleans up the fixture via an `EXIT` trap.

Related issue: https://github.com/rapidsai/cudf/issues/22271

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
