### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Aggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/Aggregation.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -61,7 +61,8 @@ abstract class Aggregation {
         MERGE_TDIGEST(33), // This can take a delta argument for accuracy level
         HISTOGRAM(34),
         MERGE_HISTOGRAM(35),
-        BITWISE_AGG(36);
+        BITWISE_AGG(36),
+        SUM_WITH_OVERFLOW(37);
 
         final int nativeId;
 
@@ -531,6 +532,23 @@ abstract class Aggregation {
      */
     static SumAggregation sum() {
         return new SumAggregation();
+    }
+
+    static final class SumWithOverflowAggregation extends NoParamAggregation {
+        private SumWithOverflowAggregation() {
+            super(Kind.SUM_WITH_OVERFLOW);
+        }
+    }
+
+    /**
+     * Sum aggregation that also reports overflow. The result is a struct with
+     * children {sum, overflow: BOOL8}. For column reductions the input must be
+     * INT64. For hash-based groupby the input may be any signed integer type
+     * (INT8/16/32/64) or fixed-point decimal. Sort-based groupby, scan,
+     * segmented reduce, and rolling are not supported by cudf.
+     */
+    static SumWithOverflowAggregation sumWithOverflow() {
+        return new SumWithOverflowAggregation();
     }
 
     static final class ProductAggregation extends NoParamAggregation {

--- a/java/src/main/java/ai/rapids/cudf/GroupByAggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/GroupByAggregation.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -67,6 +67,19 @@ public final class GroupByAggregation {
    */
   public static GroupByAggregation sum() {
     return new GroupByAggregation(Aggregation.sum());
+  }
+
+  /**
+   * Sum aggregation that also reports per-group overflow. The result column is a
+   * STRUCT with children {sum: input-type, overflow: BOOL8}. Supported input
+   * types are signed integers (INT8/16/32/64) and fixed-point decimal
+   * (DECIMAL32/64/128). The sum-child has the same type AND scale as the input
+   * column -- e.g. a DECIMAL64 input at scale -4 produces a DECIMAL64 sum-child
+   * at scale -4; cudf does not widen or rescale. Only hash-based groupby is
+   * supported; sort-based groupby will throw.
+   */
+  public static GroupByAggregation sumWithOverflow() {
+    return new GroupByAggregation(Aggregation.sumWithOverflow());
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/ReductionAggregation.java
+++ b/java/src/main/java/ai/rapids/cudf/ReductionAggregation.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -50,6 +50,14 @@ public final class ReductionAggregation {
    */
   public static ReductionAggregation sum() {
     return new ReductionAggregation(Aggregation.sum());
+  }
+
+  /**
+   * Sum reduction that also reports int64 overflow. Result is a struct scalar
+   * with children {sum: INT64, overflow: BOOL8}. Input column must be INT64.
+   */
+  public static ReductionAggregation sumWithOverflow() {
+    return new ReductionAggregation(Aggregation.sumWithOverflow());
   }
 
   /**

--- a/java/src/main/native/src/AggregationJni.cpp
+++ b/java/src/main/native/src/AggregationJni.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -96,6 +96,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNoParamAgg(JNIEnv*
         case 35:  // MERGE_HISTOGRAM
           return cudf::make_merge_histogram_aggregation();
           // case 36: BITWISE_AGG
+        case 37:  // SUM_WITH_OVERFLOW
+          return cudf::make_sum_with_overflow_aggregation();
 
         default: throw std::logic_error("Unsupported No Parameter Aggregation Operation");
       }

--- a/java/src/test/java/ai/rapids/cudf/ReductionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ReductionTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -13,11 +13,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.math.BigInteger;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReductionTest extends CudfTestBase {
   public static final double DELTAD = 0.00001;
@@ -637,6 +641,137 @@ class ReductionTest extends CudfTestBase {
          ColumnVector cv = ColumnVector.fromBytes(new byte[]{1, 2, 3, 4});
          Scalar result = cv.standardDeviation(DType.FLOAT32)) {
       assertEquals(expected, result);
+    }
+  }
+
+  // Decoded struct scalar produced by SUM_WITH_OVERFLOW reduction.
+  // sumValid=false models the cudf "no valid input" case (null sum child).
+  private static final class SumWithOverflowResult {
+    final boolean sumValid;
+    final long sumValue;
+    final boolean overflow;
+
+    SumWithOverflowResult(boolean sumValid, long sumValue, boolean overflow) {
+      this.sumValid = sumValid;
+      this.sumValue = sumValue;
+      this.overflow = overflow;
+    }
+  }
+
+  // SUM_WITH_OVERFLOW reduction returns a struct scalar with children
+  // {sum: INT64, overflow: BOOL8}. Helper closes the temporary children views.
+  private static SumWithOverflowResult readSumWithOverflow(Scalar result) {
+    assertEquals(DType.STRUCT, result.getType());
+    assertTrue(result.isValid());
+    ColumnView[] children = result.getChildrenFromStructScalar();
+    try {
+      assertEquals(2, children.length);
+      assertEquals(DType.INT64, children[0].getType());
+      assertEquals(DType.BOOL8, children[1].getType());
+      try (ColumnVector sumCol = children[0].copyToColumnVector();
+           ColumnVector ovfCol = children[1].copyToColumnVector();
+           HostColumnVector sumHost = sumCol.copyToHost();
+           HostColumnVector ovfHost = ovfCol.copyToHost()) {
+        boolean sumValid = !sumHost.isNull(0);
+        long sumValue = sumValid ? sumHost.getLong(0) : 0L;
+        boolean overflow = ovfHost.getBoolean(0);
+        return new SumWithOverflowResult(sumValid, sumValue, overflow);
+      }
+    } finally {
+      for (ColumnView c : children) c.close();
+    }
+  }
+
+  @Test
+  void testSumWithOverflowNoOverflow() {
+    try (ColumnVector cv = ColumnVector.fromLongs(1L, 2L, 3L, 4L, 5L);
+         Scalar result = cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT)) {
+      SumWithOverflowResult r = readSumWithOverflow(result);
+      assertTrue(r.sumValid);
+      assertEquals(15L, r.sumValue);  // 1+2+3+4+5
+      assertFalse(r.overflow);
+    }
+  }
+
+  @Test
+  void testSumWithOverflowPositiveOverflow() {
+    // Long.MAX_VALUE + 1 wraps via two's complement to Long.MIN_VALUE.
+    try (ColumnVector cv = ColumnVector.fromLongs(Long.MAX_VALUE, 1L);
+         Scalar result = cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT)) {
+      SumWithOverflowResult r = readSumWithOverflow(result);
+      assertTrue(r.sumValid);
+      assertEquals(Long.MIN_VALUE, r.sumValue);
+      assertTrue(r.overflow);
+    }
+  }
+
+  @Test
+  void testSumWithOverflowNegativeOverflow() {
+    // Long.MIN_VALUE + (-1) wraps via two's complement to Long.MAX_VALUE.
+    try (ColumnVector cv = ColumnVector.fromLongs(Long.MIN_VALUE, -1L);
+         Scalar result = cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT)) {
+      SumWithOverflowResult r = readSumWithOverflow(result);
+      assertTrue(r.sumValid);
+      assertEquals(Long.MAX_VALUE, r.sumValue);
+      assertTrue(r.overflow);
+    }
+  }
+
+  @Test
+  void testSumWithOverflowEmptyColumn() {
+    try (ColumnVector cv = ColumnVector.fromLongs();
+         Scalar result = cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT)) {
+      SumWithOverflowResult r = readSumWithOverflow(result);
+      assertFalse(r.sumValid);  // empty input -> null sum
+      assertFalse(r.overflow);
+    }
+  }
+
+  @Test
+  void testSumWithOverflowAllNullColumn() {
+    try (ColumnVector cv = ColumnVector.fromBoxedLongs(null, null, null);
+         Scalar result = cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT)) {
+      SumWithOverflowResult r = readSumWithOverflow(result);
+      assertFalse(r.sumValid);  // all-null input -> null sum
+      assertFalse(r.overflow);
+    }
+  }
+
+  @Test
+  void testSumWithOverflowRejectsNonInt64() {
+    try (ColumnVector cv = ColumnVector.fromInts(1, 2, 3)) {
+      assertThrows(CudfException.class, () ->
+          cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT).close());
+    }
+  }
+
+  // The reduction path of cudf::SUM_WITH_OVERFLOW is INT64-only (see
+  // cpp/src/reductions/reductions.cpp's `requires(std::is_same_v<Source, int64_t>)`).
+  // The three tests below pin down the throw contract for fixed-point inputs;
+  // if a future cudf change broadens that requires-clause to accept decimals,
+  // these tests will start failing — the signal to expose decimal reduction.
+  @Test
+  void testSumWithOverflowReductionRejectsDecimal32() {
+    try (ColumnVector cv = ColumnVector.decimalFromInts(-2, 100, 200, 300)) {
+      assertThrows(CudfException.class, () ->
+          cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT).close());
+    }
+  }
+
+  @Test
+  void testSumWithOverflowReductionRejectsDecimal64() {
+    try (ColumnVector cv = ColumnVector.decimalFromLongs(-4, 100L, 200L, 300L)) {
+      assertThrows(CudfException.class, () ->
+          cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT).close());
+    }
+  }
+
+  @Test
+  void testSumWithOverflowReductionRejectsDecimal128() {
+    try (ColumnVector cv = ColumnVector.decimalFromBigInt(-10,
+             BigInteger.valueOf(100), BigInteger.valueOf(200), BigInteger.valueOf(300))) {
+      assertThrows(CudfException.class, () ->
+          cv.reduce(ReductionAggregation.sumWithOverflow(), DType.STRUCT).close());
     }
   }
 }

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -7828,6 +7828,233 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
+  void testGroupByHashSumWithOverflow() {
+    // int64 keys 1, 2, 3 with values that fit comfortably in int64.
+    try (Table input = new Table.TestBuilder()
+             .column(1, 2, 3, 1, 2, 2, 1, 3, 3, 2)
+             .column(10L, 20L, 30L, 11L, 21L, 22L, 12L, 31L, 32L, 23L)
+             .build();
+         Table results = input.groupBy(0).aggregate(
+             GroupByAggregation.sumWithOverflow().onColumn(1));
+         Table sorted = results.orderBy(OrderByArg.asc(0))) {
+      assertEquals(2, sorted.getNumberOfColumns());
+      assertEquals(3, sorted.getRowCount());
+
+      ColumnVector keyCol = sorted.getColumn(0);
+      ColumnVector structCol = sorted.getColumn(1);
+      assertEquals(DType.STRUCT, structCol.getType());
+
+      try (ColumnView sumChild = structCol.getChildColumnView(0);
+           ColumnView ovfChild = structCol.getChildColumnView(1);
+           ColumnVector sumCol = sumChild.copyToColumnVector();
+           ColumnVector ovfCol = ovfChild.copyToColumnVector();
+           ColumnVector expectedKeys = ColumnVector.fromInts(1, 2, 3);
+           ColumnVector expectedSum = ColumnVector.fromLongs(33L, 86L, 93L);
+           ColumnVector expectedOvf = ColumnVector.fromBooleans(false, false, false)) {
+        assertColumnsAreEqual(expectedKeys, keyCol);
+        assertColumnsAreEqual(expectedSum, sumCol);
+        assertColumnsAreEqual(expectedOvf, ovfCol);
+      }
+    }
+  }
+
+  @Test
+  void testGroupByHashSumWithOverflowDetectsOverflow() {
+    // Group 1 overflows (max + max), group 2 stays in range.
+    try (Table input = new Table.TestBuilder()
+             .column(1, 1, 2, 2)
+             .column(Long.MAX_VALUE, Long.MAX_VALUE, 3L, 4L)
+             .build();
+         Table results = input.groupBy(0).aggregate(
+             GroupByAggregation.sumWithOverflow().onColumn(1));
+         Table sorted = results.orderBy(OrderByArg.asc(0))) {
+      ColumnVector structCol = sorted.getColumn(1);
+      try (ColumnView ovfChild = structCol.getChildColumnView(1);
+           ColumnVector ovfCol = ovfChild.copyToColumnVector();
+           ColumnVector expectedOvf = ColumnVector.fromBooleans(true, false)) {
+        assertColumnsAreEqual(expectedOvf, ovfCol);
+      }
+    }
+  }
+
+  @Test
+  void testGroupByHashSumWithOverflowInt32() {
+    // Int32 input: hash groupby supports it (reduction does not).
+    try (Table input = new Table.TestBuilder()
+             .column(1, 2, 1, 2)
+             .column(1, 10, 2, 20)
+             .build();
+         Table results = input.groupBy(0).aggregate(
+             GroupByAggregation.sumWithOverflow().onColumn(1));
+         Table sorted = results.orderBy(OrderByArg.asc(0))) {
+      ColumnVector structCol = sorted.getColumn(1);
+      assertEquals(DType.STRUCT, structCol.getType());
+      try (ColumnView sumChild = structCol.getChildColumnView(0);
+           ColumnView ovfChild = structCol.getChildColumnView(1);
+           ColumnVector sumCol = sumChild.copyToColumnVector();
+           ColumnVector ovfCol = ovfChild.copyToColumnVector();
+           ColumnVector expectedSum = ColumnVector.fromInts(3, 30);
+           ColumnVector expectedOvf = ColumnVector.fromBooleans(false, false)) {
+        assertEquals(DType.INT32, sumCol.getType());
+        assertColumnsAreEqual(expectedSum, sumCol);
+        assertColumnsAreEqual(expectedOvf, ovfCol);
+      }
+    }
+  }
+
+  @Test
+  void testGroupBySortSumWithOverflowThrows() {
+    // Sort-based groupby (keysSorted=true forces the sort impl in cudf).
+    // SUM_WITH_OVERFLOW is hash-only, so cudf should throw.
+    GroupByOptions sortOpts = GroupByOptions.builder().withKeysSorted(true).build();
+    try (Table input = new Table.TestBuilder()
+             .column(1, 1, 2, 2)
+             .column(1L, 2L, 3L, 4L)
+             .build()) {
+      assertThrows(CudfException.class, () ->
+          input.groupBy(sortOpts, 0).aggregate(
+              GroupByAggregation.sumWithOverflow().onColumn(1)).close());
+    }
+  }
+
+  // For SUM_WITH_OVERFLOW on fixed-point inputs, cudf's hash groupby produces a
+  // STRUCT whose sum-child has the same decimal type AND scale as the input
+  // (target_type_impl<fixed_point, SUM_WITH_OVERFLOW> uses Source as the sum
+  // type at cpp/include/cudf/detail/aggregation/aggregation.hpp). The three
+  // tests below assert both the values and that scale is preserved end-to-end
+  // through the JNI struct-column extraction path.
+  @Test
+  void testGroupByHashSumWithOverflowDecimal32() {
+    final int scale = -2;
+    try (Table input = new Table.TestBuilder()
+             .column(1, 2, 1, 2, 1)
+             .decimal32Column(scale, 100, 200, 150, 250, 50)  // 1.00, 2.00, 1.50, 2.50, 0.50
+             .build();
+         Table results = input.groupBy(0).aggregate(
+             GroupByAggregation.sumWithOverflow().onColumn(1));
+         Table sorted = results.orderBy(OrderByArg.asc(0))) {
+      ColumnVector keyCol = sorted.getColumn(0);
+      ColumnVector structCol = sorted.getColumn(1);
+      assertEquals(DType.STRUCT, structCol.getType());
+
+      try (ColumnView sumChild = structCol.getChildColumnView(0);
+           ColumnView ovfChild = structCol.getChildColumnView(1);
+           ColumnVector sumCol = sumChild.copyToColumnVector();
+           ColumnVector ovfCol = ovfChild.copyToColumnVector();
+           ColumnVector expectedKeys = ColumnVector.fromInts(1, 2);
+           ColumnVector expectedSum = ColumnVector.decimalFromInts(scale, 300, 450);
+           ColumnVector expectedOvf = ColumnVector.fromBooleans(false, false)) {
+        assertEquals(DType.DTypeEnum.DECIMAL32, sumCol.getType().getTypeId());
+        assertEquals(scale, sumCol.getType().getScale());
+        assertColumnsAreEqual(expectedKeys, keyCol);
+        assertColumnsAreEqual(expectedSum, sumCol);
+        assertColumnsAreEqual(expectedOvf, ovfCol);
+      }
+    }
+  }
+
+  @Test
+  void testGroupByHashSumWithOverflowDecimal64() {
+    final int scale = -4;
+    try (Table input = new Table.TestBuilder()
+             .column(1, 2, 1, 2)
+             .decimal64Column(scale, 10000L, 20000L, 30000L, 40000L)  // 1.0000, 2.0000, ...
+             .build();
+         Table results = input.groupBy(0).aggregate(
+             GroupByAggregation.sumWithOverflow().onColumn(1));
+         Table sorted = results.orderBy(OrderByArg.asc(0))) {
+      ColumnVector structCol = sorted.getColumn(1);
+      assertEquals(DType.STRUCT, structCol.getType());
+
+      try (ColumnView sumChild = structCol.getChildColumnView(0);
+           ColumnView ovfChild = structCol.getChildColumnView(1);
+           ColumnVector sumCol = sumChild.copyToColumnVector();
+           ColumnVector ovfCol = ovfChild.copyToColumnVector();
+           ColumnVector expectedSum = ColumnVector.decimalFromLongs(scale, 40000L, 60000L);
+           ColumnVector expectedOvf = ColumnVector.fromBooleans(false, false)) {
+        assertEquals(DType.DTypeEnum.DECIMAL64, sumCol.getType().getTypeId());
+        assertEquals(scale, sumCol.getType().getScale());
+        assertColumnsAreEqual(expectedSum, sumCol);
+        assertColumnsAreEqual(expectedOvf, ovfCol);
+      }
+    }
+  }
+
+  @Test
+  void testGroupByHashSumWithOverflowDecimal128() {
+    final int scale = -10;
+    BigInteger v1 = BigInteger.valueOf(123456789L).multiply(BigInteger.TEN.pow(10));
+    BigInteger v2 = BigInteger.valueOf(987654321L).multiply(BigInteger.TEN.pow(10));
+    BigInteger v3 = BigInteger.valueOf(111111111L).multiply(BigInteger.TEN.pow(10));
+    BigInteger v4 = BigInteger.valueOf(222222222L).multiply(BigInteger.TEN.pow(10));
+    try (Table input = new Table.TestBuilder()
+             .column(1, 2, 1, 2)
+             .decimal128Column(scale, RoundingMode.UNNECESSARY, v1, v2, v3, v4)
+             .build();
+         Table results = input.groupBy(0).aggregate(
+             GroupByAggregation.sumWithOverflow().onColumn(1));
+         Table sorted = results.orderBy(OrderByArg.asc(0))) {
+      ColumnVector structCol = sorted.getColumn(1);
+      assertEquals(DType.STRUCT, structCol.getType());
+
+      try (ColumnView sumChild = structCol.getChildColumnView(0);
+           ColumnView ovfChild = structCol.getChildColumnView(1);
+           ColumnVector sumCol = sumChild.copyToColumnVector();
+           ColumnVector ovfCol = ovfChild.copyToColumnVector();
+           ColumnVector expectedSum = ColumnVector.decimalFromBigInt(scale,
+               v1.add(v3), v2.add(v4));
+           ColumnVector expectedOvf = ColumnVector.fromBooleans(false, false)) {
+        assertEquals(DType.DTypeEnum.DECIMAL128, sumCol.getType().getTypeId());
+        assertEquals(scale, sumCol.getType().getScale());
+        assertColumnsAreEqual(expectedSum, sumCol);
+        assertColumnsAreEqual(expectedOvf, ovfCol);
+      }
+    }
+  }
+
+  @Test
+  void testGroupByHashSumWithOverflowDecimal128DetectsOverflow() {
+    // Pick a value with at most 38 significant digits (the MathContext cap in
+    // Table.TestBuilder.decimal128Column) that still overflows int128_max when
+    // summed with itself. 10^38 - 1 is 38 nines; 2 * (10^38 - 1) ~= 2e38 which
+    // exceeds int128_max ~= 1.7e38, so cudf's kernel flags overflow.
+    final int scale = 0;
+    BigInteger nearMax = BigInteger.TEN.pow(38).subtract(BigInteger.ONE);
+    // Expected wrapped sum for group 1: two's-complement wrap of 2*nearMax in
+    // int128. 2*nearMax > int128_max, so the signed result is 2*nearMax - 2^128.
+    BigInteger two = BigInteger.valueOf(2);
+    BigInteger group1Wrapped = nearMax.multiply(two).subtract(two.pow(128));
+    BigInteger group2Sum = BigInteger.valueOf(7);  // 3 + 4
+    try (Table input = new Table.TestBuilder()
+             .column(1, 1, 2, 2)
+             .decimal128Column(scale, RoundingMode.UNNECESSARY,
+                 nearMax, nearMax, BigInteger.valueOf(3), BigInteger.valueOf(4))
+             .build();
+         Table results = input.groupBy(0).aggregate(
+             GroupByAggregation.sumWithOverflow().onColumn(1));
+         Table sorted = results.orderBy(OrderByArg.asc(0))) {
+      ColumnVector structCol = sorted.getColumn(1);
+      assertEquals(DType.STRUCT, structCol.getType());
+
+      try (ColumnView sumChild = structCol.getChildColumnView(0);
+           ColumnView ovfChild = structCol.getChildColumnView(1);
+           ColumnVector sumCol = sumChild.copyToColumnVector();
+           ColumnVector ovfCol = ovfChild.copyToColumnVector();
+           // expectedSum uses decimalFromBigInt because the wrapped group-1
+           // value has 39 significant digits and would not survive the
+           // MathContext(38) inside Table.TestBuilder.decimal128Column.
+           ColumnVector expectedSum = ColumnVector.decimalFromBigInt(scale,
+               group1Wrapped, group2Sum);
+           ColumnVector expectedOvf = ColumnVector.fromBooleans(true, false)) {
+        assertEquals(DType.DTypeEnum.DECIMAL128, sumCol.getType().getTypeId());
+        assertEquals(scale, sumCol.getType().getScale());
+        assertColumnsAreEqual(expectedSum, sumCol);
+        assertColumnsAreEqual(expectedOvf, ovfCol);
+      }
+    }
+  }
+
+  @Test
   void testGroupByMergeM2() {
     StructType nestedType = new StructType(false,
         new BasicType(true, DType.INT64),


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.