### PR TITLE
Add `pinned_max_pool_size` and `unbounded_file_read_cache` to `StreamingOptions`

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -194,6 +194,11 @@ class StreamingOptions:
         Env: ``RAPIDSMPF_PINNED_INITIAL_POOL_SIZE``.
         Default: ``0``.
         Category: rapidsmpf.
+    pinned_max_pool_size
+        Maximum pinned host memory pool size (e.g. ``"4GiB"``, ``"50%"``).
+        Env: ``RAPIDSMPF_PINNED_MAX_POOL_SIZE``.
+        Default: 80% of per-GPU host memory.
+        Category: rapidsmpf.
     spill_device_limit
         Device memory soft limit before spilling (e.g. ``"80%"`` or bytes).
         Env: ``RAPIDSMPF_SPILL_DEVICE_LIMIT``.
@@ -203,6 +208,14 @@ class StreamingOptions:
         Interval between spill checks (e.g. ``"1ms"``).
         Env: ``RAPIDSMPF_PERIODIC_SPILL_CHECK``.
         Default: ``"1ms"``.
+        Category: rapidsmpf.
+    unbounded_file_read_cache
+        Cache file-read results in the Context's message storage.
+        Accepts a memory type (``"host"``, ``"pinned"``, ``"device"``) or
+        ``"disabled"``. Primarily for benchmarking. Each file slice must be
+        read with identical parameters (see rapidsmpf docs).
+        Env: ``RAPIDSMPF_UNBOUNDED_FILE_READ_CACHE``.
+        Default: ``"disabled"``.
         Category: rapidsmpf.
     num_py_executors
         Workers for the internal Python ``ThreadPoolExecutor``.
@@ -303,11 +316,17 @@ class StreamingOptions:
     pinned_initial_pool_size: int | Unspecified = _opt(
         "rapidsmpf", "RAPIDSMPF_PINNED_INITIAL_POOL_SIZE", int
     )
+    pinned_max_pool_size: str | Unspecified = _opt(
+        "rapidsmpf", "RAPIDSMPF_PINNED_MAX_POOL_SIZE"
+    )
     spill_device_limit: str | Unspecified = _opt(
         "rapidsmpf", "RAPIDSMPF_SPILL_DEVICE_LIMIT"
     )
     periodic_spill_check: str | Unspecified = _opt(
         "rapidsmpf", "RAPIDSMPF_PERIODIC_SPILL_CHECK"
+    )
+    unbounded_file_read_cache: str | Unspecified = _opt(
+        "rapidsmpf", "RAPIDSMPF_UNBOUNDED_FILE_READ_CACHE"
     )
     # ---- Executor ----
     num_py_executors: int | Unspecified = _opt(
@@ -523,8 +542,10 @@ class StreamingOptions:
             allow_overbooking_by_default=_get("allow_overbooking_by_default"),
             pinned_memory=_get("pinned_memory"),
             pinned_initial_pool_size=_get("pinned_initial_pool_size"),
+            pinned_max_pool_size=_get("pinned_max_pool_size"),
             spill_device_limit=_get("spill_device_limit"),
             periodic_spill_check=_get("periodic_spill_check"),
+            unbounded_file_read_cache=_get("unbounded_file_read_cache"),
             hardware_binding=_get("hardware_binding"),
             num_py_executors=_get("num_py_executors"),
             fallback_mode=_get("fallback_mode"),
@@ -632,6 +653,17 @@ class StreamingOptions:
                 Env: RAPIDSMPF_PINNED_INITIAL_POOL_SIZE. Built-in default: 0."""),
         )
         g.add_argument(
+            "--pinned-max-pool-size",
+            dest="pinned_max_pool_size",
+            default=None,
+            type=str,
+            help=textwrap.dedent("""\
+                Maximum size of the pinned memory pool. Accepts byte counts
+                (e.g. "4GiB") or a percentage (e.g. "80%%").
+                Env: RAPIDSMPF_PINNED_MAX_POOL_SIZE.
+                Built-in default: 80%% of per-GPU host memory."""),
+        )
+        g.add_argument(
             "--spill-device-limit",
             dest="spill_device_limit",
             default=None,
@@ -649,6 +681,16 @@ class StreamingOptions:
             help=textwrap.dedent("""\
                 Interval between periodic spill checks (e.g. "1ms").
                 Env: RAPIDSMPF_PERIODIC_SPILL_CHECK. Built-in default: 1ms."""),
+        )
+        g.add_argument(
+            "--unbounded-file-read-cache",
+            dest="unbounded_file_read_cache",
+            default=None,
+            type=str,
+            help=textwrap.dedent("""\
+                Cache file-read results in the Context's message storage.
+                One of "host", "pinned", "device", or "disabled".
+                Env: RAPIDSMPF_UNBOUNDED_FILE_READ_CACHE. Built-in default: disabled."""),
         )
         g.add_argument(
             "--hardware-binding",

--- a/python/cudf_polars/tests/experimental/test_options.py
+++ b/python/cudf_polars/tests/experimental/test_options.py
@@ -106,13 +106,20 @@ def test_engine_options_includes_set_fields() -> None:
 
 def test_rapidsmpf_options_serialized() -> None:
     opts = StreamingOptions(
-        statistics=True, pinned_memory=False, num_streaming_threads=8, log="DEBUG"
+        statistics=True,
+        pinned_memory=False,
+        num_streaming_threads=8,
+        log="DEBUG",
+        pinned_max_pool_size="4GiB",
+        unbounded_file_read_cache="host",
     )
     strings = opts.to_rapidsmpf_options().get_strings()
     assert strings["statistics"] == "True"
     assert strings["pinned_memory"] == "False"
     assert strings["num_streaming_threads"] == "8"
     assert strings["log"] == "DEBUG"
+    assert strings["pinned_max_pool_size"] == "4GiB"
+    assert strings["unbounded_file_read_cache"] == "host"
 
 
 def test_rapidsmpf_options_unspecified_fields_absent() -> None:
@@ -141,6 +148,18 @@ def test_rapidsmpf_options_explicit_overrides_env_var(
 def test_rapidsmpf_options_env_var_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("RAPIDSMPF_LOG", raising=False)
     assert "log" not in StreamingOptions().to_rapidsmpf_options().get_strings()
+
+
+def test_pinned_max_pool_size_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPIDSMPF_PINNED_MAX_POOL_SIZE", "4GiB")
+    strings = StreamingOptions().to_rapidsmpf_options().get_strings()
+    assert strings["pinned_max_pool_size"] == "4GiB"
+
+
+def test_unbounded_file_read_cache_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPIDSMPF_UNBOUNDED_FILE_READ_CACHE", "host")
+    strings = StreamingOptions().to_rapidsmpf_options().get_strings()
+    assert strings["unbounded_file_read_cache"] == "host"
 
 
 # ---------------------------------------------------------------------------
@@ -291,12 +310,24 @@ def test_add_cli_args_then_from_argparse_roundtrip() -> None:
     parser = argparse.ArgumentParser()
     StreamingOptions._add_cli_args(parser)
     args = parser.parse_args(
-        ["--num-streaming-threads", "8", "--rapidsmpf-log", "DEBUG", "--raise-on-fail"]
+        [
+            "--num-streaming-threads",
+            "8",
+            "--rapidsmpf-log",
+            "DEBUG",
+            "--raise-on-fail",
+            "--pinned-max-pool-size",
+            "4GiB",
+            "--unbounded-file-read-cache",
+            "host",
+        ]
     )
     opts = StreamingOptions._from_argparse(args)
     assert opts.num_streaming_threads == 8
     assert opts.log == "DEBUG"
     assert opts.raise_on_fail is True
+    assert opts.pinned_max_pool_size == "4GiB"
+    assert opts.unbounded_file_read_cache == "host"
     # Unprovided args default to None → UNSPECIFIED
     assert isinstance(opts.fallback_mode, Unspecified)
 


### PR DESCRIPTION
## Description
- Expose two RapidsMPF options:
  - `pinned_max_pool_size` (`RAPIDSMPF_PINNED_MAX_POOL_SIZE`)
  - `unbounded_file_read_cache` (`RAPIDSMPF_UNBOUNDED_FILE_READ_CACHE`)
