### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING
 from rapidsmpf.shuffler import PartitionAssignment
 from rapidsmpf.streaming.core.actor import define_actor
 from rapidsmpf.streaming.core.message import Message
-from rapidsmpf.streaming.cudf.channel_metadata import ChannelMetadata, Partitioning
+from rapidsmpf.streaming.cudf.channel_metadata import (
+    ChannelMetadata,
+    OrderKey,
+    OrderScheme,
+    Partitioning,
+)
 from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
 import polars as pl
@@ -30,8 +35,10 @@ from cudf_polars.experimental.rapidsmpf.nodes import (
 )
 from cudf_polars.experimental.rapidsmpf.utils import (
     ChannelManager,
+    NormalizedPartitioning,
     allgather_reduce,
     chunk_to_frame,
+    chunkwise_evaluate,
     concat_batch,
     empty_table_chunk,
     evaluate_batch,
@@ -471,6 +478,78 @@ async def _extract_partitions_and_send(
     await ch_out.drain(context)
 
 
+def _sort_to_order_keys(ir: Sort) -> list[OrderKey]:
+    """Convert Sort IR to list of OrderKeys."""
+    return [
+        OrderKey(index, order, null_order)
+        for index, order, null_order in zip(
+            names_to_indices(ir.by, ir.schema),
+            ir.order,
+            ir.null_order,
+            strict=False,
+        )
+    ]
+
+
+def _is_already_sorted(
+    metadata_in: ChannelMetadata,
+    order_keys: list[OrderKey],
+    nranks: int,
+) -> bool:
+    """Check if the input data is already sorted according to the order keys."""
+    np = NormalizedPartitioning.from_keys(
+        metadata_in.partitioning, nranks, keys=order_keys
+    )
+    if not np:
+        # np is falsy if `order_keys` does not match
+        # any prefix of keys in `metadata_in.partitioning`.
+        # If `order_keys` is Sequence[OrderKey], the order
+        # and null_order attributes must also match.
+        return False
+    scheme = np.inter_rank_scheme
+    if not isinstance(scheme, OrderScheme):
+        return False
+    elif len(scheme.keys) < len(order_keys):
+        # If we are only sorted on a subset of the keys,
+        # we need to check if the boundaries are strict.
+        return scheme.strict_boundaries
+    return True
+
+
+def _build_order_scheme(
+    context: Context,
+    order_keys: list[OrderKey],
+    sort_boundaries_df: DataFrame,
+) -> OrderScheme:
+    """Build output OrderScheme metadata."""
+    n_keys = len(order_keys)
+    stream = sort_boundaries_df.stream
+    # sort_boundaries_df will contain a tie-breaker column
+    by_table = plc.Table(sort_boundaries_df.table.columns()[:n_keys])
+    n_rows = by_table.num_rows()
+
+    strict_boundaries = (
+        n_rows == 0
+        # TODO: Use unique_count_table
+        # Requires https://github.com/rapidsai/cudf/pull/22487
+        or plc.stream_compaction.unique(
+            by_table,
+            list(range(n_keys)),
+            plc.stream_compaction.DuplicateKeepOption.KEEP_FIRST,
+            plc.types.NullEquality.EQUAL,
+            stream=stream,
+        ).num_rows()
+        == n_rows
+    )
+
+    boundaries_chunk = TableChunk.from_pylibcudf_table(
+        by_table, stream, exclusive_view=False, br=context.br()
+    )
+    return OrderScheme(
+        order_keys, boundaries_chunk, strict_boundaries=strict_boundaries
+    )
+
+
 async def _global_sort(
     context: Context,
     comm: Communicator,
@@ -487,10 +566,12 @@ async def _global_sort(
     tracer: ActorTracer | None,
 ) -> None:
     """Global sort."""
-    # TODO: Attach OrderScheme metadata here.
     output_metadata = ChannelMetadata(
         local_count=max(1, num_partitions // comm.nranks),
-        partitioning=Partitioning(inter_rank=None, local="inherit"),
+        partitioning=Partitioning(
+            _build_order_scheme(context, _sort_to_order_keys(ir), sort_boundaries_df),
+            "inherit",
+        ),
     )
     await send_metadata(ch_out, context, output_metadata)
 
@@ -559,6 +640,20 @@ async def sort_actor(
                 metadata_in,
                 collective_ids,
                 tracer,
+            )
+            return
+
+        if _is_already_sorted(metadata_in, _sort_to_order_keys(ir), comm.nranks):
+            if tracer is not None:
+                tracer.decision = "already_sorted"
+            await chunkwise_evaluate(
+                context,
+                ir,
+                ir_context,
+                ch_out,
+                ch_in,
+                metadata_in,
+                tracer=tracer,
             )
             return
 

--- a/python/cudf_polars/tests/experimental/test_metadata.py
+++ b/python/cudf_polars/tests/experimental/test_metadata.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import pytest
 from rapidsmpf.streaming.cudf.channel_metadata import (
+    ChannelMetadata,
     HashScheme,
     OrderKey,
     OrderScheme,
@@ -21,7 +22,11 @@ import pylibcudf as plc
 from cudf_polars import Translator
 from cudf_polars.containers import DataFrame, DataType
 from cudf_polars.dsl import expr
-from cudf_polars.dsl.ir import GroupBy, HStack, Projection, Select
+from cudf_polars.dsl.ir import GroupBy, HStack, Projection, Select, Sort
+from cudf_polars.experimental.rapidsmpf.collectives.sort import (
+    _is_already_sorted,
+    _sort_to_order_keys,
+)
 from cudf_polars.experimental.rapidsmpf.core import evaluate_logical_plan
 from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.rapidsmpf.utils import (
@@ -603,3 +608,91 @@ def test_remap_partitioning_order_scheme_drops_key(spmd_engine):
     result = maybe_remap_partitioning(_make_select_ir(engine, ("b",)), part)
     assert result is not None
     assert result.inter_rank is None
+
+
+@pytest.mark.parametrize(
+    "by,descending,nulls_last",
+    [
+        (["x"], [False], [True]),
+        (["x"], [True], [False]),
+        (["x", "y"], [False, False], [True, True]),
+    ],
+)
+def test_sort_output_metadata(spmd_engine_factory, by, descending, nulls_last) -> None:
+    engine = spmd_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=3,
+            dynamic_planning=None,
+            fallback_mode="raise",
+            raise_on_fail=True,
+        )
+    )
+    config_options = ConfigOptions.from_polars_engine(engine)
+    df = pl.LazyFrame({"x": list(range(10)), "y": [i * 2 for i in range(10)]})
+    q = df.sort(by=by, descending=descending, nulls_last=nulls_last)
+    ir = Translator(q._ldf.visit(), engine).translate_ir()
+
+    metadata_collector = evaluate_logical_plan(
+        ir, config_options, collect_metadata=True
+    )[1]
+    assert metadata_collector is not None
+    assert len(metadata_collector) == 1
+    metadata = metadata_collector[0]
+
+    scheme = metadata.partitioning.inter_rank
+    assert isinstance(scheme, OrderScheme)
+    assert metadata.partitioning.local == "inherit"
+
+    output_cols = list(ir.schema.keys())
+    assert len(scheme.keys) == len(by)
+    for i, col in enumerate(by):
+        assert scheme.keys[i].column_index == output_cols.index(col)
+    assert scheme.strict_boundaries is True
+
+
+@pytest.mark.parametrize(
+    "scheme_key_count,strict,expected",
+    [
+        (1, True, True),  # prefix match + strict → skip
+        (1, False, False),  # prefix match + non-strict → no skip
+        (2, True, True),  # exact match + strict → skip
+        (2, False, True),  # exact match + non-strict → skip (strict irrelevant)
+    ],
+)
+def test_is_already_sorted(spmd_engine, scheme_key_count, strict, expected) -> None:
+    df_lf = pl.LazyFrame({"x": list(range(5)), "y": list(range(5))})
+    base_ir = Translator(df_lf._ldf.visit(), spmd_engine).translate_ir()
+    asc, before = plc.types.Order.ASCENDING, plc.types.NullOrder.BEFORE
+
+    sort_xy = Sort(
+        base_ir.schema,
+        (
+            expr.NamedExpr("x", expr.Col(base_ir.schema["x"], "x")),
+            expr.NamedExpr("y", expr.Col(base_ir.schema["y"], "y")),
+        ),
+        (asc, asc),
+        (before, before),
+        stable=False,
+        zlice=None,
+        df=base_ir,
+    )
+
+    ctx = spmd_engine.context
+    stream = ctx.get_stream_from_pool()
+    keys = [OrderKey(i, asc, before) for i in range(scheme_key_count)]
+    boundary_chunk = TableChunk.from_pylibcudf_table(
+        DataFrame.from_polars(
+            pl.DataFrame({f"k{i}": [100, 200] for i in range(scheme_key_count)}),
+            stream,
+        ).table,
+        stream,
+        exclusive_view=False,
+        br=ctx.br(),
+    )
+    scheme = OrderScheme(keys, boundary_chunk, strict_boundaries=strict)
+    meta = ChannelMetadata(
+        3, partitioning=Partitioning(inter_rank=scheme, local="inherit")
+    )
+
+    order_keys = _sort_to_order_keys(sort_xy)
+    assert _is_already_sorted(meta, order_keys, nranks=1) is expected


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.