### PR TITLE
Follow-up to recent cucascade fixes

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -18,6 +18,7 @@ dependencies:
 - cramjam
 - cuda-cudart-dev
 - cuda-nvcc
+- cuda-nvml-dev
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-python>=12.9.2,<13.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -18,6 +18,7 @@ dependencies:
 - cramjam
 - cuda-cudart-dev
 - cuda-nvcc
+- cuda-nvml-dev
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-python>=12.9.2,<13.0

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -18,6 +18,7 @@ dependencies:
 - cramjam
 - cuda-cudart-dev
 - cuda-nvcc
+- cuda-nvml-dev
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-python>=13.0.1,<14.0

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -18,6 +18,7 @@ dependencies:
 - cramjam
 - cuda-cudart-dev
 - cuda-nvcc
+- cuda-nvml-dev
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-python>=13.0.1,<14.0

--- a/cpp/cmake/Modules/FindCUDAToolkit.cmake
+++ b/cpp/cmake/Modules/FindCUDAToolkit.cmake
@@ -1025,7 +1025,9 @@ else()
     endif()
   elseif(CUDAToolkit_NVCC_EXECUTABLE)
     # Compute the version by invoking nvcc
-    execute_process(COMMAND ${CUDAToolkit_NVCC_EXECUTABLE} "--version" OUTPUT_VARIABLE NVCC_OUT)
+    execute_process(COMMAND ${CUDAToolkit_NVCC_EXECUTABLE} "--version"
+      OUTPUT_VARIABLE NVCC_OUT
+      RESULT_VARIABLE _nvcc_version_result)
     if(NVCC_OUT MATCHES [=[ V([0-9]+)\.([0-9]+)\.([0-9]+)]=])
       set(CUDAToolkit_VERSION_MAJOR "${CMAKE_MATCH_1}")
       set(CUDAToolkit_VERSION_MINOR "${CMAKE_MATCH_2}")
@@ -1487,7 +1489,12 @@ if(CUDAToolkit_FOUND)
   endif()
 
   _CUDAToolkit_find_and_add_import_lib(nvml ALT nvidia-ml nvml)
-  _CUDAToolkit_find_and_add_import_lib(nvml_static ONLY_SEARCH_FOR libnvidia-ml.a libnvml.a)
+  if(NOT TARGET CUDA::nvml_static)
+    _CUDAToolkit_find_and_add_import_lib(nvml_static ONLY_SEARCH_FOR libnvidia-ml.a libnvml.a)
+    if(TARGET CUDA::nvml_static)
+      target_link_libraries(CUDA::nvml_static INTERFACE ${CMAKE_DL_LIBS})
+    endif()
+  endif()
 
   if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 10.0)
     # Header-only variant. Uses dlopen().
@@ -1539,22 +1546,24 @@ if(CUDAToolkit_FOUND)
     set_property(TARGET CUDA::bin2c PROPERTY IMPORTED_LOCATION "${CUDA_bin2c_EXECUTABLE}")
   endif()
 
-  _CUDAToolkit_find_and_add_import_lib(
-    sanitizer
-    ONLY_SEARCH_FOR sanitizer-public
-    EXTRA_PATH_SUFFIXES
-      "../compute-sanitizer"
-      "../../../compute-sanitizer"
-      "../Sanitizer"
-      "../../../Sanitizer"
-      "../extras/Sanitizer"
-      "../../../extras/Sanitizer"
-    EXTRA_INCLUDE_DIRS "${CUDAToolkit_CUPTI_INCLUDE_DIR}"
-  )
-  if(TARGET CUDA::sanitizer)
-    get_property(loc TARGET CUDA::sanitizer PROPERTY IMPORTED_LOCATION)
-    get_filename_component(sanitizer_dir "${loc}" DIRECTORY)
-    target_include_directories(CUDA::sanitizer INTERFACE "${sanitizer_dir}/include")
+  if(NOT TARGET CUDA::sanitizer)
+    _CUDAToolkit_find_and_add_import_lib(
+      sanitizer
+      ONLY_SEARCH_FOR sanitizer-public
+      EXTRA_PATH_SUFFIXES
+        "../compute-sanitizer"
+        "../../../compute-sanitizer"
+        "../Sanitizer"
+        "../../../Sanitizer"
+        "../extras/Sanitizer"
+        "../../../extras/Sanitizer"
+      EXTRA_INCLUDE_DIRS "${CUDAToolkit_CUPTI_INCLUDE_DIR}"
+    )
+    if(TARGET CUDA::sanitizer)
+      get_property(loc TARGET CUDA::sanitizer PROPERTY IMPORTED_LOCATION)
+      get_filename_component(sanitizer_dir "${loc}" DIRECTORY)
+      target_include_directories(CUDA::sanitizer INTERFACE "${sanitizer_dir}/include")
+    endif()
   endif()
 endif()
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -667,6 +667,7 @@ dependencies:
       - output_types: [conda]
         packages:
           - cuda-cudart-dev
+          - cuda-nvml-dev
           - cuda-nvrtc-dev
           - cuda-nvtx-dev
           - cuda-sanitizer-api


### PR DESCRIPTION
## Description
- Vendor `FindCUDAToolkit` as of af0828cbbff5d9b111b7209b46242b9c9ba7865c
- Require `cuda-nvml-dev` when building devcontainers

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
