### PR TITLE
Temporarily disable cudf-polars

### DIFF
--- a/ci/build_python_noarch.sh
+++ b/ci/build_python_noarch.sh
@@ -35,12 +35,13 @@ rapids-telemetry-record build-dask-cudf.log \
                     "${RATTLER_ARGS[@]}" \
                     "${RATTLER_CHANNELS[@]}"
 
-rapids-logger "Building cudf-polars"
+# Temporarily disable cudf-polars while we break a dependency cycle
+# rapids-logger "Building cudf-polars"
 
-rapids-telemetry-record build-cudf-polars.log \
-    rattler-build build --recipe conda/recipes/cudf-polars \
-                    "${RATTLER_ARGS[@]}" \
-                    "${RATTLER_CHANNELS[@]}"
+# rapids-telemetry-record build-cudf-polars.log \
+#     rattler-build build --recipe conda/recipes/cudf-polars \
+#                     "${RATTLER_ARGS[@]}" \
+#                     "${RATTLER_CHANNELS[@]}"
 
 rapids-logger "Building custreamz"
 


### PR DESCRIPTION
## Description
We have to disable this to break a dependency cycle between cudf and rapidsmpf.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
