### PR TITLE
Revert "Temporarily WAR rapidsmpf<->libcudf conda package build cycle (#22520)"

### DIFF
--- a/conda/recipes/cudf-polars/recipe.yaml
+++ b/conda/recipes/cudf-polars/recipe.yaml
@@ -49,16 +49,16 @@ requirements:
     by_name:
       - cuda-version
 
-# tests:
-#   - python:
-#       imports:
-#         - cudf_polars
-#       pip_check: false
-#   - script:
-#       - python -c "import cudf_polars; print(cudf_polars.__version__)"
-#       - RAPIDS_NO_INITIALIZE=1 python -c "import cudf_polars; print(cudf_polars.__version__)"
-#       - CUDF_NO_INITIALIZE=1 python -c "import cudf_polars; print(cudf_polars.__version__)"
-#       - RAPIDS_NO_INITIALIZE=1 python -c "import cudf_polars; import polars as pl; print(pl.Series([1, 2, 3]))"
+tests:
+  - python:
+      imports:
+        - cudf_polars
+      pip_check: false
+  - script:
+      - python -c "import cudf_polars; print(cudf_polars.__version__)"
+      - RAPIDS_NO_INITIALIZE=1 python -c "import cudf_polars; print(cudf_polars.__version__)"
+      - CUDF_NO_INITIALIZE=1 python -c "import cudf_polars; print(cudf_polars.__version__)"
+      - RAPIDS_NO_INITIALIZE=1 python -c "import cudf_polars; import polars as pl; print(pl.Series([1, 2, 3]))"
 
 about:
   homepage: ${{ load_from_file("python/cudf_polars/pyproject.toml").project.urls.Homepage }}


### PR DESCRIPTION
Reverts #22520 which temporarily disabled the import smoketest for the `cudf-polars` package so we could get around the circular dependency with `rapidsmpf`.  Leaving this as a draft for now -- can be merged in after there are `rapidsmpf` conda packages for 26.08