### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/conda/recipes/cudf-polars/recipe.yaml
+++ b/conda/recipes/cudf-polars/recipe.yaml
@@ -49,16 +49,16 @@ requirements:
     by_name:
       - cuda-version
 
-tests:
-  - python:
-      imports:
-        - cudf_polars
-      pip_check: false
-  - script:
-      - python -c "import cudf_polars; print(cudf_polars.__version__)"
-      - RAPIDS_NO_INITIALIZE=1 python -c "import cudf_polars; print(cudf_polars.__version__)"
-      - CUDF_NO_INITIALIZE=1 python -c "import cudf_polars; print(cudf_polars.__version__)"
-      - RAPIDS_NO_INITIALIZE=1 python -c "import cudf_polars; import polars as pl; print(pl.Series([1, 2, 3]))"
+# tests:
+#   - python:
+#       imports:
+#         - cudf_polars
+#       pip_check: false
+#   - script:
+#       - python -c "import cudf_polars; print(cudf_polars.__version__)"
+#       - RAPIDS_NO_INITIALIZE=1 python -c "import cudf_polars; print(cudf_polars.__version__)"
+#       - CUDF_NO_INITIALIZE=1 python -c "import cudf_polars; print(cudf_polars.__version__)"
+#       - RAPIDS_NO_INITIALIZE=1 python -c "import cudf_polars; import polars as pl; print(pl.Series([1, 2, 3]))"
 
 about:
   homepage: ${{ load_from_file("python/cudf_polars/pyproject.toml").project.urls.Homepage }}


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.