### PR TITLE
Revert `FD_GROUPBY_REWRITE` in TPC-DS benchmark queries

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q11.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q11.py
@@ -117,24 +117,31 @@ def duckdb_impl(run_config: RunConfig) -> str:
     """
 
 
+CUSTOMER_COMPOSITE = [
+    "c_customer_id",
+    "c_first_name",
+    "c_last_name",
+    "c_preferred_cust_flag",
+    "c_birth_country",
+    "c_login",
+    "c_email_address",
+]
+
+
 def build_year_total(
     sales_table: pl.LazyFrame,
+    customer_table: pl.LazyFrame,
     customer_sk_col: str,
     date_sk_col: str,
     list_price_col: str,
     discount_col: str,
     year_dates: pl.LazyFrame,
 ) -> pl.LazyFrame:
-    """
-    Aggregate sales per customer_sk for a single year.
-
-    Groups by c_customer_sk only (not the wide customer display columns)
-    to reduce intermediate cardinality. Customer display columns are
-    joined once at the end where needed.
-    """
+    """Aggregate sales joined with customer for a single year, keyed on customer composite."""
     return (
         sales_table.join(year_dates, left_on=date_sk_col, right_on="d_date_sk")
-        .group_by(customer_sk_col)
+        .join(customer_table, left_on=customer_sk_col, right_on="c_customer_sk")
+        .group_by(CUSTOMER_COMPOSITE)
         .agg(
             [(pl.col(list_price_col) - pl.col(discount_col)).sum().alias("year_total")]
         )
@@ -160,64 +167,63 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     date_first = date_dim.filter(pl.col("d_year") == year_first).select("d_date_sk")
     date_second = date_dim.filter(pl.col("d_year") == year_second).select("d_date_sk")
 
-    # Aggregate by customer_sk only — no customer table join needed yet.
     t_s_first = (
         build_year_total(
             store_sales,
+            customer,
             "ss_customer_sk",
             "ss_sold_date_sk",
             "ss_ext_list_price",
             "ss_ext_discount_amt",
             date_first,
         )
-        .rename({"ss_customer_sk": "customer_sk", "year_total": "s_first_year_total"})
+        .rename({"year_total": "s_first_year_total"})
         .filter(pl.col("s_first_year_total") > 0)
     )
 
     t_s_sec = build_year_total(
         store_sales,
+        customer,
         "ss_customer_sk",
         "ss_sold_date_sk",
         "ss_ext_list_price",
         "ss_ext_discount_amt",
         date_second,
-    ).rename({"ss_customer_sk": "customer_sk", "year_total": "s_sec_year_total"})
+    ).rename({"year_total": "s_sec_year_total"})
 
     t_w_first = (
         build_year_total(
             web_sales,
+            customer,
             "ws_bill_customer_sk",
             "ws_sold_date_sk",
             "ws_ext_list_price",
             "ws_ext_discount_amt",
             date_first,
         )
-        .rename(
-            {"ws_bill_customer_sk": "customer_sk", "year_total": "w_first_year_total"}
-        )
+        .rename({"year_total": "w_first_year_total"})
         .filter(pl.col("w_first_year_total") > 0)
     )
 
     t_w_sec = build_year_total(
         web_sales,
+        customer,
         "ws_bill_customer_sk",
         "ws_sold_date_sk",
         "ws_ext_list_price",
         "ws_ext_discount_amt",
         date_second,
-    ).rename({"ws_bill_customer_sk": "customer_sk", "year_total": "w_sec_year_total"})
+    ).rename({"year_total": "w_sec_year_total"})
 
-    # Join all four aggregates on customer_sk, then join customer once for display cols.
     return QueryResult(
         frame=(
-            t_s_sec.join(t_s_first, on="customer_sk")
-            .join(t_w_first, on="customer_sk")
-            .join(t_w_sec, on="customer_sk")
+            t_s_sec.join(t_s_first, on=CUSTOMER_COMPOSITE, nulls_equal=True)
+            .join(t_w_first, on=CUSTOMER_COMPOSITE, nulls_equal=True)
+            .join(t_w_sec, on=CUSTOMER_COMPOSITE, nulls_equal=True)
             .filter(
                 pl.col("w_sec_year_total") / pl.col("w_first_year_total")
                 > pl.col("s_sec_year_total") / pl.col("s_first_year_total")
             )
-            .join(customer, left_on="customer_sk", right_on="c_customer_sk")
             .select(
                 [
                     pl.col("c_customer_id").alias("customer_id"),

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q4.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q4.py
@@ -179,14 +179,26 @@ def duckdb_impl(run_config: RunConfig) -> str:
     """
 
 
+CUSTOMER_COMPOSITE = [
+    "c_customer_id",
+    "c_first_name",
+    "c_last_name",
+    "c_preferred_cust_flag",
+    "c_birth_country",
+    "c_login",
+    "c_email_address",
+]
+
+
 def build_sales_agg(
     sales_df: pl.LazyFrame,
     date_df: pl.LazyFrame,
+    customer_df: pl.LazyFrame,
     sold_date_key: str,
     customer_key: str,
     col_prefix: str,
 ) -> pl.LazyFrame:
-    """Aggregate sales to (customer_sk, year_total) without joining customer table."""
+    """Aggregate sales joined with customer to (customer composite, year_total)."""
     profit_expr = (
         (
             pl.col(f"{col_prefix}ext_list_price")
@@ -198,9 +210,9 @@ def build_sales_agg(
 
     return (
         sales_df.join(date_df, left_on=sold_date_key, right_on="d_date_sk")
-        .group_by(customer_key)
+        .join(customer_df, left_on=customer_key, right_on="c_customer_sk")
+        .group_by(CUSTOMER_COMPOSITE)
         .agg(profit_expr.sum().alias("year_total"))
-        .rename({customer_key: "customer_sk"})
     )
 
 
@@ -223,53 +235,84 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     date_firstyear = date_dim.filter(pl.col("d_year") == year).select("d_date_sk")
     date_secyear = date_dim.filter(pl.col("d_year") == year + 1).select("d_date_sk")
 
-    # Aggregate each channel x year to (customer_sk, year_total)
+    # Aggregate each channel x year to (customer composite, year_total)
     t_s_fy = build_sales_agg(
-        store_sales, date_firstyear, "ss_sold_date_sk", "ss_customer_sk", "ss_"
+        store_sales,
+        date_firstyear,
+        customer,
+        "ss_sold_date_sk",
+        "ss_customer_sk",
+        "ss_",
     ).filter(pl.col("year_total") > 0)
     t_s_sy = build_sales_agg(
-        store_sales, date_secyear, "ss_sold_date_sk", "ss_customer_sk", "ss_"
+        store_sales, date_secyear, customer, "ss_sold_date_sk", "ss_customer_sk", "ss_"
     )
     t_c_fy = build_sales_agg(
-        catalog_sales, date_firstyear, "cs_sold_date_sk", "cs_bill_customer_sk", "cs_"
+        catalog_sales,
+        date_firstyear,
+        customer,
+        "cs_sold_date_sk",
+        "cs_bill_customer_sk",
+        "cs_",
     ).filter(pl.col("year_total") > 0)
     t_c_sy = build_sales_agg(
-        catalog_sales, date_secyear, "cs_sold_date_sk", "cs_bill_customer_sk", "cs_"
+        catalog_sales,
+        date_secyear,
+        customer,
+        "cs_sold_date_sk",
+        "cs_bill_customer_sk",
+        "cs_",
     )
     t_w_fy = build_sales_agg(
-        web_sales, date_firstyear, "ws_sold_date_sk", "ws_bill_customer_sk", "ws_"
+        web_sales,
+        date_firstyear,
+        customer,
+        "ws_sold_date_sk",
+        "ws_bill_customer_sk",
+        "ws_",
     ).filter(pl.col("year_total") > 0)
     t_w_sy = build_sales_agg(
-        web_sales, date_secyear, "ws_sold_date_sk", "ws_bill_customer_sk", "ws_"
+        web_sales,
+        date_secyear,
+        customer,
+        "ws_sold_date_sk",
+        "ws_bill_customer_sk",
+        "ws_",
     )
 
-    # Join all 6 subqueries on customer_sk
+    # Join all 6 subqueries on customer composite. nulls_equal=True preserves
+    # the null=null semantics of GROUP BY, since composite columns may be null.
     joined = (
         t_s_sy.rename({"year_total": "s_sy"})
         .join(
             t_s_fy.rename({"year_total": "s_fy"}),
-            on="customer_sk",
+            on=CUSTOMER_COMPOSITE,
             how="inner",
+            nulls_equal=True,
         )
         .join(
             t_c_fy.rename({"year_total": "c_fy"}),
-            on="customer_sk",
+            on=CUSTOMER_COMPOSITE,
             how="inner",
+            nulls_equal=True,
         )
         .join(
             t_c_sy.rename({"year_total": "c_sy"}),
-            on="customer_sk",
+            on=CUSTOMER_COMPOSITE,
             how="inner",
+            nulls_equal=True,
         )
         .join(
             t_w_fy.rename({"year_total": "w_fy"}),
-            on="customer_sk",
+            on=CUSTOMER_COMPOSITE,
             how="inner",
+            nulls_equal=True,
         )
         .join(
             t_w_sy.rename({"year_total": "w_sy"}),
-            on="customer_sk",
+            on=CUSTOMER_COMPOSITE,
             how="inner",
+            nulls_equal=True,
         )
         .filter(
             # Catalog growth rate > Store growth rate
@@ -294,7 +337,6 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         )
     )
 
-    # Join customer once to get output columns
     sort_cols = [
         "customer_id",
         "customer_first_name",
@@ -303,20 +345,7 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     ]
     return QueryResult(
         frame=(
-            joined.join(
-                customer.select(
-                    [
-                        "c_customer_sk",
-                        "c_customer_id",
-                        "c_first_name",
-                        "c_last_name",
-                        "c_preferred_cust_flag",
-                    ]
-                ),
-                left_on="customer_sk",
-                right_on="c_customer_sk",
-            )
-            .select(
+            joined.select(
                 [
                     pl.col("c_customer_id").alias("customer_id"),
                     pl.col("c_first_name").alias("customer_first_name"),

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q74.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q74.py
@@ -97,8 +97,12 @@ def duckdb_impl(run_config: RunConfig) -> str:
     """
 
 
+CUSTOMER_COMPOSITE = ["c_customer_id", "c_first_name", "c_last_name"]
+
+
 def _year_total_sk(
     sales: pl.LazyFrame,
+    customer: pl.LazyFrame,
     date_dim: pl.LazyFrame,
     date_fk: str,
     customer_fk: str,
@@ -108,9 +112,9 @@ def _year_total_sk(
     dates = date_dim.filter(pl.col("d_year") == year).select(["d_date_sk"])
     return (
         sales.join(dates, left_on=date_fk, right_on="d_date_sk")
-        .group_by(customer_fk)
+        .join(customer, left_on=customer_fk, right_on="c_customer_sk")
+        .group_by(CUSTOMER_COMPOSITE)
         .agg(pl.col(amount_col).std().alias("year_total"))
-        .rename({customer_fk: "customer_sk"})
     )
 
 
@@ -132,6 +136,7 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     t_s_first = (
         _year_total_sk(
             store_sales,
+            customer,
             date_dim,
             "ss_sold_date_sk",
             "ss_customer_sk",
@@ -143,6 +148,7 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     )
     t_s_sec = _year_total_sk(
         store_sales,
+        customer,
         date_dim,
         "ss_sold_date_sk",
         "ss_customer_sk",
@@ -152,6 +158,7 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     t_w_first = (
         _year_total_sk(
             web_sales,
+            customer,
             date_dim,
             "ws_sold_date_sk",
             "ws_bill_customer_sk",
@@ -163,6 +170,7 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     )
     t_w_sec = _year_total_sk(
         web_sales,
+        customer,
         date_dim,
         "ws_sold_date_sk",
         "ws_bill_customer_sk",
@@ -171,9 +179,9 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     ).rename({"year_total": "w_sec_total"})
 
     joined = (
-        t_s_first.join(t_s_sec, on="customer_sk")
-        .join(t_w_first, on="customer_sk")
-        .join(t_w_sec, on="customer_sk")
+        t_s_first.join(t_s_sec, on=CUSTOMER_COMPOSITE, nulls_equal=True)
+        .join(t_w_first, on=CUSTOMER_COMPOSITE, nulls_equal=True)
+        .join(t_w_sec, on=CUSTOMER_COMPOSITE, nulls_equal=True)
     )
 
     sort_by = {
@@ -187,13 +195,6 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
             joined.filter(
                 pl.col("w_sec_total") / pl.col("w_first_total")
                 > pl.col("s_sec_total") / pl.col("s_first_total")
-            )
-            .join(
-                customer.select(
-                    ["c_customer_sk", "c_customer_id", "c_first_name", "c_last_name"]
-                ),
-                left_on="customer_sk",
-                right_on="c_customer_sk",
             )
             .select(
                 pl.col("c_customer_id").alias("customer_id"),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
`FD_GROUPBY_REWRITE` is an optimization that takes advantage of the fact that a customer's ID number uniquely identifies them. Instead of joining the wide `customer` table to sales first and then grouping by every customer column (`c_customer_id`, `c_first_name`, `c_last_name`, ...) to compute a per-customer total, we group sales by the integer customer foreign key (`ss_customer_sk`) first, then join `customer` once at the end to attach the display columns. Grouping by one integer is cheaper than grouping by a wide string composite, and the intermediate frames stay narrower.

The rewrite is only valid because `c_customer_sk` is the primary key of `customer` (so it determines all the other customer columns) and the sales tables' customer foreign keys satisfy [referential integrity](https://en.wikipedia.org/wiki/Referential_integrity). Neither fact is something the optimizer on its own could infer without the kind of key metadata a SQL database provides: which columns are unique, and which columns point to them.

## Benchmarks

## Single GPU, streaming + spmd, SF1000

| Query | Before (s) | After (s) | Slowdown |
| ----- | ---------: | --------: | -------: |
| Q4    | 5.94       | 12.54     | 2.11x    |
| Q14   | 12.60      | 13.65     | 1.08x    |
| Q74   | 4.60       | 8.62      | 1.88x    |

## Multi GPU, streaming + ray, SF3000

| Query | Before (s) | After (s) | Slowdown |
| ----- | ---------: | --------: | -------: |
| Q4    | 3.08       | 11.41     | 3.71x    |
| Q14   | 15.61      | 15.10     | 0.97x    |
| Q74   | 2.43       | 4.63      | 1.90x    |

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
