### PR TITLE
Fix instances of use after destroy

### DIFF
--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -319,6 +319,7 @@ std::unique_ptr<column> for_each_concatenate(host_span<column_view const> views,
   } else {
     col->set_null_count(0);  // prevent null count from being materialized
   }
+  stream.synchronize();
 
   return col;
 }

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -318,8 +318,8 @@ std::unique_ptr<column> for_each_concatenate(host_span<column_view const> views,
       cudf::detail::concatenate_masks(views, (col->mutable_view()).null_mask(), stream));
   } else {
     col->set_null_count(0);  // prevent null count from being materialized
+    stream.synchronize();
   }
-  stream.synchronize();
 
   return col;
 }

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -146,6 +146,7 @@ rmm::device_uvector<codepoint_metadata_type> get_codepoint_metadata(rmm::cuda_st
     (cp_section2_end - cp_section2_begin + 1) * sizeof(codepoint_metadata[0])};
   CUDF_CUDA_TRY(
     cudf::detail::memcpy_batch_async(dsts.data(), srcs.data(), sizes.data(), 2, stream));
+  stream.synchronize();
   return table_vector;
 }
 
@@ -176,6 +177,7 @@ rmm::device_uvector<aux_codepoint_data_type> get_aux_codepoint_data(rmm::cuda_st
     (aux_section4_end - aux_section4_begin + 1) * sizeof(aux_codepoint_data[0])};
   CUDF_CUDA_TRY(
     cudf::detail::memcpy_batch_async(dsts.data(), srcs.data(), sizes.data(), 4, stream));
+  stream.synchronize();
   return table_vector;
 }
 


### PR DESCRIPTION
## Description

This PR fixes a couple instances of use-after-destroy bug in libcudf concatenate and normalize utils.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
