### PR TITLE
Preserve filter fallback row order

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -4,11 +4,14 @@
 
 from __future__ import annotations
 
+import itertools
 import operator
 from functools import partial, reduce
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
+
+import pylibcudf as plc
 
 import cudf_polars.experimental.distinct
 import cudf_polars.experimental.groupby
@@ -17,11 +20,12 @@ import cudf_polars.experimental.join
 import cudf_polars.experimental.select
 import cudf_polars.experimental.shuffle
 import cudf_polars.experimental.sort  # noqa: F401
-from cudf_polars.containers import DataType
+from cudf_polars.containers import Column, DataFrame, DataType
 from cudf_polars.dsl.expr import Col, Literal, NamedExpr
 from cudf_polars.dsl.ir import (
     IR,
     Cache,
+    DataFrameScan,
     Filter,
     HConcat,
     HStack,
@@ -29,26 +33,189 @@ from cudf_polars.dsl.ir import (
     Projection,
     Select,
     Slice,
+    Sort,
     Union,
 )
 from cudf_polars.dsl.traversal import CachingVisitor, traversal
 from cudf_polars.dsl.utils.naming import unique_names
-from cudf_polars.experimental.base import PartitionInfo
+from cudf_polars.experimental.base import ColumnStat, PartitionInfo
 from cudf_polars.experimental.dispatch import lower_ir_node
 from cudf_polars.experimental.io import _clear_source_info_cache
 from cudf_polars.experimental.repartition import Repartition
 from cudf_polars.experimental.utils import (
     _contains_over,
     _dynamic_planning_on,
+    _fallback_inform,
     _lower_ir_fallback,
 )
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
 
+    from cudf_polars.dsl.ir import IRExecutionContext
     from cudf_polars.experimental.base import StatsCollector
     from cudf_polars.experimental.dispatch import LowerIRTransformer, State
+    from cudf_polars.typing import Schema
     from cudf_polars.utils.config import ConfigOptions, StreamingExecutor
+
+
+class RowIndex(IR):
+    """Add a temporary row index with partition-specific offsets."""
+
+    __slots__ = ("name", "offsets", "partition_order")
+    _non_child = ("schema", "name", "offsets", "partition_order")
+    _n_non_child_args = 2
+    name: str
+    offsets: tuple[int, ...]
+    partition_order: int | tuple[Any, ...]
+
+    def __init__(
+        self,
+        schema: Schema,
+        name: str,
+        offsets: tuple[int, ...],
+        partition_order: int | tuple[Any, ...],
+        df: IR,
+    ):
+        self.schema = schema
+        self.name = name
+        self.offsets = offsets
+        self.partition_order = partition_order
+        self._non_child_args = (name, offsets, partition_order)
+        self.children = (df,)
+
+    @classmethod
+    def do_evaluate(
+        cls,
+        name: str,
+        offset: int,
+        df: DataFrame,
+        *,
+        context: IRExecutionContext,
+    ) -> DataFrame:
+        """Evaluate and return a dataframe with a leading row-index column."""
+        stream = df.stream
+        dtype = DataType(pl.UInt64())
+        step = plc.Scalar.from_py(1, dtype.plc_type, stream=stream)
+        init = plc.Scalar.from_py(offset, dtype.plc_type, stream=stream)
+        index_col = Column(
+            plc.filling.sequence(df.num_rows, init, step, stream=stream),
+            is_sorted=plc.types.Sorted.YES,
+            order=plc.types.Order.ASCENDING,
+            null_order=plc.types.NullOrder.AFTER,
+            name=name,
+            dtype=dtype,
+        )
+        return DataFrame([index_col, *df.columns], stream=stream)
+
+
+def _partition_row_counts(
+    ir: IR,
+    partition_info: MutableMapping[IR, PartitionInfo],
+    stats: StatsCollector,
+) -> tuple[list[int], int | tuple[Any, ...]] | None:
+    """Return exact row counts for the partitions of *ir*, if known."""
+    if isinstance(ir, DataFrameScan):
+        count = partition_info[ir].count
+        nrows = ir.df.shape()[0]
+        length = max(1, (nrows + count - 1) // count)
+        counts = [max(0, min(length, nrows - i * length)) for i in range(count)]
+        return counts, count
+
+    if isinstance(ir, Union):
+        counts: list[int] = []
+        partition_order = []
+        for child in ir.children:
+            child_info = _partition_row_counts(child, partition_info, stats)
+            if child_info is None:
+                return None
+            child_counts, child_partition_order = child_info
+            counts.extend(child_counts)
+            partition_order.append(child_partition_order)
+        return counts, tuple(partition_order)
+
+    if isinstance(ir, Repartition):
+        child_info = _partition_row_counts(ir.children[0], partition_info, stats)
+        if child_info is None:
+            return None
+        child_counts, _ = child_info
+        count_out = partition_info[ir].count
+        n, remainder = divmod(len(child_counts), count_out)
+        offsets = [
+            0,
+            *itertools.accumulate(n + (i < remainder) for i in range(count_out)),
+        ]
+        counts = [
+            sum(child_counts[offsets[i] : offsets[i + 1]]) for i in range(count_out)
+        ]
+        return counts, count_out
+
+    if partition_info[ir].count == 1:
+        value = stats.row_count.get(ir, ColumnStat[int]()).value
+        return ([value], 1) if value is not None else None
+
+    if len(ir.children) == 1 and isinstance(ir, (Cache, HStack, Projection)):
+        return _partition_row_counts(ir.children[0], partition_info, stats)
+
+    if isinstance(ir, MapFunction) and ir.name == "rename":
+        return _partition_row_counts(ir.children[0], partition_info, stats)
+
+    return None
+
+
+def _lower_over_filter_fallback(
+    ir: Filter,
+    child: IR,
+    rec: LowerIRTransformer,
+    partition_info: MutableMapping[IR, PartitionInfo],
+) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+    row_count_info = _partition_row_counts(child, partition_info, rec.state["stats"])
+    if row_count_info is None:
+        return _lower_ir_fallback(
+            ir.reconstruct([child]),
+            rec,
+            msg=(
+                "over(...) inside filter is not supported for multiple partitions; "
+                "falling back to in-memory evaluation."
+            ),
+        )
+    counts, partition_order = row_count_info
+
+    temp_name = next(
+        unique_names((f"__cudf_polars_filter_order_{abs(hash(ir))}", *child.schema))
+    )
+
+    order_dtype = DataType(pl.UInt64())
+    indexed_schema = {temp_name: order_dtype, **child.schema}
+    offsets = tuple(itertools.accumulate((0, *counts)))[:-1]
+    indexed_child = RowIndex(indexed_schema, temp_name, offsets, partition_order, child)
+    partition_info[indexed_child] = PartitionInfo(count=partition_info[child].count)
+
+    if partition_info[indexed_child].count > 1:
+        _fallback_inform(
+            "over(...) inside filter is not supported for multiple partitions; "
+            "falling back to in-memory evaluation.",
+            rec.state["config_options"],
+        )
+        indexed_child = Repartition(indexed_schema, indexed_child)
+        partition_info[indexed_child] = PartitionInfo(count=1)
+
+    filtered = Filter(indexed_schema, ir.mask, indexed_child)
+    partition_info[filtered] = PartitionInfo(count=1)
+    order_key = NamedExpr(temp_name, Col(order_dtype, temp_name))
+    sorted_filter = Sort(
+        indexed_schema,
+        (order_key,),
+        (plc.types.Order.ASCENDING,),
+        (plc.types.NullOrder.AFTER,),
+        stable=True,
+        zlice=None,
+        df=filtered,
+    )
+    partition_info[sorted_filter] = PartitionInfo(count=1)
+    projected = Projection(ir.schema, sorted_filter)
+    partition_info[projected] = PartitionInfo(count=1)
+    return projected, partition_info
 
 
 @lower_ir_node.register(IR)
@@ -212,14 +379,7 @@ def _(
 
     if partition_info[child].count > 1 and _contains_over([ir.mask.value]):
         # mask contains .over(...), collapse to single partition
-        return _lower_ir_fallback(
-            ir.reconstruct([child]),
-            rec,
-            msg=(
-                "over(...) inside filter is not supported for multiple partitions; "
-                "falling back to in-memory evaluation."
-            ),
-        )
+        return _lower_over_filter_fallback(ir, child, rec, partition_info)
 
     if partition_info[child].count > 1 and not all(
         expr.is_pointwise for expr in traversal([ir.mask.value])

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/nodes.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/nodes.py
@@ -20,6 +20,7 @@ from rapidsmpf.streaming.cudf.table_chunk import (
 
 from cudf_polars.containers import DataFrame
 from cudf_polars.dsl.ir import IR, Empty
+from cudf_polars.experimental.parallel import RowIndex
 from cudf_polars.experimental.rapidsmpf.dispatch import (
     generate_ir_sub_network,
 )
@@ -43,6 +44,35 @@ if TYPE_CHECKING:
 
     from cudf_polars.dsl.ir import IRExecutionContext
     from cudf_polars.experimental.rapidsmpf.dispatch import SubNetGenerator
+
+
+def _partition_order_count(partition_order: int | tuple[Any, ...]) -> int:
+    if isinstance(partition_order, int):
+        return partition_order
+    return sum(_partition_order_count(child) for child in partition_order)
+
+
+def _local_partition_indices(
+    partition_order: int | tuple[Any, ...],
+    rank: int,
+    nranks: int,
+    *,
+    base: int = 0,
+) -> tuple[int, ...]:
+    if isinstance(partition_order, int):
+        local_count = (partition_order + nranks - 1) // nranks
+        start = local_count * rank
+        stop = min(start + local_count, partition_order)
+        return tuple(range(base + start, base + stop))
+
+    indices: list[int] = []
+    child_base = base
+    for child in partition_order:
+        indices.extend(
+            _local_partition_indices(child, rank, nranks, base=child_base)
+        )
+        child_base += _partition_order_count(child)
+    return tuple(indices)
 
 
 @define_actor()
@@ -550,6 +580,106 @@ def _(
             )
         ]
 
+    return nodes, channels
+
+
+@define_actor()
+async def row_index_node(
+    context: Context,
+    ir: RowIndex,
+    ir_context: IRExecutionContext,
+    ch_out: Channel[TableChunk],
+    ch_in: Channel[TableChunk],
+) -> None:
+    """
+    Row-index node for rapidsmpf.
+
+    Notes
+    -----
+    The generic single-input node cannot evaluate RowIndex because the
+    partition-specific offset is keyed by each message's sequence number.
+    """
+    async with shutdown_on_error(
+        context, ch_in, ch_out, trace_ir=ir, ir_context=ir_context
+    ) as tracer:
+        metadata_in = await recv_metadata(ch_in, context)
+        metadata_out = ChannelMetadata(
+            local_count=metadata_in.local_count,
+            partitioning=metadata_in.partitioning,
+            duplicated=metadata_in.duplicated,
+        )
+        await send_metadata(ch_out, context, metadata_out)
+        if tracer is not None and metadata_out.duplicated:
+            tracer.set_duplicated()
+
+        partition_indices = _local_partition_indices(
+            ir.partition_order,
+            context.comm().rank,
+            context.comm().nranks,
+        )
+
+        while (msg := await ch_in.recv(context)) is not None:
+            seq_num = msg.sequence_number
+            if seq_num >= len(partition_indices):
+                raise RuntimeError(
+                    "RowIndex received more chunks than expected from its input."
+                )
+            chunk = TableChunk.from_message(msg, br=context.br())
+            del msg
+            chunk, extra = await make_table_chunks_available_or_wait(
+                context,
+                chunk,
+                reserve_extra=chunk.data_alloc_size(),
+                net_memory_delta=0,
+            )
+            partition_index = partition_indices[seq_num]
+            with opaque_memory_usage(extra):
+                df = await ir_context.to_thread(
+                    ir.do_evaluate,
+                    ir.name,
+                    ir.offsets[partition_index],
+                    DataFrame.from_table(
+                        chunk.table_view(),
+                        list(ir.children[0].schema.keys()),
+                        list(ir.children[0].schema.values()),
+                        chunk.stream,
+                    ),
+                    context=ir_context,
+                )
+            if tracer is not None:
+                tracer.add_chunk(table=df.table)
+            await ch_out.send(
+                context,
+                Message(
+                    seq_num,
+                    TableChunk.from_pylibcudf_table(
+                        df.table,
+                        df.stream,
+                        exclusive_view=True,
+                        br=context.br(),
+                    ),
+                ),
+            )
+            del chunk, df
+
+        await ch_out.drain(context)
+
+
+@generate_ir_sub_network.register(RowIndex)
+def _(
+    ir: RowIndex, rec: SubNetGenerator
+) -> tuple[dict[IR, list[Any]], dict[IR, ChannelManager]]:
+    nodes, channels = process_children(ir, rec)
+    channels[ir] = ChannelManager(rec.state["context"])
+    nodes[ir] = [
+        row_index_node(
+            rec.state["context"],
+            ir,
+            rec.state["ir_context"],
+            channels[ir].reserve_input_slot(),
+            channels[ir.children[0]].reserve_output_slot(),
+        )
+    ]
     return nodes, channels
 
 

--- a/python/cudf_polars/tests/experimental/test_filter.py
+++ b/python/cudf_polars/tests/experimental/test_filter.py
@@ -43,3 +43,29 @@ def test_filter_non_pointwise(df, engine):
         match="This filter is not supported for multiple partitions.",
     ):
         assert_gpu_result_equal(query, engine=engine)
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        pl.len().over("k") == 2,
+        pl.col("v").max().over("k") > 4,
+    ],
+)
+def test_filter_over_fallback_preserves_row_order(engine, mask):
+    query = pl.concat(
+        [
+            pl.LazyFrame({"k": ["x", "y"], "v": [3, 2]}),
+            pl.LazyFrame({"k": ["x", "y"], "v": [5, 7]}),
+        ]
+    ).filter(mask)
+
+    with warns_on_spmd(
+        engine,
+        UserWarning,
+        match=(
+            "over\\(\\.\\.\\.\\) inside filter is not supported "
+            "for multiple partitions"
+        ),
+    ):
+        assert_gpu_result_equal(query, engine=engine)


### PR DESCRIPTION
## Summary

Fixes #22405 a row-order mismatch in cudf-polars streaming fallback when a `Filter` mask contains an `over(...)` expression, such as:

- `pl.len().over(...)`
- `pl.col(...).over(...)`

Previously, multi-partition fallback collapsed/evaluated partitions in a way that preserved the correct rows but could return them in a different order than Polars CPU execution.

## What changed

- Added an internal `RowIndex` IR node that attaches a temporary row-position column before fallback evaluation.
- For `Filter` nodes whose mask contains `over(...)`, the fallback path now:
  1. adds the temporary row index,
  2. collapses to a single fallback partition,
  3. evaluates the filter,
  4. sorts by the temporary row index,
  5. projects back to the original user-visible schema.
- Added RAPIDS-MPF handling for the new `RowIndex` node.
- Added a regression test covering:
  - `pl.len().over("k") == 2`
  - `pl.col("v").max().over("k") > 4`

## Validation

Local checks run:

```bash
PYTHONPYCACHEPREFIX=/tmp/codex_pycache python3.11 -m py_compile \
  python/cudf_polars/cudf_polars/experimental/parallel.py \
  python/cudf_polars/cudf_polars/experimental/rapidsmpf/nodes.py \
  python/cudf_polars/tests/experimental/test_filter.py

git diff --check
Also ran targeted ruff checks for the new code paths.

## Why this is safe

The temporary row index is introduced only inside the fallback path for `Filter`
nodes whose mask contains `over(...)`. It is removed before returning to the
user-visible schema, so the output columns remain unchanged.

The extra sort is only applied to this fallback path to restore Polars CPU row
ordering semantics.

## Behavior

Before this change, the fallback path could preserve the correct set of rows
but return them in partition-concatenation order rather than the original global
input order.

After this change, rows are tagged before fallback evaluation and sorted back
to their original input order after filtering.

I could not run the full GPU/Ray reproducer locally because my machine does not
have the RAPIDS GPU test environment. I added regression coverage for the
affected `over(...)` filter cases and ran local compile/diff checks. Full GPU CI
should validate the multi-rank execution path.