### PR TITLE
Preserve multi-rank concat row order

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/common.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/common.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Literal
 
 from rapidsmpf.shuffler import Shuffler
 
-from cudf_polars.dsl.ir import Distinct, GroupBy, Sort
+from cudf_polars.dsl.ir import Distinct, GroupBy, Sort, Union
 from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.io import StreamingSink
 from cudf_polars.experimental.join import Join
@@ -92,6 +92,7 @@ class ReserveOpIDs:
             Repartition,
             StreamingSink,
             Sort,
+            Union,
         )
         if self.dynamic_planning_enabled:
             collective_types = (
@@ -103,6 +104,7 @@ class ReserveOpIDs:
                 GroupBy,
                 Distinct,
                 Over,
+                Union,
             )
 
         self.collective_nodes: list[IR] = [

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/union.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/union.py
@@ -10,7 +10,9 @@ from rapidsmpf.streaming.core.message import Message
 from rapidsmpf.streaming.cudf.channel_metadata import ChannelMetadata
 from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
+from cudf_polars.containers import DataFrame
 from cudf_polars.dsl.ir import Union
+from cudf_polars.experimental.rapidsmpf.collectives.allgather import AllGatherManager
 from cudf_polars.experimental.rapidsmpf.dispatch import (
     generate_ir_sub_network,
 )
@@ -23,6 +25,7 @@ from cudf_polars.experimental.rapidsmpf.utils import (
     recv_metadata,
     send_metadata,
 )
+from cudf_polars.experimental.utils import _concat
 
 if TYPE_CHECKING:
     from rapidsmpf.communicator.communicator import Communicator
@@ -41,6 +44,7 @@ async def union_node(
     ir_context: IRExecutionContext,
     ch_out: Channel[TableChunk],
     *chs_in: Channel[TableChunk],
+    collective_ids: list[int],
 ) -> None:
     """
     Union node for rapidsmpf.
@@ -59,6 +63,8 @@ async def union_node(
         The output Channel[TableChunk].
     chs_in
         The input Channel[TableChunk]s.
+    collective_ids
+        Pre-allocated collective IDs for per-child AllGather operations.
     """
     async with shutdown_on_error(
         context, *chs_in, ch_out, trace_ir=ir, ir_context=ir_context
@@ -69,6 +75,70 @@ async def union_node(
         metadata = await gather_in_task_group(
             *(recv_metadata(ch, context) for ch in chs_in)
         )
+
+        if comm.nranks > 1:
+            # Gather each child independently so child order is preserved before
+            # redistributing the concatenated result into rank-contiguous slices.
+            await send_metadata(
+                ch_out,
+                context,
+                ChannelMetadata(local_count=1),
+            )
+
+            stream = context.get_stream_from_pool()
+            dfs: list[DataFrame] = []
+            collective_id = collective_ids[0]
+            for ch_in, meta in zip(chs_in, metadata, strict=True):
+                allgather = AllGatherManager(context, comm, collective_id)
+                with allgather.inserting() as inserter:
+                    seq_num = 0
+                    skip_insert = meta.duplicated and comm.rank != 0
+                    while (msg := await ch_in.recv(context)) is not None:
+                        if not skip_insert:
+                            inserter.insert(
+                                seq_num,
+                                TableChunk.from_message(msg, br=context.br()),
+                            )
+                            seq_num += 1
+                        del msg
+
+                table = await allgather.extract_concatenated(
+                    stream, ir_context=ir_context
+                )
+                if table.num_columns() == 0 and len(ir.schema) > 0:
+                    chunk = empty_table_chunk(ir, context, stream)
+                    table = chunk.table_view()
+                    stream = chunk.stream
+                dfs.append(
+                    DataFrame.from_table(
+                        table,
+                        list(ir.schema.keys()),
+                        list(ir.schema.values()),
+                        stream,
+                    )
+                )
+
+            df = _concat(*dfs, context=ir_context)
+            rows_per_rank = max(1, (df.num_rows + comm.nranks - 1) // comm.nranks)
+            offset = rows_per_rank * comm.rank
+            length = max(0, min(rows_per_rank, df.num_rows - offset))
+            df = df.slice((offset, length))
+            await ch_out.send(
+                context,
+                Message(
+                    0,
+                    TableChunk.from_pylibcudf_table(
+                        df.table,
+                        df.stream,
+                        exclusive_view=True,
+                        br=context.br(),
+                    ),
+                ),
+            )
+            del df
+            await ch_out.drain(context)
+            return
+
         # Chunk counts on the wire are uniform across ranks, so report the
         # full sum.
         total_local_count = sum(meta.local_count for meta in metadata)
@@ -82,21 +152,13 @@ async def union_node(
             ),
         )
 
-        # When a child has duplicated=True, every rank has produced the same
-        # rows, so we drop them everywhere except rank 0 to avoid N counting.
-        suppress = tuple(meta.duplicated and comm.rank != 0 for meta in metadata)
-
         seq_num_offset = 0
-        for ch_in, drop in zip(chs_in, suppress, strict=True):
+        for ch_in in chs_in:
             num_ch_chunks = 0
             while (msg := await ch_in.recv(context)) is not None:
-                if drop:
-                    stream = ir_context.get_cuda_stream()
-                    out_chunk = empty_table_chunk(ir, context, stream)
-                else:
-                    out_chunk = TableChunk.from_message(
-                        msg, br=context.br()
-                    ).make_available_and_spill(context.br(), allow_overbooking=True)
+                out_chunk = TableChunk.from_message(
+                    msg, br=context.br()
+                ).make_available_and_spill(context.br(), allow_overbooking=True)
                 await ch_out.send(
                     context,
                     Message(
@@ -132,6 +194,7 @@ def _(
             rec.state["ir_context"],
             channels[ir].reserve_input_slot(),
             *[channels[c].reserve_output_slot() for c in ir.children],
+            collective_ids=rec.state["collective_id_map"][ir],
         )
     ]
     return nodes, channels

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -60,20 +60,10 @@ def test_parallel_dataframescan(df, streaming_engine_factory, max_rows_per_parti
         assert count == 1
 
 
-def test_dataframescan_concat(request, df, streaming_engine_factory):
+def test_dataframescan_concat(df, streaming_engine_factory):
     streaming_engine = streaming_engine_factory(
         StreamingOptions(max_rows_per_partition=1_000),
     )
-    if streaming_engine.nranks > 1:
-        # Multi-rank Union interleaves child outputs across ranks: client
-        # receives [rank0_A, rank0_B, rank1_A, rank1_B] instead of the
-        # polars-CPU [A, B].
-        request.applymarker(
-            pytest.mark.xfail(
-                reason="https://github.com/rapidsai/cudf/issues/22376",
-                strict=False,
-            )
-        )
     df2 = pl.concat([df, df])
     assert_gpu_result_equal(df2, engine=streaming_engine)
 


### PR DESCRIPTION
Closes #22376.

This PR fixes multi-rank RAPIDS-MPF `Union` / `pl.concat` row ordering. Polars `pl.concat([A, B])` semantics require all rows from `A` before all rows from `B`, but the streaming runtime previously emitted rank-local child order, producing layouts like `A_rank0, B_rank0, A_rank1, B_rank1`.

### What changed

For multi-rank `Union` execution, the RAPIDS-MPF union actor now:

1. Collects each child input independently across ranks.
2. Concatenates the gathered child results in original child order.
3. Redistributes the concatenated result into rank-contiguous slices.

This preserves global `pl.concat` row order before downstream operators run. The single-rank path remains the existing streaming pass-through path.

This also removes the xfail from the existing multi-rank `DataFrameScan` concat regression test.

### Validation

Local checks run:

```bash
PYTHONPYCACHEPREFIX=/tmp/codex_pycache python3.11 -m py_compile \
  python/cudf_polars/cudf_polars/experimental/rapidsmpf/union.py \
  python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/common.py \
  python/cudf_polars/tests/experimental/test_dataframescan.py

git diff --check

python3 -m ruff check --select RUF023,D102,FBT003,F821,I,TC001,TC002,TC003 \
  python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/common.py \
  python/cudf_polars/cudf_polars/experimental/rapidsmpf/union.py \
  python/cudf_polars/tests/experimental/test_dataframescan.py
```

Full RAPIDS-MPF / GPU validation should run in CI.

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
