### PR TITLE
fix(deps): include `ctk` extra in `cupy` dependency

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1168,11 +1168,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0,!=14.0.0
+              - cupy-cuda12x[ctk]>=13.6.0,!=14.0.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0,!=14.0.0
+              - cupy-cuda13x[ctk]>=13.6.0,!=14.0.0
   depends_on_libkvikio:
     common:
       - output_types: conda

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.11"
 dependencies = [
     "cachetools",
     "cuda-python>=13.0.1,<14.0",
-    "cupy-cuda13x>=13.6.0,!=14.0.0",
+    "cupy-cuda13x[ctk]>=13.6.0,!=14.0.0",
     "fsspec>=0.6.0",
     "libcudf==26.6.*,>=0.0.0a0",
     "numba-cuda>=0.22.2,<0.29.0",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -22,7 +22,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
     "cudf==26.6.*,>=0.0.0a0",
-    "cupy-cuda13x>=13.6.0,!=14.0.0",
+    "cupy-cuda13x[ctk]>=13.6.0,!=14.0.0",
     "fsspec>=0.6.0",
     "numpy>=1.26,<3.0",
     "nvidia-ml-py>=12",

--- a/python/pylibcudf/pyproject.toml
+++ b/python/pylibcudf/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "cupy-cuda13x>=13.6.0,!=14.0.0",
+    "cupy-cuda13x[ctk]>=13.6.0,!=14.0.0",
     "fastavro>=0.22.9",
     "mmh3",
     "nanoarrow",


### PR DESCRIPTION
## Description

I've been experimenting with reducing the size of our CI test images and when attempting to run a smaller `citestwheel` on cudf in https://github.com/rapidsai/cudf/pull/22171 I ran into some unexpected dependency errors.

Specifically, many of the tests that use `cupy` directly or indirectly fail because of missing libraries.

A representative example from https://github.com/rapidsai/cudf/actions/runs/26051657809/job/76594371859?pr=22171:

```
FAILED test_column_from_array.py::test_non_c_contiguous_raises[<class 'numpy.bool'>-ndim=4] - ImportError: Failure finding "libcublasLt.so": No such file: libcublasLt.so*, No such file: libcublasLt.so*
  listdir("/__w/cudf/cudf/env/lib/python3.13/site-packages/nvidia/cu13/lib"):
    libcudadevrt.a
    libcudart.so.13
    libcudart_static.a
    libnvJitLink.so.13
    libnvrtc-builtins.so.13.2
    libnvrtc.so.13
    libnvvm.so.4
```

`cupy` does note these dependencies, but they are behind a `ctk` extra. I think these tests have been passing here because the `cuda-devel` image happens to have these shared objects available.

I _think_ we want to depend on the `ctk` extra with `cupy` so we pull in the dependencies we need, but there could well be other considerations I'm not aware of, but I wanted to at least get a PR up in case this needs to get fixed before 26.06 goes out.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
