### PR TITLE
[release/26.06] Remove stale import of `deleted assert_collect_raises`

### DIFF
--- a/python/cudf_polars/tests/test_hconcat.py
+++ b/python/cudf_polars/tests/test_hconcat.py
@@ -8,7 +8,7 @@ import polars as pl
 
 from cudf_polars.containers import DataType
 from cudf_polars.dsl.ir import DataFrameScan, Empty, HConcat, IRExecutionContext
-from cudf_polars.testing.asserts import assert_collect_raises, assert_gpu_result_equal
+from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.versions import POLARS_VERSION_LT_139
 
 
@@ -38,11 +38,10 @@ def test_hconcat_strict_different_heights():
     left = pl.LazyFrame({"a": [1, 2, 3]})
     right = pl.LazyFrame({"b": [4, 5]})
     q = pl.concat([left, right], how="horizontal", strict=True)
-    assert_collect_raises(
-        q,
-        polars_except=pl.exceptions.ShapeError,
-        cudf_except=pl.exceptions.ShapeError,
-    )
+    with pytest.raises(pl.exceptions.ShapeError):
+        q.collect()
+    with pytest.raises(pl.exceptions.ShapeError):
+        q.collect(engine=pl.GPUEngine(raise_on_fail=True))
 
 
 def test_hconcat_should_broadcast():

--- a/python/cudf_polars/tests/test_hconcat.py
+++ b/python/cudf_polars/tests/test_hconcat.py
@@ -41,7 +41,7 @@ def test_hconcat_strict_different_heights():
     with pytest.raises(pl.exceptions.ShapeError):
         q.collect()
     with pytest.raises(pl.exceptions.ShapeError):
-        q.collect(engine=pl.GPUEngine(raise_on_fail=True))
+        q.collect(engine=pl.GPUEngine(executor="in-memory", raise_on_fail=True))
 
 
 def test_hconcat_should_broadcast():


### PR DESCRIPTION
## Description

PR #22048 (merged today) added the new `test_hconcat_strict_different_heights` test, which imports `assert_collect_raises`. However, PR #22535 (also merged today) removed that helper.

The two PRs landed on `release/26.06` without the conflict being noticed.

On `main`, `test_hconcat.py` does not contain the strict-mode test, so the issue is limited to `release/26.06`.
