### PR TITLE
Fix JSON token count estimate to account for the delimiter in recovery mode

### DIFF
--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -1631,6 +1631,11 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
       tokenizer_pda::get_translation_table(recover_from_error)),
     stream);
 
+  // In case we're recovering on invalid JSON lines, post-processing the token stream requires to
+  // see a JSON-line delimiter as the very first item
+  SymbolOffsetT const delimiter_offset =
+    (format == tokenizer_pda::json_format_cfg_t::JSON_LINES_RECOVER ? 1 : 0);
+
   // Perform a PDA-transducer pass
   // Compute the maximum amount of tokens that can possibly be emitted for a given input size
   // Worst case ratio of tokens per input char is given for a struct with an empty field name, that
@@ -1639,13 +1644,10 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   std::size_t constexpr min_chars_per_struct  = 5;
   std::size_t constexpr max_tokens_per_struct = 6;
   auto const max_token_out_count =
-    cudf::util::div_rounding_up_safe(json_in.size(), min_chars_per_struct) * max_tokens_per_struct;
+    cudf::util::div_rounding_up_safe(json_in.size(), min_chars_per_struct) * max_tokens_per_struct +
+    delimiter_offset;
   cudf::detail::device_scalar<std::size_t> num_written_tokens{
     stream, cudf::get_current_device_resource_ref()};
-  // In case we're recovering on invalid JSON lines, post-processing the token stream requires to
-  // see a JSON-line delimiter as the very first item
-  SymbolOffsetT const delimiter_offset =
-    (format == tokenizer_pda::json_format_cfg_t::JSON_LINES_RECOVER ? 1 : 0);
 
   // Run FST to estimate the size of output buffers
   json_to_tokens_fst.Transduce(zip_in,

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -2062,11 +2062,6 @@ TEST_F(JsonReaderTest, JSONLinesRecovering)
 
 TEST_F(JsonReaderTest, JSONLinesRecoveringMalformedOpenBraces)
 {
-  /**
-   * @brief Test that recovery mode handles multiple malformed lines with just open braces.
-   * This is a regression test for a bug where the token count estimate didn't account for
-   * the delimiter_offset in recovery mode, causing an assertion failure.
-   */
   std::string data =
     // Two lines with just an open brace (malformed JSON)
     "{\n"

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -2073,8 +2073,9 @@ TEST_F(JsonReaderTest, JSONLinesRecoveringMalformedOpenBraces)
     "{";
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>{
-      reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true)
       .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL);
 

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -2060,6 +2060,30 @@ TEST_F(JsonReaderTest, JSONLinesRecovering)
                     c_validity.cbegin()});
 }
 
+TEST_F(JsonReaderTest, JSONLinesRecoveringMalformedOpenBraces)
+{
+  /**
+   * @brief Test that recovery mode handles multiple malformed lines with just open braces.
+   * This is a regression test for a bug where the token count estimate didn't account for
+   * the delimiter_offset in recovery mode, causing an assertion failure.
+   */
+  std::string data =
+    // Two lines with just an open brace (malformed JSON)
+    "{\n"
+    "{";
+
+  cudf::io::json_reader_options in_options =
+    cudf::io::json_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+      .lines(true)
+      .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL);
+
+  cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
+
+  // All rows are invalid with no schema to infer, so we expect 0 rows
+  EXPECT_EQ(result.tbl->num_rows(), 0);
+}
+
 TEST_F(JsonReaderTest, JSONLinesRecoveringIgnoreExcessChars)
 {
   /**


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/spark-rapids/issues/14813
Fixes an assertion failure in the JSON reader when parsing malformed JSON in recovery mode:
```
nested_json_gpu.cu:1681: Generated token count exceeds the expected token count
```

The `max_token_out_count` estimate didn't account for `delimiter_offset` (a synthetic `LineEnd` token prepended in `JSON_LINES_RECOVER` mode). For small malformed inputs, `num_total_tokens` could exceed `max_token_out_count`, triggering the assertion.

The fix is to move `delimiter_offset` calculation before `max_token_out_count` and include it in the estimate.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
