### PR TITLE
Reduce some input data sizes for cudf_polars unit tests

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -835,13 +835,11 @@ class Scan(IR):
                 # TODO: Nested column names
                 names = chunk.column_names(include_children=False)
                 concatenated_columns = chunk.tbl.columns()
-                while reader.has_next():  # pragma: no cover
+                while reader.has_next():
                     columns = reader.read_chunk().tbl.columns()
                     # Discard columns while concatenating to reduce memory footprint.
                     # Reverse order to avoid O(n^2) list popping cost.
-                    for i in range(  # pragma: no cover
-                        len(concatenated_columns) - 1, -1, -1
-                    ):
+                    for i in reversed(range(len(concatenated_columns))):
                         concatenated_columns[i] = plc.concatenate.concatenate(
                             [concatenated_columns[i], columns.pop()], stream=stream
                         )

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -27,9 +27,9 @@ def _assert_stable_ids_match(orig, loaded) -> None:
 def df():
     return pl.LazyFrame(
         {
-            "x": range(30_000),
-            "y": [1, 2, 3] * 10_000,
-            "z": [1.0, 2.0, 3.0, 4.0, 5.0] * 6_000,
+            "x": range(3_000),
+            "y": [1, 2, 3] * 1_000,
+            "z": [1.0, 2.0, 3.0, 4.0, 5.0] * 600,
         }
     )
 

--- a/python/cudf_polars/tests/experimental/test_explain.py
+++ b/python/cudf_polars/tests/experimental/test_explain.py
@@ -30,9 +30,9 @@ if TYPE_CHECKING:
 def df():
     return pl.DataFrame(
         {
-            "x": range(25_000),
-            "y": ["cat", "dog"] * 12_500,
-            "z": [1.0, 2.0] * 12_500,
+            "x": range(30),
+            "y": ["cat", "dog"] * 15,
+            "z": [1.0, 2.0] * 15,
         }
     )
 

--- a/python/cudf_polars/tests/experimental/test_io_multirank.py
+++ b/python/cudf_polars/tests/experimental/test_io_multirank.py
@@ -31,9 +31,9 @@ pytestmark = [
 def df() -> pl.LazyFrame:
     return pl.LazyFrame(
         {
-            "x": range(30_000),
-            "y": [1, 2, None] * 10_000,
-            "z": ["ẅ", "a", "z", "123", "abcd"] * 6_000,
+            "x": range(30),
+            "y": [1, 2, None] * 10,
+            "z": ["ẅ", "a", "z", "123", "abcd"] * 6,
         }
     )
 
@@ -44,7 +44,7 @@ def engine(
 ) -> StreamingEngine:
     """Yield each supported streaming engine pinned to small partitions."""
     return streaming_engine_factory(
-        StreamingOptions(max_rows_per_partition=1_000),
+        StreamingOptions(max_rows_per_partition=10),
     )
 
 

--- a/python/cudf_polars/tests/experimental/test_sink.py
+++ b/python/cudf_polars/tests/experimental/test_sink.py
@@ -17,17 +17,17 @@ from cudf_polars.testing.asserts import assert_sink_result_equal
 def df():
     return pl.LazyFrame(
         {
-            "x": range(30_000),
-            "y": [1, 2, None] * 10_000,
-            "z": ["ẅ", "a", "z", "123", "abcd"] * 6_000,
+            "x": range(30),
+            "y": [1, 2, None] * 10,
+            "z": ["ẅ", "a", "z", "123", "abcd"] * 6,
         }
     )
 
 
 @pytest.mark.parametrize("mkdir", [True, False])
-@pytest.mark.parametrize("data_page_size", [None, 256_000])
-@pytest.mark.parametrize("row_group_size", [None, 1_000])
-@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+@pytest.mark.parametrize("data_page_size", [None, 1024])
+@pytest.mark.parametrize("row_group_size", [None, 10])
+@pytest.mark.parametrize("max_rows_per_partition", [10, 1_000_000])
 def test_sink_parquet_single_file(
     df,
     streaming_engine_factory,
@@ -53,9 +53,9 @@ def test_sink_parquet_single_file(
 
 
 @pytest.mark.parametrize("mkdir", [True, False])
-@pytest.mark.parametrize("data_page_size", [None, 256_000])
-@pytest.mark.parametrize("row_group_size", [None, 1_000])
-@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+@pytest.mark.parametrize("data_page_size", [None, 1024])
+@pytest.mark.parametrize("row_group_size", [None, 10])
+@pytest.mark.parametrize("max_rows_per_partition", [10, 1_000_000])
 def test_sink_parquet_directory(
     df,
     streaming_engine_factory,
@@ -104,7 +104,7 @@ def test_sink_parquet_raises(df: pl.LazyFrame, tmp_path, streaming_engine_factor
 @pytest.mark.parametrize("include_header", [True, False])
 @pytest.mark.parametrize("null_value", [None, "NA"])
 @pytest.mark.parametrize("separator", [",", "|"])
-@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+@pytest.mark.parametrize("max_rows_per_partition", [10, 1_000_000])
 def test_sink_csv(
     df,
     streaming_engine_factory,
@@ -135,7 +135,7 @@ def test_sink_csv(
     )
 
 
-@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+@pytest.mark.parametrize("max_rows_per_partition", [10, 1_000_000])
 def test_sink_ndjson(df, streaming_engine_factory, tmp_path, max_rows_per_partition):
     engine = streaming_engine_factory(
         StreamingOptions(

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -15,7 +15,7 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
-from cudf_polars.testing.engine_utils import get_blocksize_mode, is_streaming_engine
+from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
 )
@@ -292,18 +292,13 @@ def test_groupby_nested_list_struct_raises(dtype):
     assert_ir_translation_raises(q, NotImplementedError)
 
 
-@pytest.mark.parametrize("nrows", [30, 300, 300_000])
 @pytest.mark.parametrize("nkeys", [1, 2, 4])
 def test_groupby_maintain_order_random(
     engine: pl.GPUEngine,
-    nrows,
-    nkeys,
-    with_nulls,
+    nkeys: int,
+    with_nulls: bool,  # noqa: FBT001
 ):
-    if nrows > 30 and (
-        get_blocksize_mode(engine) == "small" or is_streaming_engine(engine)
-    ):
-        pytest.skip("streaming executor too slow for large n_rows")
+    nrows = 30
     key_names = [f"key{key}" for key in range(nkeys)]
     rng = random.Random(2)
     key_values = [rng.choices(range(100), k=nrows) for _ in key_names]

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -416,6 +416,8 @@ def chunked_df(df, tmpdir_factory, chunked_slice):
         (0, 1),
         (1, 0),
         (1, 1),
+        (2, 1),
+        (1, 2),
     ],
     ids=lambda x: f"limit_{x}",
 )

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -390,14 +390,13 @@ def chunked_slice(request):
 
 
 @pytest.fixture(scope="module")
-def large_df(df, tmpdir_factory, chunked_slice):
-    # Something big enough that we get more than a single chunk,
-    # empirically determined
-    df = pl.concat([df] * 1000)
-    df = pl.concat([df] * 10)
-    df = pl.concat([df] * 10)
-    path = str(tmpdir_factory.mktemp("data") / "large.pq")
-    make_partitioned_source(df, path, "parquet")
+def chunked_df(df, tmpdir_factory, chunked_slice):
+    # Many small row groups so that ``pass_read_limit`` (one pass per row
+    # group) and ``chunk_read_limit`` (one output chunk per page within a
+    # pass) can force the libcudf chunked reader to return multiple chunks.
+    df = pl.concat([df] * 100)
+    path = str(tmpdir_factory.mktemp("data") / "chunked.pq")
+    make_partitioned_source(df, path, "parquet", row_group_size=10)
     n_rows = len(df)
     q = pl.scan_parquet(path)
     if chunked_slice == "no_slice":
@@ -411,24 +410,28 @@ def large_df(df, tmpdir_factory, chunked_slice):
 
 
 @pytest.mark.parametrize(
-    "chunk_read_limit", [0, 1, 2, 4, 8, 16], ids=lambda x: f"chunk_{x}"
-)
-@pytest.mark.parametrize(
-    "pass_read_limit", [0, 1, 2, 4, 8, 16], ids=lambda x: f"pass_{x}"
+    "chunk_read_limit, pass_read_limit",
+    [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+    ],
+    ids=lambda x: f"limit_{x}",
 )
 @pytest.mark.parametrize(
     "filter", [None, pl.col("a") > 3], ids=["no_filters", "with_filters"]
 )
 def test_scan_parquet_chunked(
-    large_df,
+    chunked_df,
     chunk_read_limit,
     pass_read_limit,
     filter,
 ):
     if filter is None:
-        q = large_df
+        q = chunked_df
     else:
-        q = large_df.filter(filter)
+        q = chunked_df.filter(filter)
     assert_gpu_result_equal(
         q,
         engine=pl.GPUEngine(


### PR DESCRIPTION
## Description
Related to our discussion about large data allocations in the cudf_polars tests suite, I had Claude identify tests and reduce LazyFrame input sizes while preserving the intent to test single vs multi-partition paths.

Additionally identified that `test_scan_parquet_chunked` wasn't actually covering our (in memory) chunked parquet reader with more than 1 chunk.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
