### PR TITLE
Use `nvcompGetStatusString` when available

### DIFF
--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -27,7 +27,6 @@ namespace {
 [[nodiscard]] std::string nvcomp_status_to_string(nvcompStatus_t status)
 {
 #if NVCOMP_VER_MAJOR > 5 || (NVCOMP_VER_MAJOR == 5 && NVCOMP_VER_MINOR >= 2)
-  // nvcompGetStatusString added in nvcomp 5.2
   if (auto const* str = nvcompGetStatusString(status); str != nullptr) { return str; }
   return "nvcompStatus_t(" + std::to_string(static_cast<int>(status)) + ")";
 #else

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,6 +26,11 @@ namespace {
 
 [[nodiscard]] std::string nvcomp_status_to_string(nvcompStatus_t status)
 {
+#if NVCOMP_VER_MAJOR > 5 || (NVCOMP_VER_MAJOR == 5 && NVCOMP_VER_MINOR >= 2)
+  // nvcompGetStatusString added in nvcomp 5.2
+  if (auto const* str = nvcompGetStatusString(status); str != nullptr) { return str; }
+  return "nvcompStatus_t(" + std::to_string(static_cast<int>(status)) + ")";
+#else
   switch (status) {
     case nvcompStatus_t::nvcompSuccess: return "nvcompSuccess";
     case nvcompStatus_t::nvcompErrorInvalidValue: return "nvcompErrorInvalidValue";
@@ -47,6 +52,7 @@ namespace {
 #endif
   }
   return "nvcompStatus_t(" + std::to_string(static_cast<int>(status)) + ")";
+#endif
 }
 
 [[nodiscard]] std::string compression_type_name(compression_type compression)


### PR DESCRIPTION
Replaces the hand-maintained switch over `nvcompStatus_t` values in the nvCOMP adapter with a call to `nvcompGetStatusString` (added in nvcomp 5.2), falling back to the existing switch on older nvcomp versions.