### PR TITLE
Add nvtx annotations to more cudf-polars IO

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -350,6 +350,7 @@ _COMPARISON_BINOPS = {
 }
 
 
+@nvtx_annotate_cudf_polars(message="_parquet_physical_types")
 def _parquet_physical_types(
     paths: list[str], columns: list[str] | None
 ) -> dict[str, plc.DataType]:
@@ -648,6 +649,7 @@ class Scan(IR):
             [Column(filepaths, name=name, dtype=dtype)], stream=df.stream
         )
 
+    @nvtx_annotate_cudf_polars(message="Scan.fast_count")
     def fast_count(self) -> int:  # pragma: no cover
         """Get the number of rows in a Parquet Scan."""
         meta = plc.io.parquet_metadata.read_parquet_metadata(
@@ -659,6 +661,7 @@ class Scan(IR):
         return max(total_rows, 0)
 
     @staticmethod
+    @nvtx_annotate_cudf_polars(message="Scan._get_parquet_row_count_from_metadata")
     def _get_parquet_row_count_from_metadata(
         paths: list[str], skip_rows: int, n_rows: int
     ) -> int:

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -352,10 +352,7 @@ def get_data(path: str | Path, table_name: str, suffix: str = "") -> pl.LazyFram
     local filesystem, falls back to scanning ``{path}/{table_name}`` as a
     directory of parquet files.
     """
-    file_path = Path(path) / f"{table_name}{suffix}"
-    if suffix and not file_path.exists():
-        # Directory-based layout: e.g. tpch-rs partitioned output
-        return pl.scan_parquet(Path(path) / table_name)
+    file_path = str(path).removesuffix("/") + f"/{table_name}{suffix}"
     return pl.scan_parquet(file_path)
 
 

--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -23,6 +23,7 @@ from cudf_polars.dsl.ir import (
     Scan,
     Sink,
 )
+from cudf_polars.dsl.tracing import nvtx_annotate_cudf_polars
 from cudf_polars.experimental.base import (
     IOPartitionFlavor,
     IOPartitionPlan,
@@ -460,6 +461,7 @@ class ParquetMetadata:
     sample_paths: tuple[str, ...]
     """Sampled file paths."""
 
+    @nvtx_annotate_cudf_polars(message="ParquetMetadata")
     def __init__(self, paths: tuple[str, ...], max_footer_samples: int):
         self.paths = paths
         self.max_footer_samples = max_footer_samples
@@ -513,6 +515,7 @@ class ParquetMetadata:
         self.row_count = row_count
 
 
+@nvtx_annotate_cudf_polars(message="_sample_rg_sizes")
 def _sample_rg_sizes(
     metadata: ParquetMetadata,
     target_cols: list[str],

--- a/python/cudf_polars/cudf_polars/experimental/statistics.py
+++ b/python/cudf_polars/cudf_polars/experimental/statistics.py
@@ -16,7 +16,10 @@ if TYPE_CHECKING:
     from cudf_polars.dsl.ir import IR
     from cudf_polars.utils.config import ConfigOptions, StreamingExecutor
 
+from cudf_polars.dsl.tracing import nvtx_annotate_cudf_polars
 
+
+@nvtx_annotate_cudf_polars(message="collect_statistics")
 def collect_statistics(
     root: IR,
     config_options: ConfigOptions[StreamingExecutor],


### PR DESCRIPTION
## Description

This adds some more nvtx annotations to spots where cudf-polars does IO

- statistics gathering (both metadata reads and row group sampling)
- schema inspection
- fast-paths for `scan_parquet().select().count()`


<img width="1621" height="482" alt="Screenshot 2026-05-19 at 8 01 30 AM" src="https://github.com/user-attachments/assets/2268d320-41a0-4b7f-a275-ed9d8f63561c" />


And it reapplies a change from https://github.com/rapidsai/cudf/pull/22005 to the benchmark script that was dropped with the CLI refactor.