### PR TITLE
Fix AST `resolve_input` to preserve decimal intermediate scale on readback

### DIFF
--- a/cpp/include/cudf/ast/detail/expression_evaluator.cuh
+++ b/cpp/include/cudf/ast/detail/expression_evaluator.cuh
@@ -309,9 +309,23 @@ struct expression_evaluator {
       // Using a temporary variable ensures that the compiler knows the result is aligned
       IntermediateDataType<has_nulls> intermediate =
         thread_intermediate_storage[input_reference.data_index];
-      ReturnType tmp;
-      memcpy(&tmp, &intermediate, sizeof(ReturnType));
-      return tmp;
+      if constexpr (cuda::std::is_same_v<Element, numeric::decimal32> or
+                    cuda::std::is_same_v<Element, numeric::decimal64>) {
+        using RepType    = typename Element::rep;
+        auto const scale = numeric::scale_type{input_reference.data_type.scale()};
+        if constexpr (has_nulls) {
+          if (not intermediate.has_value()) { return ReturnType{}; }
+          auto const rep = static_cast<RepType>(*intermediate);
+          return ReturnType{Element{numeric::scaled_integer<RepType>{rep, scale}}};
+        } else {
+          auto const rep = static_cast<RepType>(intermediate);
+          return ReturnType{Element{numeric::scaled_integer<RepType>{rep, scale}}};
+        }
+      } else {
+        ReturnType tmp;
+        memcpy(&tmp, &intermediate, sizeof(ReturnType));
+        return tmp;
+      }
     }
     // Unreachable return used to silence compiler warnings.
     return {};

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -1367,6 +1367,92 @@ TYPED_TEST(DecimalTests, DecimalDifferentScales)
   }
 }
 
+TYPED_TEST(DecimalTests, LessConsumesMulOfDecimalsAstIntermediate)
+{
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  auto const scale = numeric::scale_type{-2};
+
+  // col_a    in {1, 2, 5, 10, 25, 50}.00      (reps 100, 200, 500, 1000, 2500, 5000)
+  // col_thresh = 0.20                         (rep 20)
+  // col_avg    = 25.00                        (rep 2500)
+  // expected: col_a < (col_thresh * col_avg) = col_a < 5.00 => [1,1,0,0,0,0]
+  auto col_a = cudf::test::fixed_point_column_wrapper<RepType>(
+    {RepType{100}, RepType{200}, RepType{500}, RepType{1000}, RepType{2500}, RepType{5000}}, scale);
+  auto col_thresh = cudf::test::fixed_point_column_wrapper<RepType>(
+    {RepType{20}, RepType{20}, RepType{20}, RepType{20}, RepType{20}, RepType{20}}, scale);
+  auto col_avg = cudf::test::fixed_point_column_wrapper<RepType>(
+    {RepType{2500}, RepType{2500}, RepType{2500}, RepType{2500}, RepType{2500}, RepType{2500}},
+    scale);
+  auto table = cudf::table_view{{col_a, col_thresh, col_avg}};
+
+  // Fused AST: col_a < (col_thresh * col_avg)
+  // The MUL produces a fixed_point intermediate at scale -4 (rep 50000, value 5.0000).
+  // LESS then rescales both operands to the common scale before comparing.
+  auto ref_a      = cudf::ast::column_reference(0);
+  auto ref_thresh = cudf::ast::column_reference(1);
+  auto ref_avg    = cudf::ast::column_reference(2);
+  cudf::ast::tree tree{};
+  auto const& mul_expr =
+    tree.push(cudf::ast::operation(cudf::ast::ast_operator::MUL, ref_thresh, ref_avg));
+  auto const& lt_expr =
+    tree.push(cudf::ast::operation(cudf::ast::ast_operator::LESS, ref_a, mul_expr));
+
+  auto const expected = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 0, 0, 0, 0};
+
+  auto result = cudf::compute_column(table, lt_expr);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
+
+  result = cudf::compute_column_jit(table, lt_expr);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
+}
+
+TYPED_TEST(DecimalTests, LessConsumesMulOfDecimalsWithNullsAstIntermediate)
+{
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  auto const scale = numeric::scale_type{-2};
+
+  // Same shape as LessConsumesMulOfDecimalsAstIntermediate but exercises the
+  // has_nulls=true intermediate-slot path (cuda::std::optional<int64_t>).
+  // Null bits chosen so each side has at least one null row mid-table.
+  auto col_a = cudf::test::fixed_point_column_wrapper<RepType>(
+    {RepType{100}, RepType{200}, RepType{500}, RepType{1000}, RepType{2500}, RepType{5000}},
+    {1, 1, 1, 0, 1, 1},
+    scale);
+  auto col_thresh = cudf::test::fixed_point_column_wrapper<RepType>(
+    {RepType{20}, RepType{20}, RepType{20}, RepType{20}, RepType{20}, RepType{20}},
+    {1, 1, 1, 1, 1, 0},
+    scale);
+  auto col_avg = cudf::test::fixed_point_column_wrapper<RepType>(
+    {RepType{2500}, RepType{2500}, RepType{2500}, RepType{2500}, RepType{2500}, RepType{2500}},
+    {1, 1, 1, 1, 1, 1},
+    scale);
+  auto table = cudf::table_view{{col_a, col_thresh, col_avg}};
+
+  auto ref_a      = cudf::ast::column_reference(0);
+  auto ref_thresh = cudf::ast::column_reference(1);
+  auto ref_avg    = cudf::ast::column_reference(2);
+  cudf::ast::tree tree{};
+  auto const& mul_expr =
+    tree.push(cudf::ast::operation(cudf::ast::ast_operator::MUL, ref_thresh, ref_avg));
+  auto const& lt_expr =
+    tree.push(cudf::ast::operation(cudf::ast::ast_operator::LESS, ref_a, mul_expr));
+
+  // Rows 3 (col_a null) and 5 (col_thresh null) propagate null through the
+  // comparison; remaining rows are col_a < 5.00.
+  auto const expected =
+    cudf::test::fixed_width_column_wrapper<bool>{{1, 1, 0, 0, 0, 0}, {1, 1, 1, 0, 1, 0}};
+
+  auto result = cudf::compute_column(table, lt_expr);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
+
+  result = cudf::compute_column_jit(table, lt_expr);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
+}
+
 TYPED_TEST(TransformTest, NonDefaultStream)
 {
   // This test ensures that the algorithm is stream safe when a nondefault


### PR DESCRIPTION
## Description

Closes #22506.

This is the read-side counterpart to #21996. PR #21996 fixed the write half
of the fixed-point AST intermediate problem (`resolve_output` strips the
`fixed_point` struct down to its rep before writing into the 8-byte
intermediate slot, and `return_type_functor` was taught to compute the
correct intermediate scale). The read half was untouched: `resolve_input`
was doing `memcpy(sizeof(ReturnType))` for every type, which for
`fixed_point<int{32,64}_t>` copied 16 bytes out of the 8-byte slot and
picked up adjacent stack/register bytes as `_scale`. Any downstream
operator that called `rescaled()` on its operands — comparisons
(`LESS` / `GREATER` / `EQUAL`), `ADD`, `SUB` — then silently produced wrong
results. `MUL` / `DIV` consumers hid the bug because their per-element
functors only touch the rep, which is why existing decimal-AST coverage
(`NestedDecimalArithmetic`, the repros in #21980 / #22122) didn't surface
it.

### Fix

Add a `constexpr if` branch to the `INTERMEDIATE` arm of `resolve_input`
for `decimal32` / `decimal64`: read the rep as `int{32,64}_t` from the
slot and rebuild the `fixed_point` using the scale already carried in
`input_reference.data_type` (which the parser populates via
`return_type_functor`). The `has_nulls` path unwraps the
`cuda::std::optional<int64_t>` slot accordingly.

The slot width is unchanged, so #21996's `decimal128` deferral
(*"`decimal128` support is deferred since the maximum intermediate-value
type size is `int64`"*) still applies — `resolve_input` is unchanged for
that type.

### Tests

Two new `TYPED_TEST` cases on the existing `DecimalTests` fixture
(`decimal32` and `decimal64`), all of which fail before this change and
pass after:

- `LessConsumesMulOfDecimalsAstIntermediate` — the exact shape from
  #22506 (`col_a < (col_thresh * col_avg)`), demonstrating the comparison
  consumer reading a corrupted `_scale`. Before fix: `[1,1,1,1,1,1]`;
  after fix: `[1,1,0,0,0,0]`.
- `LessConsumesMulOfDecimalsWithNullsAstIntermediate` — exercises the
  `has_nulls = true` slot (`cuda::std::optional<int64_t>`) path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.