### PR TITLE
Clone rapidsmpf before devcontainer env creation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -669,7 +669,6 @@ jobs:
       node_type: "cpu8"
       timeout-minutes: 90
       env: |
-        CONDA_ENV_CREATE_QUIET=true
         SCCACHE_DIST_MAX_RETRIES=inf
         SCCACHE_SERVER_LOG=sccache=debug
         SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -669,6 +669,7 @@ jobs:
       node_type: "cpu8"
       timeout-minutes: 90
       env: |
+        CONDA_ENV_CREATE_QUIET=true
         SCCACHE_DIST_MAX_RETRIES=inf
         SCCACHE_SERVER_LOG=sccache=debug
         SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -662,7 +662,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@fix/make-python-env-creation-success-optional
     with:
       arch: '["amd64", "arm64"]'
       cuda: '["13.2"]'
@@ -672,14 +672,14 @@ jobs:
         SCCACHE_DIST_MAX_RETRIES=inf
         SCCACHE_SERVER_LOG=sccache=debug
         SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
-      # clone-rapidsmpf to not use the rapidsmpf wheels from cudf_polars dependency
+      # Call clone-rapidsmpf before creating the Python env to exclude cudf_polars' dependency on rapidsmpf
       # librapidsmpf-cu13 wheels brings in a hardcoded libnuma-dev cmake target: https://github.com/NVIDIA/cuCascade/issues/118
       # -DBUILD_TESTS=OFF to match rapidsmpf https://github.com/rapidsai/rapidsmpf/blob/main/.github/workflows/pr.yaml#L351 (leads to compilation errors)
       # -DCUDF_BUILD_TESTUTIL=OFF to avoid IMPORTED_GLOBAL promotion errors when cuCascade's find_package(cudf) loads cudf-config.cmake from a CPM subdirectory
       build_command: |
         sccache --zero-stats;
         clone-rapidsmpf -j$(nproc) -v -q --branch "$(cat ~/cudf/RAPIDS_BRANCH)" --clone-upstream --depth 1 --single-branch --shallow-submodules;
-        if [ "$PYTHON_PACKAGE_MANAGER" = "pip" ]; then rapids-make-pip-env --force; elif [ "$PYTHON_PACKAGE_MANAGER" = "conda" ]; then rapids-make-conda-env --force; fi;
+        rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
         rapids-generate-scripts;
         build-all -j0 -DBUILD_BENCHMARKS=OFF -DBUILD_NUMA_SUPPORT=OFF -DBUILD_TESTS=OFF -DCUDF_BUILD_TESTUTIL=OFF --verbose 2>&1 | tee telemetry-artifacts/build.log;
         sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -662,7 +662,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@fix/make-python-env-creation-success-optional
+    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
     with:
       arch: '["amd64", "arm64"]'
       cuda: '["13.2"]'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -679,8 +679,6 @@ jobs:
       build_command: |
         sccache --zero-stats;
         clone-rapidsmpf -j$(nproc) -v -q --branch "$(cat ~/cudf/RAPIDS_BRANCH)" --clone-upstream --depth 1 --single-branch --shallow-submodules;
-        rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
-        rapids-generate-scripts;
         build-all -j0 -DBUILD_BENCHMARKS=OFF -DBUILD_NUMA_SUPPORT=OFF -DBUILD_TESTS=OFF -DCUDF_BUILD_TESTUTIL=OFF --verbose 2>&1 | tee telemetry-artifacts/build.log;
         sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
   unit-tests-cudf-pandas:


### PR DESCRIPTION
## Description
Update the devcontainer PR job to clone rapidsmpf before the repo-owned Python environment creation step, so cudf devcontainers include rapidsmpf from source instead of solving against published rapidsmpf packages pulled in through cudf_polars dependencies.

Depends on rapidsai/shared-workflows#553.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.