### PR TITLE
Patch Arrow to set CMAKE_POLICY_VERSION_MINIMUM for RapidJSON

### DIFF
--- a/cpp/cmake/thirdparty/patches/arrow_rapidjson_cmake_policy_version_minimum.diff
+++ b/cpp/cmake/thirdparty/patches/arrow_rapidjson_cmake_policy_version_minimum.diff
@@ -1,0 +1,15 @@
+diff --git a/cpp/cmake_modules/FindRapidJSONAlt.cmake b/cpp/cmake_modules/FindRapidJSONAlt.cmake
+index babb450e20..148dd93a78 100644
+--- a/cpp/cmake_modules/FindRapidJSONAlt.cmake
++++ b/cpp/cmake_modules/FindRapidJSONAlt.cmake
+@@ -26,7 +26,10 @@ endif()
+ if(RapidJSONAlt_FIND_QUIETLY)
+   list(APPEND find_package_args QUIET)
+ endif()
++set(_CMAKE_POLICY_VERSION_MINIMUM_OLD ${CMAKE_POLICY_VERSION_MINIMUM})
++set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+ find_package(RapidJSON ${find_package_args})
++set(CMAKE_POLICY_VERSION_MINIMUM ${_CMAKE_POLICY_VERSION_MINIMUM_OLD})
+ if(RapidJSON_FOUND)
+   set(RapidJSONAlt_FOUND TRUE)
+   if(NOT TARGET RapidJSON)

--- a/cpp/cmake/thirdparty/patches/override.json
+++ b/cpp/cmake/thirdparty/patches/override.json
@@ -9,7 +9,7 @@
       "patches" : [
         {
           "file" : "${current_json_dir}/arrow_rapidjson_cmake_policy_version_minimum.diff",
-          "issue": "https://github.com/apache/arrow/issues/48801"
+          "issue": "https://github.com/apache/arrow/pull/49993"
         }
       ],
       "source_subdir": "cpp"

--- a/cpp/cmake/thirdparty/patches/override.json
+++ b/cpp/cmake/thirdparty/patches/override.json
@@ -1,0 +1,18 @@
+
+{
+  "packages" : {
+    "arrow" : {
+      "version" : "21.0.0",
+      "git_url" : "https://github.com/apache/arrow.git",
+      "git_tag" : "apache-arrow-${version}",
+      "git_shallow" : false,
+      "patches" : [
+        {
+          "file" : "${current_json_dir}/arrow_rapidjson_cmake_policy_version_minimum.diff",
+          "issue": "https://github.com/apache/arrow/issues/48801"
+        }
+      ],
+      "source_subdir": "cpp"
+    }
+  }
+}

--- a/cpp/cmake/thirdparty/patches/override.json
+++ b/cpp/cmake/thirdparty/patches/override.json
@@ -1,14 +1,13 @@
-
 {
-  "packages" : {
-    "arrow" : {
-      "version" : "21.0.0",
-      "git_url" : "https://github.com/apache/arrow.git",
-      "git_tag" : "apache-arrow-${version}",
-      "git_shallow" : false,
-      "patches" : [
+  "packages": {
+    "arrow": {
+      "version": "21.0.0",
+      "git_url": "https://github.com/apache/arrow.git",
+      "git_tag": "apache-arrow-${version}",
+      "git_shallow": false,
+      "patches": [
         {
-          "file" : "${current_json_dir}/arrow_rapidjson_cmake_policy_version_minimum.diff",
+          "file": "${current_json_dir}/arrow_rapidjson_cmake_policy_version_minimum.diff",
           "issue": "https://github.com/apache/arrow/pull/49993"
         }
       ],

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -12,7 +12,9 @@ include(rapids-cmake)
 include(rapids-cuda)
 include(rapids-find)
 include(rapids-cpm)
-rapids_cpm_init()
+rapids_cpm_init(
+  OVERRIDE "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cpp/cmake/thirdparty/patches/override.json"
+)
 
 rapids_cuda_init_architectures(CUDF_JNI)
 


### PR DESCRIPTION
## Description
Provide a patch for https://github.com/apache/arrow/issues/48801

Fixes https://github.com/rapidsai/cudf/issues/22540

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
