### PR TITLE
pylibcudf read_parquet accepts pre-materialized FileMetadata

### DIFF
--- a/python/pylibcudf/pylibcudf/io/__init__.py
+++ b/python/pylibcudf/pylibcudf/io/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from . import (
@@ -14,9 +14,11 @@ from . import (
     timezone,
     types,
 )
+from .parquet_metadata import FileMetaData
 from .types import SinkInfo, SourceInfo, TableWithMetadata
 
 __all__ = [
+    "FileMetaData",
     "SinkInfo",
     "SourceInfo",
     "TableWithMetadata",

--- a/python/pylibcudf/pylibcudf/io/experimental/__init__.py
+++ b/python/pylibcudf/pylibcudf/io/experimental/__init__.py
@@ -1,14 +1,14 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from pylibcudf.io.experimental.hybrid_scan import (
-    FileMetaData,
     HybridScanReader,
     UseDataPageMask,
 )
+from pylibcudf.io.parquet_metadata import FileMetaData
 
 __all__ = [
-    "FileMetaData",
+    "FileMetaData",  # backwards compatibility
     "HybridScanReader",
     "UseDataPageMask",
 ]

--- a/python/pylibcudf/pylibcudf/io/experimental/hybrid_scan.pxd
+++ b/python/pylibcudf/pylibcudf/io/experimental/hybrid_scan.pxd
@@ -10,24 +10,17 @@ from rmm.pylibrmm.stream cimport Stream
 
 from pylibcudf.column cimport Column
 from pylibcudf.io.parquet cimport ParquetReaderOptions
+from pylibcudf.io.parquet_metadata cimport FileMetaData as c_FileMetaData
 from pylibcudf.io.types cimport TableWithMetadata
 from pylibcudf.libcudf.io.hybrid_scan cimport (
     hybrid_scan_reader as cpp_hybrid_scan_reader,
     use_data_page_mask,
 )
-from pylibcudf.libcudf.io.parquet_schema cimport FileMetaData as cpp_FileMetaData
 from pylibcudf.libcudf.io.hybrid_scan cimport const_uint8_t
 from pylibcudf.libcudf.utilities.span cimport device_span
 
 
 cdef device_span[const_uint8_t] _get_device_span(object obj) except *
-
-
-cdef class FileMetaData:
-    cdef cpp_FileMetaData c_obj
-
-    @staticmethod
-    cdef FileMetaData from_cpp(cpp_FileMetaData metadata)
 
 
 cdef class HybridScanReader:

--- a/python/pylibcudf/pylibcudf/io/experimental/hybrid_scan.pyi
+++ b/python/pylibcudf/pylibcudf/io/experimental/hybrid_scan.pyi
@@ -7,6 +7,7 @@ from rmm.pylibrmm.memory_resource import DeviceMemoryResource
 
 from pylibcudf.column import Column
 from pylibcudf.io.parquet import ParquetReaderOptions
+from pylibcudf.io.parquet_metadata import FileMetaData
 from pylibcudf.io.text import ByteRangeInfo
 from pylibcudf.io.types import TableWithMetadata
 from pylibcudf.span import Span
@@ -20,14 +21,6 @@ except ImportError:
 class UseDataPageMask(IntEnum):
     YES: int
     NO: int
-
-class FileMetaData:
-    @property
-    def version(self) -> int: ...
-    @property
-    def num_rows(self) -> int: ...
-    @property
-    def created_by(self) -> str: ...
 
 class HybridScanReader:
     def __init__(

--- a/python/pylibcudf/pylibcudf/io/experimental/hybrid_scan.pyx
+++ b/python/pylibcudf/pylibcudf/io/experimental/hybrid_scan.pyx
@@ -13,6 +13,7 @@ from rmm.pylibrmm.stream cimport Stream
 
 from pylibcudf.column cimport Column
 from pylibcudf.io.parquet cimport ParquetReaderOptions
+from pylibcudf.io.parquet_metadata cimport FileMetaData as c_FileMetaData
 from pylibcudf.io.text cimport ByteRangeInfo
 from pylibcudf.io.types cimport TableWithMetadata
 from pylibcudf.libcudf.column.column cimport column
@@ -24,7 +25,6 @@ from pylibcudf.libcudf.io.hybrid_scan cimport (
     hybrid_scan_reader as cpp_hybrid_scan_reader,
     use_data_page_mask as cpp_use_data_page_mask,
 )
-from pylibcudf.libcudf.io.parquet_schema cimport FileMetaData as cpp_FileMetaData
 from pylibcudf.libcudf.io.text cimport byte_range_info
 from pylibcudf.libcudf.io.types cimport table_with_metadata
 from pylibcudf.libcudf.types cimport size_type
@@ -32,16 +32,13 @@ from pylibcudf.libcudf.utilities.span cimport device_span, host_span
 from pylibcudf.utils cimport _get_memory_resource, _get_stream
 
 from pylibcudf.span import is_span
+from pylibcudf.io.parquet_metadata import FileMetaData
 
 import pylibcudf.libcudf.io.hybrid_scan
 
 UseDataPageMask = pylibcudf.libcudf.io.hybrid_scan.use_data_page_mask
 
-__all__ = [
-    "FileMetaData",
-    "HybridScanReader",
-    "UseDataPageMask",
-]
+__all__ = ["FileMetaData", "HybridScanReader", "UseDataPageMask"]
 
 
 cdef device_span[const_uint8_t] _get_device_span(object obj) except *:
@@ -53,37 +50,6 @@ cdef device_span[const_uint8_t] _get_device_span(object obj) except *:
     return device_span[const_uint8_t](<const_uint8_t*>
                                       <uintptr_t>obj.ptr,
                                       <size_t>obj.size)
-
-
-cdef class FileMetaData:
-    """Parquet file footer metadata.
-
-    For details, see :cpp:class:`cudf::io::parquet::FileMetaData`
-    """
-
-    def __init__(self):
-        raise ValueError("FileMetaData cannot be constructed directly")
-
-    @staticmethod
-    cdef FileMetaData from_cpp(cpp_FileMetaData metadata):
-        cdef FileMetaData result = FileMetaData.__new__(FileMetaData)
-        result.c_obj = metadata
-        return result
-
-    @property
-    def version(self):
-        """Get the file format version."""
-        return self.c_obj.version
-
-    @property
-    def num_rows(self):
-        """Get the total number of rows."""
-        return self.c_obj.num_rows
-
-    @property
-    def created_by(self):
-        """Get the application that created the file."""
-        return self.c_obj.created_by.decode('utf-8')
 
 
 cdef class HybridScanReader:
@@ -121,7 +87,7 @@ cdef class HybridScanReader:
         )
 
     @staticmethod
-    def from_parquet_metadata(FileMetaData metadata, ParquetReaderOptions options):
+    def from_parquet_metadata(c_FileMetaData metadata, ParquetReaderOptions options):
         """Create a HybridScanReader from pre-populated metadata.
 
         Parameters
@@ -150,7 +116,7 @@ cdef class HybridScanReader:
         FileMetaData
             Parquet file footer metadata
         """
-        return FileMetaData.from_cpp(self.c_obj.get()[0].parquet_metadata())
+        return c_FileMetaData.from_cpp(self.c_obj.get()[0].parquet_metadata())
 
     def page_index_byte_range(self):
         """Get the byte range of the page index.

--- a/python/pylibcudf/pylibcudf/io/parquet.pxd
+++ b/python/pylibcudf/pylibcudf/io/parquet.pxd
@@ -10,6 +10,7 @@ from rmm.pylibrmm.memory_resource cimport DeviceMemoryResource
 from rmm.pylibrmm.stream cimport Stream
 
 from pylibcudf.expressions cimport Expression
+from pylibcudf.io.parquet_metadata cimport FileMetaData
 
 from pylibcudf.io.types cimport (
     compression_type,
@@ -83,7 +84,10 @@ cdef class ChunkedParquetReader:
 
 
 cpdef read_parquet(
-    ParquetReaderOptions options, object stream = *, DeviceMemoryResource mr=*
+    ParquetReaderOptions options,
+    object stream = *,
+    DeviceMemoryResource mr=*,
+    object parquet_metadatas=*,
 )
 
 

--- a/python/pylibcudf/pylibcudf/io/parquet.pyi
+++ b/python/pylibcudf/pylibcudf/io/parquet.pyi
@@ -7,6 +7,7 @@ from typing import Self
 from rmm.pylibrmm.memory_resource import DeviceMemoryResource
 
 from pylibcudf.expressions import Expression
+from pylibcudf.io.parquet_metadata import FileMetaData
 from pylibcudf.io.types import (
     CompressionType,
     DictionaryPolicy,
@@ -54,8 +55,10 @@ class ChunkedParquetReader:
         self,
         options: ParquetReaderOptions,
         stream: CudaStreamLike | None = None,
+        mr: DeviceMemoryResource | None = None,
         chunk_read_limit: int = 0,
         pass_read_limit: int = 1024000000,
+        parquet_metadatas: Sequence[FileMetaData] | None = None,
     ) -> None: ...
     def has_next(self) -> bool: ...
     def read_chunk(self) -> TableWithMetadata: ...
@@ -64,6 +67,7 @@ def read_parquet(
     options: ParquetReaderOptions,
     stream: CudaStreamLike | None = None,
     mr: DeviceMemoryResource | None = None,
+    parquet_metadatas: Sequence[FileMetaData] | None = None,
 ) -> TableWithMetadata: ...
 
 class ParquetWriterOptions:

--- a/python/pylibcudf/pylibcudf/io/parquet.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet.pyx
@@ -527,12 +527,19 @@ cdef class ChunkedParquetReader:
     ----------
     options : ParquetReaderOptions
         Settings for controlling reading behavior
+    stream : Stream | None
+        CUDA stream used for device memory operations and kernel launches
+    mr : DeviceMemoryResource, optional
+        Device memory resource used to allocate the returned table's device memory.
     chunk_read_limit : size_t, default 0
         Limit on total number of bytes to be returned per read,
         or 0 if there is no limit.
     pass_read_limit : size_t, default 1024000000
         Limit on the amount of memory used for reading and decompressing data
         or 0 if there is no limit.
+    parquet_metadatas : list[FileMetaData], optional
+        Pre-materialized parquet footer metadata, one for each source. If not
+        provided, footers are read from the sources internally.
     """
     def __init__(
         self,

--- a/python/pylibcudf/pylibcudf/io/parquet.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet.pyx
@@ -94,8 +94,8 @@ cdef vector[cpp_FileMetaData] _build_parquet_metadatas(
 
     if c_metadatas.size() != num_sources:
         raise ValueError(
-            "len(parquet_metadatas) "
-            f"({c_metadatas.size()}) must match the number of input sources "
+            f"Length of 'parquet_metadatas' ({c_metadatas.size()}) "
+            f"must match the number of input sources "
             f"({num_sources})"
         )
 

--- a/python/pylibcudf/pylibcudf/io/parquet.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet.pyx
@@ -23,7 +23,9 @@ from pylibcudf.io.types cimport (
     TableInputMetadata,
     TableWithMetadata,
 )
+from pylibcudf.io.parquet_metadata cimport FileMetaData
 from pylibcudf.libcudf.expressions cimport expression
+from pylibcudf.libcudf.io.datasource cimport datasource, make_datasources
 from pylibcudf.libcudf.io.parquet cimport (
     chunked_parquet_reader as cpp_chunked_parquet_reader,
     parquet_reader_options,
@@ -36,6 +38,7 @@ from pylibcudf.libcudf.io.parquet cimport (
     chunked_parquet_writer_options,
     merge_row_group_metadata as cpp_merge_row_group_metadata,
 )
+from pylibcudf.libcudf.io.parquet_schema cimport FileMetaData as cpp_FileMetaData
 from pylibcudf.libcudf.io.types cimport (
     compression_type,
     dictionary_policy as dictionary_policy_t,
@@ -71,6 +74,32 @@ def _warn_deprecated(api_name, new_api):
         f"future version of cudf. Use {new_api} instead.",
         FutureWarning
     )
+
+
+cdef vector[cpp_FileMetaData] _build_parquet_metadatas(
+    object parquet_metadatas,
+    size_t num_sources,
+) except *:
+    cdef vector[cpp_FileMetaData] c_metadatas
+    cdef object metadata
+    if parquet_metadatas is None:
+        return c_metadatas
+
+    for metadata in parquet_metadatas:
+        if not isinstance(metadata, FileMetaData):
+            raise TypeError(
+                "parquet_metadatas must contain only FileMetaData objects"
+            )
+        c_metadatas.push_back((<FileMetaData>metadata).c_obj)
+
+    if c_metadatas.size() != num_sources:
+        raise ValueError(
+            "len(parquet_metadatas) "
+            f"({c_metadatas.size()}) must match the number of input sources "
+            f"({num_sources})"
+        )
+
+    return c_metadatas
 
 
 cdef class ParquetReaderOptions:
@@ -512,20 +541,41 @@ cdef class ChunkedParquetReader:
         DeviceMemoryResource mr = None,
         size_t chunk_read_limit=0,
         size_t pass_read_limit=1024000000,
+        object parquet_metadatas=None,
     ):
         self._stream = _get_stream(stream)
         self.mr = _get_memory_resource(mr)
+        cdef vector[unique_ptr[datasource]] sources
+        cdef vector[cpp_FileMetaData] c_metadatas
         cdef cudaStream_t stream_view = self._stream.view().value()
-        with nogil:
-            self.reader.reset(
-                new cpp_chunked_parquet_reader(
-                    chunk_read_limit,
-                    pass_read_limit,
-                    options.c_obj,
-                    stream_view,
-                    self.mr.get_mr()
+        if parquet_metadatas is None:
+            with nogil:
+                self.reader.reset(
+                    new cpp_chunked_parquet_reader(
+                        chunk_read_limit,
+                        pass_read_limit,
+                        options.c_obj,
+                        stream_view,
+                        self.mr.get_mr()
+                    )
                 )
+        else:
+            sources = make_datasources(options.c_obj.get_source())
+            c_metadatas = _build_parquet_metadatas(
+                parquet_metadatas, sources.size()
             )
+            with nogil:
+                self.reader.reset(
+                    new cpp_chunked_parquet_reader(
+                        chunk_read_limit,
+                        pass_read_limit,
+                        move(sources),
+                        move(c_metadatas),
+                        options.c_obj,
+                        stream_view,
+                        self.mr.get_mr()
+                    )
+                )
 
     __hash__ = None
 
@@ -566,7 +616,10 @@ cdef class ChunkedParquetReader:
 
 
 cpdef read_parquet(
-    ParquetReaderOptions options, object stream = None, DeviceMemoryResource mr=None
+    ParquetReaderOptions options,
+    object stream = None,
+    DeviceMemoryResource mr=None,
+    object parquet_metadatas=None,
 ):
     """
     Read from Parquet format.
@@ -584,12 +637,32 @@ cpdef read_parquet(
         CUDA stream used for device memory operations and kernel launches
     mr : DeviceMemoryResource, optional
         Device memory resource used to allocate the returned table's device memory.
+    parquet_metadatas : list[FileMetaData], optional
+        Pre-materialized parquet footer metadata, one for each source. If not
+        provided, footers are read from the sources internally.
     """
     cdef Stream s = _get_stream(stream)
     cdef cudaStream_t _cs = s.view().value()
+    cdef vector[unique_ptr[datasource]] sources
+    cdef vector[cpp_FileMetaData] c_metadatas
+    cdef table_with_metadata c_result
     mr = _get_memory_resource(mr)
-    with nogil:
-        c_result = move(cpp_read_parquet(options.c_obj, _cs, mr.get_mr()))
+    if parquet_metadatas is None:
+        with nogil:
+            c_result = move(cpp_read_parquet(options.c_obj, _cs, mr.get_mr()))
+    else:
+        sources = make_datasources(options.c_obj.get_source())
+        c_metadatas = _build_parquet_metadatas(parquet_metadatas, sources.size())
+        with nogil:
+            c_result = move(
+                cpp_read_parquet(
+                    move(sources),
+                    move(c_metadatas),
+                    options.c_obj,
+                    _cs,
+                    mr.get_mr(),
+                )
+            )
 
     return TableWithMetadata.from_libcudf(c_result, s, mr)
 

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pxd
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pxd
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pylibcudf.io.types cimport SourceInfo
+from pylibcudf.libcudf.io.parquet_schema cimport FileMetaData as cpp_FileMetaData
 from pylibcudf.libcudf.io.parquet_metadata cimport(
     parquet_metadata,
     parquet_schema,
@@ -57,4 +58,11 @@ cdef class ParquetMetadata:
 
     cpdef dict columnchunk_metadata(self)
 
+cdef class FileMetaData:
+    cdef cpp_FileMetaData c_obj
+
+    @staticmethod
+    cdef FileMetaData from_cpp(cpp_FileMetaData metadata)
+
 cpdef ParquetMetadata read_parquet_metadata(SourceInfo src_info)
+cpdef list read_parquet_footers(SourceInfo src_info)

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pyi
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pyi
@@ -4,10 +4,17 @@
 from pylibcudf.io.types import SourceInfo
 from pylibcudf.types import DataType
 
+try:
+    from collections.abc import Buffer
+except ImportError:
+    from typing_extensions import Buffer
+
 __all__ = [
+    "FileMetaData",
     "ParquetColumnSchema",
     "ParquetMetadata",
     "ParquetSchema",
+    "read_parquet_footers",
     "read_parquet_metadata",
 ]
 
@@ -30,4 +37,15 @@ class ParquetMetadata:
     def rowgroup_metadata(self) -> list[dict[str, int]]: ...
     def columnchunk_metadata(self) -> dict[str, list[int]]: ...
 
+class FileMetaData:
+    @classmethod
+    def from_bytes(cls, footer_bytes: Buffer) -> FileMetaData: ...
+    @property
+    def version(self) -> int: ...
+    @property
+    def num_rows(self) -> int: ...
+    @property
+    def created_by(self) -> str: ...
+
 def read_parquet_metadata(src_info: SourceInfo) -> ParquetMetadata: ...
+def read_parquet_footers(src_info: SourceInfo) -> list[FileMetaData]: ...

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
@@ -1,15 +1,31 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+from libc.stdint cimport uint8_t
+from libcpp.memory cimport make_unique, unique_ptr
+from libcpp.vector cimport vector
+
 from pylibcudf.io.types cimport SourceInfo
+from pylibcudf.libcudf.io.datasource cimport datasource, make_datasources
+from pylibcudf.libcudf.io.hybrid_scan cimport (
+    const_uint8_t,
+    hybrid_scan_reader as cpp_hybrid_scan_reader,
+)
+from pylibcudf.libcudf.io.parquet cimport parquet_reader_options
 from pylibcudf.libcudf.io cimport parquet_metadata as cpp_parquet_metadata
+from pylibcudf.libcudf.io.parquet_schema cimport FileMetaData as cpp_FileMetaData
+from pylibcudf.libcudf.utilities.span cimport host_span
 from pylibcudf.types cimport DataType
+
+ctypedef const unique_ptr[datasource] const_unique_ptr_datasource
 
 
 __all__ = [
+    "FileMetaData",
     "ParquetColumnSchema",
     "ParquetMetadata",
     "ParquetSchema",
+    "read_parquet_footers",
     "read_parquet_metadata",
 ]
 
@@ -244,6 +260,78 @@ cdef class ParquetMetadata:
         }
 
 
+cdef class FileMetaData:
+    """Parquet file footer metadata.
+
+    For details, see :cpp:class:`cudf::io::parquet::FileMetaData`
+
+    See Also
+    --------
+    read_parquet_footers
+        Read one ``FileMetaData`` per source directly from :class:`SourceInfo`.
+    """
+
+    def __init__(self):
+        raise ValueError("FileMetaData cannot be constructed directly")
+
+    @staticmethod
+    cdef FileMetaData from_cpp(cpp_FileMetaData metadata):
+        cdef FileMetaData result = FileMetaData.__new__(FileMetaData)
+        result.c_obj = metadata
+        return result
+
+    @property
+    def version(self):
+        """Get the file format version."""
+        return self.c_obj.version
+
+    @property
+    def num_rows(self):
+        """Get the total number of rows."""
+        return self.c_obj.num_rows
+
+    @property
+    def created_by(self):
+        """Get the application that created the file."""
+        return self.c_obj.created_by.decode("utf-8")
+
+    @classmethod
+    def from_bytes(cls, const uint8_t[::1] footer_bytes):
+        """Build ``FileMetaData`` from parquet footer bytes.
+
+        Parameters
+        ----------
+        footer_bytes : Buffer
+            A contiguous bytes-like object containing parquet footer bytes.
+            The bytes are forwarded as-is to
+            :cpp:class:`cudf::io::parquet::experimental::hybrid_scan_reader`
+            without Python-side preprocessing. This method does not strip the
+            parquet footer suffix (4-byte footer length + ``PAR1`` magic), so
+            callers should generally pass only the footer region bytes.
+
+        Returns
+        -------
+        FileMetaData
+            Parsed parquet file footer metadata.
+        """
+        cdef parquet_reader_options options = parquet_reader_options()
+        cdef unique_ptr[cpp_hybrid_scan_reader] reader
+        cdef cpp_FileMetaData metadata
+        cdef const uint8_t* footer_ptr = <const uint8_t*>0
+
+        if len(footer_bytes) > 0:
+            footer_ptr = &footer_bytes[0]
+
+        with nogil:
+            reader = make_unique[cpp_hybrid_scan_reader](
+                host_span[const_uint8_t](footer_ptr, len(footer_bytes)),
+                options,
+            )
+            metadata = reader.get()[0].parquet_metadata()
+
+        return FileMetaData.from_cpp(metadata)
+
+
 cpdef ParquetMetadata read_parquet_metadata(SourceInfo src_info):
     """
     Reads metadata of parquet dataset.
@@ -258,6 +346,12 @@ cpdef ParquetMetadata read_parquet_metadata(SourceInfo src_info):
     ParquetMetadata
         Parquet_metadata with parquet schema, number of rows,
         number of row groups and key-value metadata.
+
+    See Also
+    --------
+    read_parquet_footers
+        To read the pre-materialized flie footer metadata used
+        in :func:`pylibcudf.io.parquet.read_parquet`.
     """
     cdef cpp_parquet_metadata.parquet_metadata c_result
 
@@ -265,3 +359,31 @@ cpdef ParquetMetadata read_parquet_metadata(SourceInfo src_info):
         c_result = cpp_parquet_metadata.read_parquet_metadata(src_info.c_obj)
 
     return ParquetMetadata.from_metadata(c_result)
+
+
+cpdef list read_parquet_footers(SourceInfo src_info):
+    """
+    Read parquet file footers as ``FileMetaData`` objects.
+
+    Parameters
+    ----------
+    src_info : SourceInfo
+        Dataset source.
+
+    Returns
+    -------
+    list[FileMetaData]
+        One footer metadata object per input source.
+    """
+    cdef vector[unique_ptr[datasource]] sources = make_datasources(src_info.c_obj)
+    cdef vector[cpp_FileMetaData] c_result
+    cdef cpp_FileMetaData metadata
+    with nogil:
+        c_result = cpp_parquet_metadata.read_parquet_footers(
+            host_span[const_unique_ptr_datasource](
+                <const_unique_ptr_datasource*>sources.data(),
+                sources.size(),
+            )
+        )
+
+    return [FileMetaData.from_cpp(metadata) for metadata in c_result]

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
@@ -350,7 +350,7 @@ cpdef ParquetMetadata read_parquet_metadata(SourceInfo src_info):
     See Also
     --------
     read_parquet_footers
-        To read the pre-materialized flie footer metadata used
+        To read the pre-materialized file footer metadata used
         in :func:`pylibcudf.io.parquet.read_parquet`.
     """
     cdef cpp_parquet_metadata.parquet_metadata c_result

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
@@ -268,7 +268,8 @@ cdef class FileMetaData:
     See Also
     --------
     read_parquet_footers
-        Read one ``FileMetaData`` per source directly from :class:`SourceInfo`.
+        Read one ``FileMetaData`` per source directly from
+        :class:`pylibcudf.io.types.SourceInfo`.
     """
 
     def __init__(self):

--- a/python/pylibcudf/pylibcudf/libcudf/io/datasource.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/datasource.pxd
@@ -1,5 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
+from libc.stddef cimport size_t
+from libcpp.memory cimport unique_ptr
+from libcpp.vector cimport vector
+from pylibcudf.libcudf.io.types cimport source_info
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 
 
@@ -8,3 +12,7 @@ cdef extern from "cudf/io/datasource.hpp" \
 
     cdef cppclass datasource:
         pass
+
+    cdef vector[unique_ptr[datasource]] make_datasources(
+        source_info info
+    ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/io/parquet.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/parquet.pxd
@@ -10,6 +10,8 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.expressions cimport expression
+from pylibcudf.libcudf.io.datasource cimport datasource
+from pylibcudf.libcudf.io.parquet_schema cimport FileMetaData
 from pylibcudf.libcudf.io.types cimport (
     compression_type,
     dictionary_policy,
@@ -29,7 +31,7 @@ from rmm.librmm.memory_resource cimport device_async_resource_ref
 cdef extern from "cudf/io/parquet.hpp" namespace "cudf::io" nogil:
     cdef cppclass parquet_reader_options:
         parquet_reader_options() except +libcudf_exception_handler
-        source_info get_source_info() except +libcudf_exception_handler
+        source_info get_source() except +libcudf_exception_handler
         vector[vector[size_type]] get_row_groups() except +libcudf_exception_handler
         const optional[reference_wrapper[expression]]& get_filter()\
             except +libcudf_exception_handler
@@ -124,6 +126,13 @@ cdef extern from "cudf/io/parquet.hpp" namespace "cudf::io" nogil:
 
     cdef table_with_metadata read_parquet(
         parquet_reader_options args,
+        cudaStream_t stream,
+        device_async_resource_ref mr
+    ) except +libcudf_exception_handler
+    cdef table_with_metadata read_parquet(
+        vector[unique_ptr[datasource]] sources,
+        vector[FileMetaData] parquet_metadatas,
+        const parquet_reader_options& args,
         cudaStream_t stream,
         device_async_resource_ref mr
     ) except +libcudf_exception_handler
@@ -308,7 +317,24 @@ cdef extern from "cudf/io/parquet.hpp" namespace "cudf::io" nogil:
         ) except +libcudf_exception_handler
         chunked_parquet_reader(
             size_t chunk_read_limit,
+            vector[unique_ptr[datasource]] sources,
+            vector[FileMetaData] parquet_metadatas,
+            const parquet_reader_options& options,
+            cudaStream_t stream,
+            device_async_resource_ref mr
+        ) except +libcudf_exception_handler
+        chunked_parquet_reader(
+            size_t chunk_read_limit,
             size_t pass_read_limit,
+            const parquet_reader_options& options,
+            cudaStream_t stream,
+            device_async_resource_ref mr
+        ) except +libcudf_exception_handler
+        chunked_parquet_reader(
+            size_t chunk_read_limit,
+            size_t pass_read_limit,
+            vector[unique_ptr[datasource]] sources,
+            vector[FileMetaData] parquet_metadatas,
             const parquet_reader_options& options,
             cudaStream_t stream,
             device_async_resource_ref mr

--- a/python/pylibcudf/pylibcudf/libcudf/io/parquet_metadata.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/parquet_metadata.pxd
@@ -1,12 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int64_t
+from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
 from libcpp.unordered_map cimport unordered_map
 from libcpp.vector cimport vector
 from pylibcudf.exception_handler cimport libcudf_exception_handler
+from pylibcudf.libcudf.io.datasource cimport datasource
+from pylibcudf.libcudf.io.parquet_schema cimport FileMetaData
 from pylibcudf.libcudf.types cimport data_type, size_type
 from pylibcudf.libcudf.io.types cimport source_info
+from pylibcudf.libcudf.utilities.span cimport host_span
+
+ctypedef const unique_ptr[datasource] const_unique_ptr_datasource
 
 
 cdef extern from "cudf/io/parquet_metadata.hpp" namespace "cudf::io" nogil:
@@ -36,4 +42,8 @@ cdef extern from "cudf/io/parquet_metadata.hpp" namespace "cudf::io" nogil:
 
     cdef parquet_metadata read_parquet_metadata(
         source_info src_info
+    ) except +libcudf_exception_handler
+
+    cdef vector[FileMetaData] read_parquet_footers(
+        host_span[const_unique_ptr_datasource] sources
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/tests/conftest.py
+++ b/python/pylibcudf/tests/conftest.py
@@ -235,7 +235,9 @@ def _generate_table_data(types, nrows, seed=42):
 
 
 @pytest.fixture(scope="session", params=[0, 100])
-def table_data(request):
+def table_data(
+    request: pytest.FixtureRequest,
+) -> tuple[plc.io.types.TableWithMetadata, pa.Table]:
     """
     Returns (TableWithMetadata, pa_table).
 
@@ -292,7 +294,9 @@ def source_or_sink(request, tmp_path):
 @pytest.fixture(
     params=["a.txt", pathlib.Path("a.txt"), io.BytesIO],
 )
-def binary_source_or_sink(request, tmp_path):
+def binary_source_or_sink(
+    request: pytest.FixtureRequest, tmp_path: pathlib.Path
+) -> str | pathlib.Path | io.BytesIO:
     fp_or_buf = request.param
     if isinstance(fp_or_buf, str):
         return f"{tmp_path}/{fp_or_buf}"

--- a/python/pylibcudf/tests/io/test_experimental_hybrid_scan.py
+++ b/python/pylibcudf/tests/io/test_experimental_hybrid_scan.py
@@ -120,6 +120,7 @@ def test_hybrid_scan_reader_from_metadata(
     """Test creating HybridScanReader from pre-populated metadata."""
     # Get metadata from the fixture reader
     metadata = simple_hybrid_scan_reader.parquet_metadata()
+    assert isinstance(metadata, plc.io.parquet_metadata.FileMetaData)
 
     # Create a second reader from the metadata
     reader2 = HybridScanReader.from_parquet_metadata(

--- a/python/pylibcudf/tests/io/test_parquet.py
+++ b/python/pylibcudf/tests/io/test_parquet.py
@@ -387,7 +387,7 @@ def test_file_metadata_from_bytes(
 
 
 def test_file_metadata_from_bytes_empty() -> None:
-    with pytest.raises(ValueError, match="footer_bytes must be non-empty"):
+    with pytest.raises(RuntimeError, match="Cannot initialize schema"):
         plc.io.parquet_metadata.FileMetaData.from_bytes(memoryview(b""))
 
 

--- a/python/pylibcudf/tests/io/test_parquet.py
+++ b/python/pylibcudf/tests/io/test_parquet.py
@@ -304,7 +304,7 @@ def test_read_parquet_with_pre_materialized_metadata_len_mismatch(
 
     with pytest.raises(
         ValueError,
-        match="len\\(parquet_metadatas\\).*must match the number of input sources",
+        match=r"Length of 'parquet_metadatas' \(0\) must match the number of input sources \(1\)",
     ):
         plc.io.parquet.read_parquet(options, parquet_metadatas=[])
 

--- a/python/pylibcudf/tests/io/test_parquet.py
+++ b/python/pylibcudf/tests/io/test_parquet.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 import io
+import os
 
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
-from pyarrow.parquet import read_table
+from pyarrow.parquet import read_table, write_table
 from utils import (
     assert_table_and_meta_eq,
     get_bytes_from_source,
@@ -27,6 +28,24 @@ from pylibcudf.expressions import (
 
 # Shared kwargs to pass to make_source
 _COMMON_PARQUET_SOURCE_KWARGS = {"format": "parquet"}
+
+
+def _extract_footer_bytes_with_suffix(
+    file_bytes: bytes,
+) -> tuple[memoryview, memoryview]:
+    """Return footer bytes with and without the parquet footer suffix."""
+    parquet_suffix_size = 8  # 4-byte footer length + 4-byte magic bytes (PAR1)
+    file_memoryview = memoryview(file_bytes)
+    footer_size = int.from_bytes(
+        file_memoryview[-parquet_suffix_size:-4], byteorder="little"
+    )
+    footer_start = len(file_memoryview) - parquet_suffix_size - footer_size
+    footer_stop = len(file_memoryview)
+    footer_with_suffix = file_memoryview[footer_start:footer_stop]
+    footer_without_suffix = file_memoryview[
+        footer_start : footer_stop - parquet_suffix_size
+    ]
+    return footer_without_suffix, footer_with_suffix
 
 
 @pytest.mark.parametrize("stream", [None, Stream()])
@@ -93,7 +112,7 @@ def test_read_parquet_filters_metadata(tmp_path, if_prune_rowgroup, result):
     max_element = max(col_list)
     tbl1 = pa.Table.from_pydict({"a": col_list})
     path1 = tmp_path / "tbl1.parquet"
-    pa.parquet.write_table(tbl1, path1)
+    write_table(tbl1, path1)
     source = plc.io.SourceInfo([path1])
     options = plc.io.parquet.ParquetReaderOptions.builder(source).build()
 
@@ -249,6 +268,127 @@ def test_read_parquet_from_device_buffers(
     expected = expected.slice(skiprows, nrows if nrows > -1 else None)
 
     assert_table_and_meta_eq(expected, res, check_field_nullability=False)
+
+
+def test_read_parquet_with_pre_materialized_metadata(
+    table_data: tuple[plc.io.types.TableWithMetadata, pa.Table],
+    binary_source_or_sink: str | os.PathLike[str] | io.BytesIO,
+) -> None:
+    _, pa_table = table_data
+    source = make_source(
+        binary_source_or_sink, pa_table, **_COMMON_PARQUET_SOURCE_KWARGS
+    )
+    source_info = plc.io.SourceInfo([source])
+    options = plc.io.parquet.ParquetReaderOptions.builder(source_info).build()
+
+    parquet_metadatas = plc.io.parquet_metadata.read_parquet_footers(
+        source_info
+    )
+    result = plc.io.parquet.read_parquet(
+        options, parquet_metadatas=parquet_metadatas
+    )
+
+    assert_table_and_meta_eq(pa_table, result, check_field_nullability=False)
+
+
+def test_read_parquet_with_pre_materialized_metadata_len_mismatch(
+    table_data: tuple[plc.io.types.TableWithMetadata, pa.Table],
+    binary_source_or_sink: str | os.PathLike[str] | io.BytesIO,
+) -> None:
+    _, pa_table = table_data
+    source = make_source(
+        binary_source_or_sink, pa_table, **_COMMON_PARQUET_SOURCE_KWARGS
+    )
+    source_info = plc.io.SourceInfo([source])
+    options = plc.io.parquet.ParquetReaderOptions.builder(source_info).build()
+
+    with pytest.raises(
+        ValueError,
+        match="len\\(parquet_metadatas\\).*must match the number of input sources",
+    ):
+        plc.io.parquet.read_parquet(options, parquet_metadatas=[])
+
+
+def test_chunked_parquet_reader_with_pre_materialized_metadata(
+    table_data: tuple[plc.io.types.TableWithMetadata, pa.Table],
+    binary_source_or_sink: str | os.PathLike[str] | io.BytesIO,
+) -> None:
+    _, pa_table = table_data
+    source = make_source(
+        binary_source_or_sink, pa_table, **_COMMON_PARQUET_SOURCE_KWARGS
+    )
+    source_info = plc.io.SourceInfo([source])
+    options = plc.io.parquet.ParquetReaderOptions.builder(source_info).build()
+    parquet_metadatas = plc.io.parquet_metadata.read_parquet_footers(
+        source_info
+    )
+
+    default_reader = plc.io.parquet.ChunkedParquetReader(
+        options,
+        chunk_read_limit=512,
+    )
+    default_chunks: list[pa.Table] = []
+    while default_reader.has_next():
+        default_chunks.append(default_reader.read_chunk().tbl.to_arrow())
+
+    metadata_reader = plc.io.parquet.ChunkedParquetReader(
+        options,
+        chunk_read_limit=512,
+        parquet_metadatas=parquet_metadatas,
+    )
+    metadata_chunks: list[pa.Table] = []
+    while metadata_reader.has_next():
+        metadata_chunks.append(metadata_reader.read_chunk().tbl.to_arrow())
+
+    if default_chunks:
+        expected = pa.concat_tables(default_chunks)
+    else:
+        expected = pa_table.slice(0, 0)
+    if metadata_chunks:
+        result = pa.concat_tables(metadata_chunks)
+    else:
+        result = pa_table.slice(0, 0)
+
+    assert result.equals(expected)
+
+
+def test_file_metadata_from_bytes(
+    table_data: tuple[plc.io.types.TableWithMetadata, pa.Table],
+    binary_source_or_sink: str | os.PathLike[str] | io.BytesIO,
+) -> None:
+    _, pa_table = table_data
+    source = make_source(
+        binary_source_or_sink, pa_table, **_COMMON_PARQUET_SOURCE_KWARGS
+    )
+    source_bytes = get_bytes_from_source(source)
+    footer_without_suffix, footer_with_suffix = (
+        _extract_footer_bytes_with_suffix(source_bytes)
+    )
+
+    metadata_from_footer_only = (
+        plc.io.parquet_metadata.FileMetaData.from_bytes(footer_without_suffix)
+    )
+    metadata_from_footer_with_suffix = (
+        plc.io.parquet_metadata.FileMetaData.from_bytes(footer_with_suffix)
+    )
+    assert (
+        metadata_from_footer_only.version
+        == metadata_from_footer_with_suffix.version
+    )
+    assert (
+        metadata_from_footer_only.num_rows
+        == metadata_from_footer_with_suffix.num_rows
+    )
+    assert (
+        metadata_from_footer_only.created_by
+        == metadata_from_footer_with_suffix.created_by
+    )
+    assert metadata_from_footer_only.num_rows == pa_table.num_rows
+
+
+def test_file_metadata_from_bytes_empty() -> None:
+    with pytest.raises(ValueError, match="footer_bytes must be non-empty"):
+        plc.io.parquet_metadata.FileMetaData.from_bytes(memoryview(b""))
 
 
 # TODO: Test these options


### PR DESCRIPTION
## Description

This updates `pylibcudf.io.parquet.read_parquet_metadata` to accept an optional `parquet_metadatas` argument, matching the behavior of the `parquet_metadatas` object in the C++ reader. The lets users pre-fetch all parquet metadata.

A few notes:

1. pylibcudf previously exposed a `FileMetadata` via `pylibcudf.io.experimental.hybrid_scan`. I've moved that to `pylibcudf.io.parquet_metadata`
2. I've added this as an optional argument to `read_parquet`, rather than a separate function. I think that's compatible with how pylibcudf does things.
3. I've added a new `read_parquet_footers` wrapping the C++ version. So the flow for users is
```python
    parquet_metadatas = plc.io.parquet_metadata.read_parquet_footers(
        source_info
    )
    result = plc.io.parquet.read_parquet(
        options, parquet_metadatas=parquet_metadatas
    )

```

Closes https://github.com/rapidsai/cudf/issues/22580.