### PR TITLE
Remove unnecessary max token count check in JSON tokenizer

### DIFF
--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -1632,14 +1632,6 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
     stream);
 
   // Perform a PDA-transducer pass
-  // Compute the maximum amount of tokens that can possibly be emitted for a given input size
-  // Worst case ratio of tokens per input char is given for a struct with an empty field name, that
-  // may be arbitrarily deeply nested: {"":_}, where '_' is a placeholder for any JSON value,
-  // possibly another such struct. That is, 6 tokens for 5 chars (plus chars and tokens of '_')
-  std::size_t constexpr min_chars_per_struct  = 5;
-  std::size_t constexpr max_tokens_per_struct = 6;
-  auto const max_token_out_count =
-    cudf::util::div_rounding_up_safe(json_in.size(), min_chars_per_struct) * max_tokens_per_struct;
   cudf::detail::device_scalar<std::size_t> num_written_tokens{
     stream, cudf::get_current_device_resource_ref()};
   // In case we're recovering on invalid JSON lines, post-processing the token stream requires to
@@ -1677,9 +1669,6 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
     tokens         = std::move(filtered_tokens);
     tokens_indices = std::move(filtered_tokens_indices);
   }
-
-  CUDF_EXPECTS(num_total_tokens <= max_token_out_count,
-               "Generated token count exceeds the expected token count");
 
   return std::make_pair(std::move(tokens), std::move(tokens_indices));
 }

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -2060,6 +2060,51 @@ TEST_F(JsonReaderTest, JSONLinesRecovering)
                     c_validity.cbegin()});
 }
 
+TEST_F(JsonReaderTest, JSONLinesRecoveringMalformedOpenBraces)
+{
+  // Test recovery mode with various malformed JSON patterns
+  for (int num_lines : {2, 4, 8, 16}) {
+    // Test "{\n" pattern
+    {
+      std::string data;
+      for (int i = 0; i < num_lines - 1; ++i) {
+        data += "{\n";
+      }
+      data += "{";
+
+      cudf::io::json_reader_options in_options =
+        cudf::io::json_reader_options::builder(
+          cudf::io::source_info{cudf::host_span<std::byte const>{
+            reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+          .lines(true)
+          .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL);
+
+      cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
+      EXPECT_EQ(result.tbl->num_rows(), 0) << "Failed {\\n pattern with " << num_lines << " lines";
+    }
+
+    // Test {"\n pattern
+    {
+      std::string data;
+      for (int i = 0; i < num_lines - 1; ++i) {
+        data += "{\"\n";
+      }
+      data += "{\"";
+
+      cudf::io::json_reader_options in_options =
+        cudf::io::json_reader_options::builder(
+          cudf::io::source_info{cudf::host_span<std::byte const>{
+            reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+          .lines(true)
+          .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL);
+
+      cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
+      EXPECT_EQ(result.tbl->num_rows(), 0)
+        << "Failed {\"\\n pattern with " << num_lines << " lines";
+    }
+  }
+}
+
 TEST_F(JsonReaderTest, JSONLinesRecoveringIgnoreExcessChars)
 {
   /**


### PR DESCRIPTION
## Summary
- Remove the `CUDF_EXPECTS` check that was comparing the actual token count against an analytical upper bound
- Expand test coverage for malformed JSON recovery with `{\n` and `{"\n` patterns

### Details
The JSON tokenizer was failing on malformed input like repeated `{\n` lines in recovery mode with:
```
CUDF failure at: nested_json_gpu.cu:1683: Generated token count exceeds the expected token count
```
The analytical bound assumed a worst-case ratio of 6 tokens per 5 characters (based on valid JSON like {"":_}), but recovery mode can produce higher ratios—for example, {"\n produces 5 tokens for 3 characters.
Since the buffer allocation uses the exact count from a sizing FST pass (not the analytical bound), this check served only as a debug assertion. Removing it fixes the failure without any functional impact.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
