### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/cpp/doxygen/regex.md
+++ b/cpp/doxygen/regex.md
@@ -28,7 +28,6 @@ By default, only the `\n` character is recognized as a line break. The [cudf::st
 - Unescaped special characters (listed in the third row of the Characters table below) when they are intended to match as literals.
 - Unmatched paired special characters like `()`, `[]`, and `{}`.
 - Empty groups, classes, or quantifiers. That is, `()` and `[]` without an enclosing expression and `{}` without a valid integer.
-- Incomplete ranges in character classes like `[-z]`, `[a-]`, and `[-]`.
 - Unqualified quantifiers. That is, a quantifier with no preceding item to match like `*a`, `a⎮?`, `(+)`, `{2}a`, etc.
 
 ## Features Supported

--- a/cpp/include/cudf/ast/detail/expression_evaluator.cuh
+++ b/cpp/include/cudf/ast/detail/expression_evaluator.cuh
@@ -305,13 +305,37 @@ struct expression_evaluator {
       }
     } else {  // Assumes input_reference.reference_type ==
               // detail::device_data_reference_type::INTERMEDIATE
-      // Using memcpy instead of reinterpret_cast<Element*> for safe type aliasing
-      // Using a temporary variable ensures that the compiler knows the result is aligned
       IntermediateDataType<has_nulls> intermediate =
         thread_intermediate_storage[input_reference.data_index];
-      ReturnType tmp;
-      memcpy(&tmp, &intermediate, sizeof(ReturnType));
-      return tmp;
+      if constexpr (cudf::is_fixed_point<Element>()) {
+        using rep        = typename Element::rep;
+        auto const scale = numeric::scale_type{input_reference.data_type.scale()};
+        if constexpr (has_nulls) {
+          if (!intermediate.has_value()) { return ReturnType{}; }
+          return ReturnType{
+            Element{numeric::scaled_integer<rep>{static_cast<rep>(*intermediate), scale}}};
+        } else {
+          rep rep_val;
+          memcpy(&rep_val, &intermediate, sizeof(rep));
+          return ReturnType{numeric::scaled_integer<rep>{rep_val, scale}};
+        }
+      } else {
+        if constexpr (has_nulls) {
+          // Mirror the explicit construction done in resolve_output: extract the
+          // int64_t value from optional<int64_t> and rebuild optional<Element>.
+          if (!intermediate.has_value()) { return ReturnType{}; }
+          Element val{};
+          auto const rep = *intermediate;
+          memcpy(&val, &rep, sizeof(Element));
+          return ReturnType{val};
+        } else {
+          // Using memcpy instead of reinterpret_cast<Element*> for safe type aliasing
+          // Using a temporary variable ensures that the compiler knows the result is aligned
+          ReturnType tmp;
+          memcpy(&tmp, &intermediate, sizeof(ReturnType));
+          return tmp;
+        }
+      }
     }
     // Unreachable return used to silence compiler warnings.
     return {};
@@ -607,11 +631,23 @@ struct expression_evaluator {
         output_object.template set_value<Element>(row_index, result);
       } else {  // Assumes device_data_reference.reference_type ==
                 // detail::device_data_reference_type::INTERMEDIATE
-        // Using memcpy instead of reinterpret_cast<Element*> for safe type aliasing.
-        // Using a temporary variable ensures that the compiler knows the result is aligned.
-        IntermediateDataType<has_nulls> tmp;
-        memcpy(&tmp, &result, sizeof(possibly_null_value_t<Element, has_nulls>));
-        thread_intermediate_storage[device_data_reference.data_index] = tmp;
+        if constexpr (has_nulls) {
+          if (result.has_value()) {
+            std::int64_t rep{};
+            memcpy(&rep, &(result.value()), sizeof(Element));
+            thread_intermediate_storage[device_data_reference.data_index] =
+              IntermediateDataType<has_nulls>{rep};
+          } else {
+            thread_intermediate_storage[device_data_reference.data_index] =
+              IntermediateDataType<has_nulls>{};
+          }
+        } else {
+          // Using memcpy instead of reinterpret_cast<Element*> for safe type aliasing.
+          // Using a temporary variable ensures that the compiler knows the result is aligned.
+          IntermediateDataType<has_nulls> tmp;
+          memcpy(&tmp, &result, sizeof(possibly_null_value_t<Element, has_nulls>));
+          thread_intermediate_storage[device_data_reference.data_index] = tmp;
+        }
       }
     }
 
@@ -626,18 +662,21 @@ struct expression_evaluator {
       possibly_null_value_t<Element, has_nulls> const& result) const
     {
       using RepType = typename Element::rep;
-      auto const v  = result.value();
-      auto const rv = [&v, &result] {
-        if constexpr (cuda::std::is_same_v<cuda::std::remove_cvref_t<decltype(v)>, RepType>) {
-          return v;  // no nulls path
-        } else {
-          // rewrap rep component value appropriately
-          using ResultType = possibly_null_value_t<RepType, has_nulls>;
-          return result.has_value() ? ResultType{v.value()} : ResultType{};
-        }
-      }();
-      resolve_output<RepType, ResultSubclass, T, result_has_nulls>(
-        output_object, device_data_reference, row_index, thread_intermediate_storage, rv);
+      if constexpr (has_nulls) {
+        // result is optional<Element>; must guard before calling .value() to avoid
+        // bad_optional_access when result is null.
+        using ResultType = possibly_null_value_t<RepType, true>;
+        auto const rv    = result.has_value() ? ResultType{result->value()} : ResultType{};
+        resolve_output<RepType, ResultSubclass, T, result_has_nulls>(
+          output_object, device_data_reference, row_index, thread_intermediate_storage, rv);
+      } else {
+        // result is Element; .value() is Element::value() which returns RepType.
+        resolve_output<RepType, ResultSubclass, T, result_has_nulls>(output_object,
+                                                                     device_data_reference,
+                                                                     row_index,
+                                                                     thread_intermediate_storage,
+                                                                     result.value());
+      }
     }
 
     template <typename Element, typename ResultSubclass, typename T, bool result_has_nulls>

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -11,6 +11,7 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/ast/expressions.hpp>
+#include <cudf/binaryop.hpp>
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/iterator.cuh>
@@ -1365,6 +1366,96 @@ TYPED_TEST(DecimalTests, DecimalDifferentScales)
     result = cudf::compute_column_jit(table, expr);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   }
+}
+
+TYPED_TEST(DecimalTests, LessConsumesMulOfDecimals)
+{
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  auto const scale = numeric::scale_type{-2};
+  // Values at scale=-2:  col_a in {1, 2, 5, 10, 25, 50}.00,
+  // col_thresh = 0.20, col_avg = 25.00.  Expected: col_a < 5.00 → [1,1,0,0,0,0].
+  auto col_a =
+    cudf::test::fixed_point_column_wrapper<RepType>({100, 200, 500, 1000, 2500, 5000}, scale);
+  auto col_thresh =
+    cudf::test::fixed_point_column_wrapper<RepType>({20, 20, 20, 20, 20, 20}, scale);
+  auto col_avg =
+    cudf::test::fixed_point_column_wrapper<RepType>({2500, 2500, 2500, 2500, 2500, 2500}, scale);
+  auto table = cudf::table_view{{col_a, col_thresh, col_avg}};
+
+  // Path 1: single fused AST -- col_a < (col_thresh * col_avg)
+  auto ra         = cudf::ast::column_reference(0);
+  auto rt         = cudf::ast::column_reference(1);
+  auto rv         = cudf::ast::column_reference(2);
+  auto mul        = cudf::ast::operation(cudf::ast::ast_operator::MUL, rt, rv);
+  auto lt         = cudf::ast::operation(cudf::ast::ast_operator::LESS, ra, mul);
+  auto ast_result = cudf::compute_column(table, lt);
+
+  // Path 2: chained binary_operation, no AST intermediate
+  auto decimal_type = cudf::data_type{cudf::type_to_id<decimalXX>(), numeric::scale_type{-4}};
+  auto tmp = cudf::binary_operation(col_thresh, col_avg, cudf::binary_operator::MUL, decimal_type);
+  auto ref_result = cudf::binary_operation(
+    col_a, tmp->view(), cudf::binary_operator::LESS, cudf::data_type{cudf::type_id::BOOL8});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(ast_result->view(), ref_result->view());
+  ast_result = cudf::compute_column_jit(table, lt);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(ast_result->view(), ref_result->view());
+}
+
+TEST_F(ComputeColumnTest, NullPropagatesViaSmallTypeIntermediate)
+{
+  auto a     = cudf::test::fixed_width_column_wrapper<int32_t>{{1, 2, 3, 4}, {1, 0, 1, 1}};
+  auto b     = cudf::test::fixed_width_column_wrapper<int32_t>{{10, 10, 10, 10}, {1, 1, 1, 1}};
+  auto c     = cudf::test::fixed_width_column_wrapper<int32_t>{{5, 5, 5, 5}, {1, 1, 0, 1}};
+  auto table = cudf::table_view{{a, b, c}};
+
+  auto ra  = cudf::ast::column_reference(0);
+  auto rb  = cudf::ast::column_reference(1);
+  auto rc  = cudf::ast::column_reference(2);
+  auto mul = cudf::ast::operation(cudf::ast::ast_operator::MUL, ra, rb);
+  auto add = cudf::ast::operation(cudf::ast::ast_operator::ADD, mul, rc);
+
+  // row 0: 1*10+5  = 15 (valid)
+  // row 1: null*10 = null → null+5 = null
+  // row 2: 3*10    = 30  → 30+null = null
+  // row 3: 4*10+5  = 45 (valid)
+  auto expected = column_wrapper<int32_t>{{15, 0, 0, 45}, {1, 0, 0, 1}};
+  auto result   = cudf::compute_column(table, add);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
+}
+
+TYPED_TEST(DecimalTests, LessConsumesMulOfDecimalsWithNulls)
+{
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  auto const scale = numeric::scale_type{-2};
+  // col_a  at scale=-2: {1.00, null, 5.00, 10.00}
+  // thresh at scale=-2: {0.20, 0.20, null, 0.20}
+  // avg    at scale=-2: {25.00, 25.00, 25.00, 25.00} (no nulls)
+  auto col_a =
+    cudf::test::fixed_point_column_wrapper<RepType>({100, 200, 500, 1000}, {1, 0, 1, 1}, scale);
+  auto col_thresh =
+    cudf::test::fixed_point_column_wrapper<RepType>({20, 20, 20, 20}, {1, 1, 0, 1}, scale);
+  auto col_avg = cudf::test::fixed_point_column_wrapper<RepType>({2500, 2500, 2500, 2500}, scale);
+  auto table   = cudf::table_view{{col_a, col_thresh, col_avg}};
+
+  auto ra  = cudf::ast::column_reference(0);
+  auto rt  = cudf::ast::column_reference(1);
+  auto rv  = cudf::ast::column_reference(2);
+  auto mul = cudf::ast::operation(cudf::ast::ast_operator::MUL, rt, rv);
+  auto lt  = cudf::ast::operation(cudf::ast::ast_operator::LESS, ra, mul);
+
+  // row 0: 1.00 < (0.20*25.00 = 5.00) → true
+  // row 1: col_a=null                  → null
+  // row 2: col_thresh=null → MUL=null  → null
+  // row 3: 10.00 < 5.00                → false
+  auto expected = cudf::test::fixed_width_column_wrapper<bool>({1, 0, 0, 0}, {1, 0, 0, 1});
+  auto result   = cudf::compute_column(table, lt);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
+  result = cudf::compute_column_jit(table, lt);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TYPED_TEST(TransformTest, NonDefaultStream)

--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -838,13 +838,11 @@ class Scan(IR):
                 # TODO: Nested column names
                 names = chunk.column_names(include_children=False)
                 concatenated_columns = chunk.tbl.columns()
-                while reader.has_next():  # pragma: no cover
+                while reader.has_next():
                     columns = reader.read_chunk().tbl.columns()
                     # Discard columns while concatenating to reduce memory footprint.
                     # Reverse order to avoid O(n^2) list popping cost.
-                    for i in range(  # pragma: no cover
-                        len(concatenated_columns) - 1, -1, -1
-                    ):
+                    for i in reversed(range(len(concatenated_columns))):
                         concatenated_columns[i] = plc.concatenate.concatenate(
                             [concatenated_columns[i], columns.pop()], stream=stream
                         )

--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -350,6 +350,7 @@ _COMPARISON_BINOPS = {
 }
 
 
+@nvtx_annotate_cudf_polars(message="_parquet_physical_types")
 def _parquet_physical_types(
     paths: list[str], columns: list[str] | None
 ) -> dict[str, plc.DataType]:
@@ -648,6 +649,7 @@ class Scan(IR):
             [Column(filepaths, name=name, dtype=dtype)], stream=df.stream
         )
 
+    @nvtx_annotate_cudf_polars(message="Scan.fast_count")
     def fast_count(self) -> int:  # pragma: no cover
         """Get the number of rows in a Parquet Scan."""
         meta = plc.io.parquet_metadata.read_parquet_metadata(
@@ -659,6 +661,7 @@ class Scan(IR):
         return max(total_rows, 0)
 
     @staticmethod
+    @nvtx_annotate_cudf_polars(message="Scan._get_parquet_row_count_from_metadata")
     def _get_parquet_row_count_from_metadata(
         paths: list[str], skip_rows: int, n_rows: int
     ) -> int:

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -352,10 +352,7 @@ def get_data(path: str | Path, table_name: str, suffix: str = "") -> pl.LazyFram
     local filesystem, falls back to scanning ``{path}/{table_name}`` as a
     directory of parquet files.
     """
-    file_path = Path(path) / f"{table_name}{suffix}"
-    if suffix and not file_path.exists():
-        # Directory-based layout: e.g. tpch-rs partitioned output
-        return pl.scan_parquet(Path(path) / table_name)
+    file_path = str(path).removesuffix("/") + f"/{table_name}{suffix}"
     return pl.scan_parquet(file_path)
 
 

--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -23,6 +23,7 @@ from cudf_polars.dsl.ir import (
     Scan,
     Sink,
 )
+from cudf_polars.dsl.tracing import nvtx_annotate_cudf_polars
 from cudf_polars.experimental.base import (
     IOPartitionFlavor,
     IOPartitionPlan,
@@ -460,6 +461,7 @@ class ParquetMetadata:
     sample_paths: tuple[str, ...]
     """Sampled file paths."""
 
+    @nvtx_annotate_cudf_polars(message="ParquetMetadata")
     def __init__(self, paths: tuple[str, ...], max_footer_samples: int):
         self.paths = paths
         self.max_footer_samples = max_footer_samples
@@ -513,6 +515,7 @@ class ParquetMetadata:
         self.row_count = row_count
 
 
+@nvtx_annotate_cudf_polars(message="_sample_rg_sizes")
 def _sample_rg_sizes(
     metadata: ParquetMetadata,
     target_cols: list[str],

--- a/python/cudf_polars/cudf_polars/experimental/statistics.py
+++ b/python/cudf_polars/cudf_polars/experimental/statistics.py
@@ -16,7 +16,10 @@ if TYPE_CHECKING:
     from cudf_polars.dsl.ir import IR
     from cudf_polars.utils.config import ConfigOptions, StreamingExecutor
 
+from cudf_polars.dsl.tracing import nvtx_annotate_cudf_polars
 
+
+@nvtx_annotate_cudf_polars(message="collect_statistics")
 def collect_statistics(
     root: IR,
     config_options: ConfigOptions[StreamingExecutor],

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -27,9 +27,9 @@ def _assert_stable_ids_match(orig, loaded) -> None:
 def df():
     return pl.LazyFrame(
         {
-            "x": range(30_000),
-            "y": [1, 2, 3] * 10_000,
-            "z": [1.0, 2.0, 3.0, 4.0, 5.0] * 6_000,
+            "x": range(3_000),
+            "y": [1, 2, 3] * 1_000,
+            "z": [1.0, 2.0, 3.0, 4.0, 5.0] * 600,
         }
     )
 

--- a/python/cudf_polars/tests/experimental/test_explain.py
+++ b/python/cudf_polars/tests/experimental/test_explain.py
@@ -30,9 +30,9 @@ if TYPE_CHECKING:
 def df():
     return pl.DataFrame(
         {
-            "x": range(25_000),
-            "y": ["cat", "dog"] * 12_500,
-            "z": [1.0, 2.0] * 12_500,
+            "x": range(30),
+            "y": ["cat", "dog"] * 15,
+            "z": [1.0, 2.0] * 15,
         }
     )
 

--- a/python/cudf_polars/tests/experimental/test_io_multirank.py
+++ b/python/cudf_polars/tests/experimental/test_io_multirank.py
@@ -31,9 +31,9 @@ pytestmark = [
 def df() -> pl.LazyFrame:
     return pl.LazyFrame(
         {
-            "x": range(30_000),
-            "y": [1, 2, None] * 10_000,
-            "z": ["ẅ", "a", "z", "123", "abcd"] * 6_000,
+            "x": range(30),
+            "y": [1, 2, None] * 10,
+            "z": ["ẅ", "a", "z", "123", "abcd"] * 6,
         }
     )
 
@@ -44,7 +44,7 @@ def engine(
 ) -> StreamingEngine:
     """Yield each supported streaming engine pinned to small partitions."""
     return streaming_engine_factory(
-        StreamingOptions(max_rows_per_partition=1_000),
+        StreamingOptions(max_rows_per_partition=10),
     )
 
 

--- a/python/cudf_polars/tests/experimental/test_sink.py
+++ b/python/cudf_polars/tests/experimental/test_sink.py
@@ -17,17 +17,17 @@ from cudf_polars.testing.asserts import assert_sink_result_equal
 def df():
     return pl.LazyFrame(
         {
-            "x": range(30_000),
-            "y": [1, 2, None] * 10_000,
-            "z": ["ẅ", "a", "z", "123", "abcd"] * 6_000,
+            "x": range(30),
+            "y": [1, 2, None] * 10,
+            "z": ["ẅ", "a", "z", "123", "abcd"] * 6,
         }
     )
 
 
 @pytest.mark.parametrize("mkdir", [True, False])
-@pytest.mark.parametrize("data_page_size", [None, 256_000])
-@pytest.mark.parametrize("row_group_size", [None, 1_000])
-@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+@pytest.mark.parametrize("data_page_size", [None, 1024])
+@pytest.mark.parametrize("row_group_size", [None, 10])
+@pytest.mark.parametrize("max_rows_per_partition", [10, 1_000_000])
 def test_sink_parquet_single_file(
     df,
     streaming_engine_factory,
@@ -53,9 +53,9 @@ def test_sink_parquet_single_file(
 
 
 @pytest.mark.parametrize("mkdir", [True, False])
-@pytest.mark.parametrize("data_page_size", [None, 256_000])
-@pytest.mark.parametrize("row_group_size", [None, 1_000])
-@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+@pytest.mark.parametrize("data_page_size", [None, 1024])
+@pytest.mark.parametrize("row_group_size", [None, 10])
+@pytest.mark.parametrize("max_rows_per_partition", [10, 1_000_000])
 def test_sink_parquet_directory(
     df,
     streaming_engine_factory,
@@ -104,7 +104,7 @@ def test_sink_parquet_raises(df: pl.LazyFrame, tmp_path, streaming_engine_factor
 @pytest.mark.parametrize("include_header", [True, False])
 @pytest.mark.parametrize("null_value", [None, "NA"])
 @pytest.mark.parametrize("separator", [",", "|"])
-@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+@pytest.mark.parametrize("max_rows_per_partition", [10, 1_000_000])
 def test_sink_csv(
     df,
     streaming_engine_factory,
@@ -135,7 +135,7 @@ def test_sink_csv(
     )
 
 
-@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+@pytest.mark.parametrize("max_rows_per_partition", [10, 1_000_000])
 def test_sink_ndjson(df, streaming_engine_factory, tmp_path, max_rows_per_partition):
     engine = streaming_engine_factory(
         StreamingOptions(

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -15,7 +15,7 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
-from cudf_polars.testing.engine_utils import get_blocksize_mode, is_streaming_engine
+from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
 )
@@ -292,18 +292,13 @@ def test_groupby_nested_list_struct_raises(dtype):
     assert_ir_translation_raises(q, NotImplementedError)
 
 
-@pytest.mark.parametrize("nrows", [30, 300, 300_000])
 @pytest.mark.parametrize("nkeys", [1, 2, 4])
 def test_groupby_maintain_order_random(
     engine: pl.GPUEngine,
-    nrows,
-    nkeys,
-    with_nulls,
+    nkeys: int,
+    with_nulls: bool,  # noqa: FBT001
 ):
-    if nrows > 30 and (
-        get_blocksize_mode(engine) == "small" or is_streaming_engine(engine)
-    ):
-        pytest.skip("streaming executor too slow for large n_rows")
+    nrows = 30
     key_names = [f"key{key}" for key in range(nkeys)]
     rng = random.Random(2)
     key_values = [rng.choices(range(100), k=nrows) for _ in key_names]

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -390,14 +390,13 @@ def chunked_slice(request):
 
 
 @pytest.fixture(scope="module")
-def large_df(df, tmpdir_factory, chunked_slice):
-    # Something big enough that we get more than a single chunk,
-    # empirically determined
-    df = pl.concat([df] * 1000)
-    df = pl.concat([df] * 10)
-    df = pl.concat([df] * 10)
-    path = str(tmpdir_factory.mktemp("data") / "large.pq")
-    make_partitioned_source(df, path, "parquet")
+def chunked_df(df, tmpdir_factory, chunked_slice):
+    # Many small row groups so that ``pass_read_limit`` (one pass per row
+    # group) and ``chunk_read_limit`` (one output chunk per page within a
+    # pass) can force the libcudf chunked reader to return multiple chunks.
+    df = pl.concat([df] * 100)
+    path = str(tmpdir_factory.mktemp("data") / "chunked.pq")
+    make_partitioned_source(df, path, "parquet", row_group_size=10)
     n_rows = len(df)
     q = pl.scan_parquet(path)
     if chunked_slice == "no_slice":
@@ -411,24 +410,30 @@ def large_df(df, tmpdir_factory, chunked_slice):
 
 
 @pytest.mark.parametrize(
-    "chunk_read_limit", [0, 1, 2, 4, 8, 16], ids=lambda x: f"chunk_{x}"
-)
-@pytest.mark.parametrize(
-    "pass_read_limit", [0, 1, 2, 4, 8, 16], ids=lambda x: f"pass_{x}"
+    "chunk_read_limit, pass_read_limit",
+    [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+        (2, 1),
+        (1, 2),
+    ],
+    ids=lambda x: f"limit_{x}",
 )
 @pytest.mark.parametrize(
     "filter", [None, pl.col("a") > 3], ids=["no_filters", "with_filters"]
 )
 def test_scan_parquet_chunked(
-    large_df,
+    chunked_df,
     chunk_read_limit,
     pass_read_limit,
     filter,
 ):
     if filter is None:
-        q = large_df
+        q = chunked_df
     else:
-        q = large_df.filter(filter)
+        q = chunked_df.filter(filter)
     assert_gpu_result_equal(
         q,
         engine=pl.GPUEngine(


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.