### PR TITLE
Adapt ast conversion for literals

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -46,7 +46,7 @@ from cudf_polars.containers.dataframe import NamedColumn
 from cudf_polars.dsl.expressions import rolling, unary
 from cudf_polars.dsl.expressions.base import ExecutionContext
 from cudf_polars.dsl.nodebase import Node
-from cudf_polars.dsl.to_ast import to_ast, to_parquet_filter
+from cudf_polars.dsl.to_ast import _DECIMAL_IDS, to_ast, to_parquet_filter
 from cudf_polars.dsl.tracing import log_do_evaluate, nvtx_annotate_cudf_polars
 from cudf_polars.dsl.utils.reshape import broadcast
 from cudf_polars.dsl.utils.windows import (
@@ -337,8 +337,6 @@ class PythonScan(IR):
         self.children = ()
         raise NotImplementedError("PythonScan not implemented")
 
-
-_DECIMAL_IDS = {plc.TypeId.DECIMAL32, plc.TypeId.DECIMAL64, plc.TypeId.DECIMAL128}
 
 _COMPARISON_BINOPS = {
     plc.binaryop.BinaryOperator.EQUAL,

--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -2017,7 +2017,7 @@ def _add_cast(
     side: expr.ColRef,
     left_casts: dict[str, DataType],
     right_casts: dict[str, DataType],
-) -> None:
+) -> None:  # pragma: no cover
     (col,) = side.children
     assert isinstance(col, expr.Col)
     casts = (
@@ -2039,7 +2039,9 @@ def _align_decimal_binop_types(
     ):
         target = DataType.common_decimal_dtype(left_type, right_type)
 
-        if left_type.id() != target.id() or left_type.scale() != target.scale():
+        if (
+            left_type.id() != target.id() or left_type.scale() != target.scale()
+        ):  # pragma: no cover
             _add_cast(target, left_expr, left_casts, right_casts)
 
         if right_type.id() != target.id() or right_type.scale() != target.scale():
@@ -2051,7 +2053,7 @@ def _align_decimal_binop_types(
     ) or (
         plc.traits.is_fixed_point(right_type.plc_type)
         and plc.traits.is_floating_point(left_type.plc_type)
-    ):
+    ):  # pragma: no cover
         is_decimal_left = plc.traits.is_fixed_point(left_type.plc_type)
         decimal_expr, float_expr = (
             (left_expr, right_expr) if is_decimal_left else (right_expr, left_expr)
@@ -2081,7 +2083,9 @@ def _collect_decimal_binop_casts(
     return left_casts, right_casts
 
 
-def _apply_casts(df: DataFrame, casts: dict[str, DataType]) -> DataFrame:
+def _apply_casts(
+    df: DataFrame, casts: dict[str, DataType]
+) -> DataFrame:  # pragma: no cover
     if not casts:
         return df
 

--- a/python/cudf_polars/cudf_polars/dsl/to_ast.py
+++ b/python/cudf_polars/cudf_polars/dsl/to_ast.py
@@ -176,7 +176,16 @@ def _(node: expr.BinOp, self: Transformer) -> plc_expr.Expression:
                 )
             ),
         )
-    return plc_expr.Operation(BINOP_TO_ASTOP[node.op], *map(self, node.children))
+    c1, c2 = node.children
+    if c1.dtype != c2.dtype:
+        if isinstance(c1, expr.Literal):
+            c1 = c1.astype(c2.dtype)
+        elif isinstance(c2, expr.Literal):
+            c2 = c2.astype(c1.dtype)
+        else:
+            raise NotImplementedError("BinOp with mismatching dtypes")
+    children = (c1, c2)
+    return plc_expr.Operation(BINOP_TO_ASTOP[node.op], *map(self, children))
 
 
 @_to_ast.register

--- a/python/cudf_polars/cudf_polars/dsl/to_ast.py
+++ b/python/cudf_polars/cudf_polars/dsl/to_ast.py
@@ -193,7 +193,9 @@ def _(node: expr.BinOp, self: Transformer) -> plc_expr.Expression:
             # unchanged.
             pass
         else:
-            raise NotImplementedError("BinOp with mismatching dtypes")
+            raise NotImplementedError(
+                "BinOp with mismatching dtypes"
+            )  # pragma: no cover
     children = (c1, c2)
     return plc_expr.Operation(BINOP_TO_ASTOP[node.op], *map(self, children))
 

--- a/python/cudf_polars/cudf_polars/dsl/to_ast.py
+++ b/python/cudf_polars/cudf_polars/dsl/to_ast.py
@@ -180,7 +180,7 @@ def _(node: expr.BinOp, self: Transformer) -> plc_expr.Expression:
         )
     c1, c2 = node.children
     if c1.dtype != c2.dtype:
-        if isinstance(c1, expr.Literal):
+        if isinstance(c1, expr.Literal):  # pragma: no cover
             c1 = c1.astype(c2.dtype)
         elif isinstance(c2, expr.Literal):
             c2 = c2.astype(c1.dtype)

--- a/python/cudf_polars/cudf_polars/dsl/to_ast.py
+++ b/python/cudf_polars/cudf_polars/dsl/to_ast.py
@@ -76,6 +76,8 @@ UOP_TO_ASTOP = {
     plc.unary.UnaryOperator.NOT: plc_expr.ASTOperator.NOT,
 }
 
+_DECIMAL_IDS = {plc.TypeId.DECIMAL32, plc.TypeId.DECIMAL64, plc.TypeId.DECIMAL128}
+
 
 class ASTState(TypedDict):
     """
@@ -182,6 +184,14 @@ def _(node: expr.BinOp, self: Transformer) -> plc_expr.Expression:
             c1 = c1.astype(c2.dtype)
         elif isinstance(c2, expr.Literal):
             c2 = c2.astype(c1.dtype)
+        elif (
+            isinstance(c1, (expr.Col, expr.ColRef)) and c1.dtype.id() in _DECIMAL_IDS
+        ) or (
+            isinstance(c2, (expr.Col, expr.ColRef)) and c2.dtype.id() in _DECIMAL_IDS
+        ):
+            # Allow mixed-precision decimal, or mixed decimal-float operations through
+            # unchanged.
+            pass
         else:
             raise NotImplementedError("BinOp with mismatching dtypes")
     children = (c1, c2)

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -282,6 +282,8 @@ def pytest_configure(config: pytest.Config):
     # test that shares a worker with a ray/dask test, so the suppression must
     # apply globally rather than per-module.
     config.addinivalue_line("filterwarnings", "ignore::ResourceWarning")
+    # https://github.com/open-telemetry/opentelemetry-python/issues/5231 (used by Ray)
+    config.addinivalue_line("filterwarnings", "ignore::DeprecationWarning")
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc):

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -741,7 +741,6 @@ def test_scan_parquet_zero_width_with_limit(
         (pl.Int32, pl.lit(2, dtype=pl.Int64)),
         (pl.Decimal(15, 2), pl.lit(1.5, dtype=pl.Float64)),
     ],
-    ids=repr,
 )
 @pytest.mark.parametrize("closed", ["both", "left", "right", "none"])
 def test_scan_parquet_is_between_literal_dtype_mismatch_22622(

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import datetime as dt
 import gzip
 import zlib
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 import zstandard as zstd
 from werkzeug import Response
@@ -722,3 +724,58 @@ def test_scan_parquet_zero_width_with_limit(
     pl.LazyFrame(height=20).sink_parquet(path)
     q = pl.scan_parquet(path).head(5)
     assert_gpu_result_equal(q, engine=active_engine)
+
+
+@pytest.mark.skipif(
+    POLARS_VERSION_LT_139,
+    reason="Change due to https://github.com/pola-rs/polars/pull/26663",
+)
+@pytest.mark.parametrize(
+    "column_dtype, lit",
+    [
+        (pl.Datetime("us"), np.datetime64("2021-01-02")),
+        (pl.Datetime("us"), pl.lit(dt.date(2021, 1, 2), dtype=pl.Date)),
+        (pl.Datetime("ms"), pl.lit(dt.date(2021, 1, 2), dtype=pl.Date)),
+        (pl.Datetime("ns"), pl.lit(dt.date(2021, 1, 2), dtype=pl.Date)),
+        (pl.Datetime("ns"), pl.lit(dt.datetime(2021, 1, 2), dtype=pl.Datetime("us"))),
+        (pl.Datetime("us"), pl.lit(dt.datetime(2021, 1, 2), dtype=pl.Datetime("ns"))),
+        (pl.Datetime("ns"), pl.lit(dt.datetime(2021, 1, 2), dtype=pl.Datetime("ms"))),
+        (pl.Duration("us"), pl.lit(dt.timedelta(seconds=1), dtype=pl.Duration("ns"))),
+        (pl.Duration("ns"), pl.lit(dt.timedelta(seconds=1), dtype=pl.Duration("us"))),
+        (pl.Int32, pl.lit(2, dtype=pl.Int64)),
+    ],
+    ids=repr,
+)
+@pytest.mark.parametrize("closed", ["both", "left", "right", "none"])
+def test_scan_parquet_is_between_literal_dtype_mismatch_22622(
+    engine: pl.GPUEngine, tmp_path, column_dtype, lit, closed
+):
+    if isinstance(column_dtype, pl.Datetime):
+        rows = [
+            dt.datetime(2021, 1, 1),
+            dt.datetime(2021, 1, 2),
+            dt.datetime(2021, 1, 2, 0, 0, 0, 1),
+            dt.datetime(2021, 1, 3),
+        ]
+        col = pl.Series("A", rows, dtype=column_dtype)
+    elif isinstance(column_dtype, pl.Duration):
+        col = pl.Series(
+            "A",
+            [
+                dt.timedelta(seconds=0),
+                dt.timedelta(seconds=1),
+                dt.timedelta(seconds=1, microseconds=1),
+                dt.timedelta(seconds=2),
+            ],
+            dtype=column_dtype,
+        )
+    else:  # integer
+        col = pl.Series("A", [0, 1, 2, 3], dtype=column_dtype)
+
+    pl.DataFrame([col]).write_parquet(tmp_path / "f.parquet")
+
+    q = pl.scan_parquet(tmp_path / "f.parquet").filter(
+        pl.col("A").is_between(lit, lit, closed=closed)
+    )
+
+    assert_gpu_result_equal(q, engine=engine)

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -726,10 +726,6 @@ def test_scan_parquet_zero_width_with_limit(
     assert_gpu_result_equal(q, engine=active_engine)
 
 
-@pytest.mark.skipif(
-    POLARS_VERSION_LT_139,
-    reason="Change due to https://github.com/pola-rs/polars/pull/26663",
-)
 @pytest.mark.parametrize(
     "column_dtype, lit",
     [

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -739,6 +739,7 @@ def test_scan_parquet_zero_width_with_limit(
         (pl.Duration("us"), pl.lit(dt.timedelta(seconds=1), dtype=pl.Duration("ns"))),
         (pl.Duration("ns"), pl.lit(dt.timedelta(seconds=1), dtype=pl.Duration("us"))),
         (pl.Int32, pl.lit(2, dtype=pl.Int64)),
+        (pl.Decimal(15, 2), pl.lit(1.5, dtype=pl.Float64)),
     ],
     ids=repr,
 )
@@ -763,6 +764,12 @@ def test_scan_parquet_is_between_literal_dtype_mismatch_22622(
                 dt.timedelta(seconds=1, microseconds=1),
                 dt.timedelta(seconds=2),
             ],
+            dtype=column_dtype,
+        )
+    elif isinstance(column_dtype, pl.Decimal):
+        col = pl.Series(
+            "A",
+            [Decimal("1.00"), Decimal("1.50"), Decimal("1.99"), Decimal("2.00")],
             dtype=column_dtype,
         )
     else:  # integer


### PR DESCRIPTION
## Description
For ast filters to work we must cast a literal in a binop to the dtype of the non-literal. The behaviour here was changed in pola-rs/polars#26663

closes https://github.com/rapidsai/cudf/issues/22622

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
