### PR TITLE
Backport #22551

### DIFF
--- a/python/cudf_polars/tests/streaming/test_spilling.py
+++ b/python/cudf_polars/tests/streaming/test_spilling.py
@@ -59,7 +59,15 @@ def test_make_spill_function(
     spilled_host_mem_type: MemoryType,
 ) -> None:
     """Test that spilling prioritizes longest queues and newest messages."""
-    engine = spmd_engine_factory(StreamingOptions(pinned_memory=pinned_memory))
+    try:
+        engine = spmd_engine_factory(
+            StreamingOptions(
+                pinned_memory=pinned_memory,
+                pinned_initial_pool_size=3 * 1024 * 1024,
+            )
+        )
+    except RuntimeError as e:
+        pytest.skip(f"Error creating engine: {e}")
     context = engine.context
 
     if spilled_host_mem_type == MemoryType.PINNED_HOST:
@@ -95,6 +103,10 @@ def test_make_spill_function(
             mid = sm.insert(msg)
             message_ids[buffer_idx].append(mid)
 
+    assert context.br().spill_manager.spill(1 * 1024 * 1024) == 0, (
+        "No messages should be spilled initially"
+    )
+
     # Register spill function
     spill_func = make_spill_function(buffers, context)
     func_id = context.br().spill_manager.add_spill_function(spill_func, priority=0)
@@ -107,6 +119,7 @@ def test_make_spill_function(
 
         # Allow some tolerance
         assert actual_spilled >= amount_to_spill * 0.95
+        assert actual_spilled <= amount_to_spill * 1.05
 
         # Verify Buffer 1 (longest queue): newest 3 messages should be spilled
         buffer_1_descs = buffers[1].get_content_descriptions()


### PR DESCRIPTION
## Description

In some CI runs, this test fails because it can't allocate pinned memory. If we observe that error up front, given we know how much pinned memory we'll need, just skip the test.

This is a backport of #22551 that probably should have go to `release/26.06` anyway.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
