### PR TITLE
Fix default ``target_partition_size`` singleton engine

### DIFF
--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -924,12 +924,7 @@ class ConfigOptions(Generic[ExecutorType]):
             case "streaming":
                 user_executor_options = user_executor_options.copy()
                 if "min_device_size" not in user_executor_options:
-                    try:
-                        user_executor_options["min_device_size"] = (
-                            get_total_device_memory()
-                        )
-                    except Exception:  # pragma: no cover
-                        user_executor_options["min_device_size"] = None
+                    user_executor_options["min_device_size"] = get_total_device_memory()
 
                 # Handle dynamic_planning: check user config, then env var
                 user_dynamic_planning = user_executor_options.get(

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -923,6 +923,13 @@ class ConfigOptions(Generic[ExecutorType]):
                 executor = InMemoryExecutor(**user_executor_options)
             case "streaming":
                 user_executor_options = user_executor_options.copy()
+                if "min_device_size" not in user_executor_options:
+                    try:
+                        user_executor_options["min_device_size"] = (
+                            get_total_device_memory()
+                        )
+                    except Exception:  # pragma: no cover
+                        user_executor_options["min_device_size"] = None
 
                 # Handle dynamic_planning: check user config, then env var
                 user_dynamic_planning = user_executor_options.get(

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import cast
 
 import pytest
@@ -371,7 +370,6 @@ def test_target_partition_from_env(
     monkeypatch: pytest.MonkeyPatch, recwarn: pytest.WarningsRecorder
 ) -> None:
     with monkeypatch.context() as m:
-        m.setitem(sys.modules, "pynvml", None)
         m.setenv("CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE", "100")
 
         engine = pl.GPUEngine(executor="streaming")

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -379,6 +379,18 @@ def test_target_partition_from_env(
         assert len(recwarn) == 0
 
 
+def test_target_partition_defaults_to_device_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with monkeypatch.context() as m:
+        m.delenv("CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE", raising=False)
+        m.setattr(cudf_polars.utils.config, "get_total_device_memory", lambda: 32 << 30)
+
+        config = ConfigOptions.from_polars_engine(pl.GPUEngine(executor="streaming"))
+        assert config.executor.min_device_size == 32 << 30
+        assert config.executor.target_partition_size == int((32 << 30) * 0.025)
+
+
 def test_fallback_mode_default(monkeypatch: pytest.MonkeyPatch) -> None:
     with monkeypatch.context() as m:
         m.setenv("CUDF_POLARS__EXECUTOR__FALLBACK_MODE", "silent")


### PR DESCRIPTION
## Description
The default singleton streaming engine is not using `get_total_device_memory` to set the `target_partition_size` configuration to an appropriate value. The `1.5GB` default will cause issues for smaller GPUs. We should fix this now.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
