### PR TITLE
Convert conftest-patch.py to a pytest plugin for pandas testing

### DIFF
--- a/ci/cudf_pandas_scripts/pandas-tests/run.sh
+++ b/ci/cudf_pandas_scripts/pandas-tests/run.sh
@@ -39,8 +39,6 @@ timeout 90m bash python/cudf/cudf/pandas/scripts/run-pandas-tests.sh \
   --durations=10 \
   --numprocesses 8 \
   --tb=line \
-  --disable-warnings \
-  -m "not slow and not single_cpu and not db and not network" \
   --max-worker-restart=3 \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-pandas.xml" \
   --dist worksteal \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,8 +157,6 @@ extend-unsafe-fixes = [
 [tool.ruff.lint.per-file-ignores]
 # We use "== None" to demonstrate null handling in this notebook
 "docs/cudf/source/cudf/missing-data.ipynb" = ["E711"]
-# Lots of pytest implicitly injected attributes in conftest-patch.py
-"python/cudf/cudf/pandas/scripts/conftest-patch.py" = ["F821"]
 "python/cudf/cudf/pandas/scripts/*" = ["D"]
 "python/cudf/cudf_pandas_tests/*" = ["D"]
 "ci/*" = ["T201"]

--- a/python/cudf/cudf/pandas/_wrappers/pandas.py
+++ b/python/cudf/cudf/pandas/_wrappers/pandas.py
@@ -1525,6 +1525,17 @@ def _register_assert_produces_warning(*args, **kwargs):
     return null_assert_produces_warning(*args, **kwargs)
 
 
+def null_raises_chained_assignment_error(*args, **kwargs):
+    # This assertion function also uses assert_produces_warning
+    # we want to ignore in pandas unit tests.
+    return null_assert_produces_warning(*args, **kwargs)
+
+
+@register_proxy_func(pd._testing.raises_chained_assignment_error)
+def _register_raises_chained_assignment_error(*args, **kwargs):
+    return null_raises_chained_assignment_error(*args, **kwargs)
+
+
 @nvtx.annotate(
     "CUDF_PANDAS_DATAFRAME_EVAL",
     color=_CUDF_PANDAS_NVTX_COLORS["EXECUTE_SLOW"],

--- a/python/cudf/cudf/pandas/_wrappers/pandas.py
+++ b/python/cudf/cudf/pandas/_wrappers/pandas.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import abc
+import contextlib
 import copyreg
 import datetime
 import functools
@@ -1506,6 +1507,22 @@ def _register_series_accessor(name):
 @register_proxy_func(pd.core.accessor.register_index_accessor)
 def _register_index_accessor(name):
     return pd.core.accessor._register_accessor(name, Index)
+
+
+@contextlib.contextmanager
+def null_assert_produces_warning(*args, **kwargs):
+    # We do not want pandas unit tests to fail because
+    # assert_produces_warning doesn't see a warning.
+    # No an explicit public API
+    try:
+        yield []
+    finally:
+        pass
+
+
+@register_proxy_func(pd._testing.assert_produces_warning)
+def _register_assert_produces_warning(*args, **kwargs):
+    return null_assert_produces_warning(*args, **kwargs)
 
 
 @nvtx.annotate(

--- a/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
+++ b/python/cudf/cudf/pandas/scripts/pandas-testing-plugin.py
@@ -1,9 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import contextlib
 import json
-import os
 import sys
 import traceback
 from collections import defaultdict
@@ -24,17 +22,8 @@ def replace_kwargs(new_kwargs):
     return wrapper
 
 
-@contextlib.contextmanager
-def null_assert_warnings(*args, **kwargs):
-    try:
-        yield []
-    finally:
-        pass
-
-
 @pytest.fixture(scope="session", autouse=True)
 def patch_testing_functions():
-    tm.assert_produces_warning = null_assert_warnings  # noqa: F821
     pytest.raises = replace_kwargs({"match": None})(pytest.raises)
 
 
@@ -7908,6 +7897,7 @@ NODEIDS_TO_SKIP: dict[str, str] = {
 }
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(session, config, items):
     for item in items:
         if (reason := NODEIDS_TO_SKIP.get(item.nodeid, None)) is not None:
@@ -7925,6 +7915,3 @@ def pytest_collection_modifyitems(session, config, items):
             item.add_marker(pytest.mark.skip(reason=reason))
         elif (reason := NODEIDS_THAT_FAIL.get(item.nodeid, None)) is not None:
             item.add_marker(pytest.mark.xfail(reason=reason))
-
-
-sys.path.append(os.path.dirname(__file__))

--- a/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
+++ b/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
@@ -15,7 +15,6 @@
 #
 # This script creates a `pandas-testing` directory if it doesn't exist
 #
-# If running locally, it's recommended to pass '-m "not slow and not single_cpu and not db"'
 
 set -euo pipefail
 
@@ -91,15 +90,16 @@ EOF
     done
 fi
 
-# append the contents of patch-confest.py to conftest.py
-cat ../python/cudf/cudf/pandas/scripts/conftest-patch.py >> pandas-tests/conftest.py
-
 # Run the tests
 cd pandas-tests/
 
 
-PANDAS_CI="1" python -m pytest -p cudf.pandas \
+PANDAS_CI="1" python -m pytest \
+    -p cudf.pandas \
+    -p cudf.pandas.scripts.pandas-testing-plugin \
     --import-mode=importlib \
+    -m "not slow and not single_cpu and not db and not network" \
+    --disable-warnings \
     "$@"
 
 mv ./*.json ..


### PR DESCRIPTION
## Description
This PR converts and renames `conftest-patch.py` to a`pandas-testing-plugin.py` pytest plugin file that can be used as pytest -p pandas-testing-plugin to patch pandas testing utilities and dynamically add our xfail or skip markers instead of modifying the existing pandas' conftest.py.

Hoping to reduce the modifications we make to the cloned repo in a follow up PR

Additionally moves some flags set in CI scripts to the script run locally for better CI/local alignment

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
