### PR TITLE
Remove deprecated `.values_host` property in cudf

### DIFF
--- a/docs/cudf/source/cudf/api_docs/dataframe.rst
+++ b/docs/cudf/source/cudf/api_docs/dataframe.rst
@@ -28,7 +28,6 @@ Attributes and underlying data
    DataFrame.info
    DataFrame.select_dtypes
    DataFrame.values
-   DataFrame.values_host
    DataFrame.ndim
    DataFrame.size
    DataFrame.shape

--- a/docs/cudf/source/cudf/api_docs/index_objects.rst
+++ b/docs/cudf/source/cudf/api_docs/index_objects.rst
@@ -38,7 +38,6 @@ Properties
    Index.transpose
    Index.T
    Index.values
-   Index.values_host
 
 Modifying and computations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/cudf/source/cudf/api_docs/series.rst
+++ b/docs/cudf/source/cudf/api_docs/series.rst
@@ -35,7 +35,6 @@ Attributes
    Series.empty
    Series.name
    Series.valid_count
-   Series.values_host
 
 Conversion
 ----------

--- a/docs/cudf/source/cudf/developer_guide/library_design.md
+++ b/docs/cudf/source/cudf/developer_guide/library_design.md
@@ -294,8 +294,7 @@ someone accesses data through the `__cuda_array_interface__`, we eagerly trigger
 
 A read-only object can be quite useful for operations that will not
 mutate the data. To achieve this, we create simple wrapper classes around the `ExposureTrackedBuffer` that will construct an equivalent CAI except it will get the pointer by calling `.get_ptr(mode="read")`, avoiding marking the pointer as exposed as would occur with a writeable ptr access.
-This will not trigger a deep copy even if multiple `ExposureTrackedBuffer`s point to the same `ExposureTrackedBufferOwner`. This approach should only be used when the lifetime of the proxy object is restricted to cudf's internal code execution. Handing this out to external libraries or user-facing APIs will lead to untracked references and undefined copy-on-write behavior. We currently use this API for device to host
-copies like in `ColumnBase.data_array_view(mode="read")` which is used for `Column.values_host`.
+This will not trigger a deep copy even if multiple `ExposureTrackedBuffer`s point to the same `ExposureTrackedBufferOwner`. This approach should only be used when the lifetime of the proxy object is restricted to cudf's internal code execution. Handing this out to external libraries or user-facing APIs will lead to untracked references and undefined copy-on-write behavior.
 
 
 ### Internal access to raw data pointers

--- a/python/cudf/benchmarks/API/bench_frame_or_index.py
+++ b/python/cudf/benchmarks/API/bench_frame_or_index.py
@@ -37,12 +37,6 @@ def bench_where(benchmark, frame_or_index):
 
 
 @benchmark_with_object(cls="frame_or_index", dtype="int", nulls=False)
-@pytest.mark.pandas_incompatible
-def bench_values_host(benchmark, frame_or_index):
-    benchmark(lambda: frame_or_index.to_numpy())
-
-
-@benchmark_with_object(cls="frame_or_index", dtype="int", nulls=False)
 def bench_values(benchmark, frame_or_index):
     benchmark(lambda: frame_or_index.values)
 

--- a/python/cudf/benchmarks/API/bench_rangeindex.py
+++ b/python/cudf/benchmarks/API/bench_rangeindex.py
@@ -4,11 +4,6 @@
 import pytest
 
 
-@pytest.mark.pandas_incompatible
-def bench_values_host(benchmark, rangeindex):
-    benchmark(lambda: rangeindex.to_numpy())
-
-
 def bench_to_numpy(benchmark, rangeindex):
     benchmark(rangeindex.to_numpy)
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1193,23 +1193,6 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
                 copy=False,
             )
 
-    @property
-    def values_host(self) -> np.ndarray:
-        """
-        Return a numpy representation of the Column.
-
-        .. deprecated:: 26.04
-            `values_host` is deprecated and will be removed in a future version.
-            Use `to_numpy()` instead.
-        """
-        warnings.warn(
-            "values_host is deprecated and will be removed in a future version. "
-            "Use to_numpy() instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.to_pandas().to_numpy()
-
     def to_numpy(self) -> np.ndarray:
         """
         Convert the Column to a NumPy array.

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -599,32 +599,6 @@ class Frame(BinaryOperand, Scannable, Serializable):
         """
         return self.to_cupy()
 
-    @property
-    @_performance_tracking
-    def values_host(self) -> np.ndarray:
-        """
-        Return a NumPy representation of the data.
-
-        Only the values in the DataFrame will be returned, the axes labels will
-        be removed.
-
-        .. deprecated:: 26.04
-            `values_host` is deprecated and will be removed in a future version.
-            Use `to_numpy()` instead.
-
-        Returns
-        -------
-        numpy.ndarray
-            A host representation of the underlying data.
-        """
-        warnings.warn(
-            "values_host is deprecated and will be removed in a future version. "
-            "Use to_numpy() instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.to_numpy()
-
     @_performance_tracking
     def __array__(self, dtype=None, copy=None):
         raise TypeError(

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2557,26 +2557,11 @@ class RangeIndex(Index):
     def values(self) -> cupy.ndarray:
         return cupy.arange(self.start, self.stop, self.step)
 
-    @cached_property
-    @_performance_tracking
-    def values_host(self) -> np.ndarray:
-        """
-        Return a numpy array from the RangeIndex.
-
-        .. deprecated:: 26.04
-            `values_host` is deprecated and will be removed in a future version.
-            Use `to_numpy()` instead.
-        """
-        warnings.warn(
-            "values_host is deprecated and will be removed in a future version. "
-            "Use to_numpy() instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return np.arange(self.start, self.stop, self.step)
-
     @_performance_tracking
     def to_numpy(self) -> np.ndarray:
+        """
+        Return a numpy array representation of the RangeIndex.
+        """
         return np.arange(self.start, self.stop, self.step)
 
     @_performance_tracking

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import itertools
 import numbers
 import operator
-import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -1294,28 +1293,10 @@ class MultiIndex(Index):
 
     @_performance_tracking
     def to_numpy(self) -> np.ndarray:
-        return self.to_pandas().values
-
-    def to_flat_index(self):
-        """
-        Convert a MultiIndex to an Index of Tuples containing the level values.
-
-        This is not currently implemented
-        """
-        # TODO: Could implement as Index of ListDtype?
-        raise NotImplementedError("to_flat_index is not currently supported.")
-
-    @property
-    @_performance_tracking
-    def values_host(self) -> np.ndarray:
         """
         Return a numpy representation of the MultiIndex.
 
         Only the values in the MultiIndex will be returned.
-
-        .. deprecated:: 26.04
-            `values_host` is deprecated and will be removed in a future version.
-            Use `to_numpy()` instead.
 
         Returns
         -------
@@ -1330,18 +1311,21 @@ class MultiIndex(Index):
         ...         codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
         ...         names=["x", "y"],
         ...     )
-        >>> midx.values_host  # doctest: +SKIP
+        >>> midx.to_numpy()
         array([(1, 1), (1, 5), (3, 2), (4, 2), (5, 1)], dtype=object)
-        >>> type(midx.values_host)  # doctest: +SKIP
+        >>> type(midx.to_numpy())
         <class 'numpy.ndarray'>
         """
-        warnings.warn(
-            "values_host is deprecated and will be removed in a future version. "
-            "Use to_numpy() instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
         return self.to_pandas().values
+
+    def to_flat_index(self):
+        """
+        Convert a MultiIndex to an Index of Tuples containing the level values.
+
+        This is not currently implemented
+        """
+        # TODO: Could implement as Index of ListDtype?
+        raise NotImplementedError("to_flat_index is not currently supported.")
 
     @property
     @_performance_tracking

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Self
 
 import cupy as cp
@@ -28,7 +27,6 @@ if TYPE_CHECKING:
     from collections.abc import Hashable, Mapping
     from types import NotImplementedType
 
-    import numpy as np
     import pyarrow as pa
 
     from cudf._typing import (
@@ -165,24 +163,6 @@ class SingleColumnFrame(Frame, NotIterable):
             .to_cupy(dtype=dtype, copy=copy, na_value=na_value)
             .reshape(len(self), order="F")
         )
-
-    @property  # type: ignore[explicit-override]
-    @_performance_tracking
-    def values_host(self) -> np.ndarray:
-        """
-        Return a numpy representation of the data.
-
-        .. deprecated:: 26.04
-            `values_host` is deprecated and will be removed in a future version.
-            Use `to_numpy()` instead.
-        """
-        warnings.warn(
-            "values_host is deprecated and will be removed in a future version. "
-            "Use to_numpy() instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self._column.to_numpy()
 
     @classmethod
     @_performance_tracking

--- a/python/cudf/cudf/tests/indexes/index/methods/test_to_numpy.py
+++ b/python/cudf/cudf/tests/indexes/index/methods/test_to_numpy.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import cudf
+
+
+@pytest.mark.parametrize("data", [[], [1]])
+def test_index_to_numpy(data, all_supported_types_as_str):
+    gdi = cudf.Index(data, dtype=all_supported_types_as_str)
+    pdi = pd.Index(data, dtype=all_supported_types_as_str)
+
+    np.testing.assert_array_equal(gdi.to_numpy(), pdi.values)

--- a/python/cudf/cudf/tests/indexes/index/test_attributes.py
+++ b/python/cudf/cudf/tests/indexes/index/test_attributes.py
@@ -114,14 +114,6 @@ def test_index_iter_error(data, all_supported_types_as_str):
         iter(gdi)
 
 
-@pytest.mark.parametrize("data", [[], [1]])
-def test_index_values_host(data, all_supported_types_as_str, request):
-    gdi = cudf.Index(data, dtype=all_supported_types_as_str)
-    pdi = pd.Index(data, dtype=all_supported_types_as_str)
-
-    np.testing.assert_array_equal(gdi.to_numpy(), pdi.values)
-
-
 def test_index_values():
     gidx = cudf.Index([1, 2, 3])
     pidx = gidx.to_pandas()

--- a/python/cudf/cudf/tests/indexes/multiindex/methods/test_to_numpy.py
+++ b/python/cudf/cudf/tests/indexes/multiindex/methods/test_to_numpy.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+import cudf
+from cudf.testing import assert_eq
+
+
+def test_multiindex_to_numpy():
+    midx = cudf.MultiIndex(
+        levels=[[1, 3, 4, 5], [1, 2, 5]],
+        codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
+        names=["x", "y"],
+    )
+    pmidx = midx.to_pandas()
+
+    assert_eq(midx.to_numpy(), pmidx.values)

--- a/python/cudf/cudf/tests/indexes/multiindex/test_attributes.py
+++ b/python/cudf/cudf/tests/indexes/multiindex/test_attributes.py
@@ -186,17 +186,6 @@ def test_multiindex_values():
     )
 
 
-def test_multiindex_values_host():
-    midx = cudf.MultiIndex(
-        levels=[[1, 3, 4, 5], [1, 2, 5]],
-        codes=[[0, 0, 1, 2, 3], [0, 2, 1, 1, 0]],
-        names=["x", "y"],
-    )
-    pmidx = midx.to_pandas()
-
-    assert_eq(midx.to_numpy(), pmidx.values)
-
-
 @pytest.mark.parametrize(
     "pdi",
     [

--- a/python/cudf/cudf/tests/series/methods/test_to_numpy.py
+++ b/python/cudf/cudf/tests/series/methods/test_to_numpy.py
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import cupy as cp
 import numpy as np
+import pandas as pd
 import pytest
 
 import cudf
@@ -33,3 +34,20 @@ def test_timedelta_series_to_numpy(data, timedelta_types_as_str):
     actual = gsr.dropna().to_numpy()
 
     np.testing.assert_array_equal(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [1, 2, 4],
+        [],
+        [5.0, 7.0, 8.0],
+        pd.Categorical(["a", "b", "c"]),
+        ["m", "a", "d", "v"],
+    ],
+)
+def test_series_to_numpy(data):
+    pds = pd.Series(data=data, dtype=None if data else float)
+    gds = cudf.Series(data=data, dtype=None if data else float)
+
+    np.testing.assert_array_equal(pds.values, gds.to_numpy())

--- a/python/cudf/cudf/tests/series/test_attributes.py
+++ b/python/cudf/cudf/tests/series/test_attributes.py
@@ -392,23 +392,6 @@ def test_series_shape_empty():
         [1, 2, 4],
         [],
         [5.0, 7.0, 8.0],
-        pd.Categorical(["a", "b", "c"]),
-        ["m", "a", "d", "v"],
-    ],
-)
-def test_series_values_host_property(data):
-    pds = pd.Series(data=data, dtype=None if data else float)
-    gds = cudf.Series(data=data, dtype=None if data else float)
-
-    np.testing.assert_array_equal(pds.values, gds.to_numpy())
-
-
-@pytest.mark.parametrize(
-    "data",
-    [
-        [1, 2, 4],
-        [],
-        [5.0, 7.0, 8.0],
         pytest.param(
             pd.Categorical(["a", "b", "c"]),
             marks=pytest.mark.xfail(raises=NotImplementedError),


### PR DESCRIPTION
## Description
Deprecated in 26.04

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
