### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/cpp/include/cudf/io/detail/json.hpp
+++ b/cpp/include/cudf/io/detail/json.hpp
@@ -31,6 +31,21 @@ table_with_metadata read_json(host_span<std::unique_ptr<datasource>> sources,
                               rmm::device_async_resource_ref mr);
 
 /**
+ * @brief Reads and returns the entire data set along with reader-specific diagnostics.
+ *
+ * @param sources Input `datasource` objects to read the dataset from
+ * @param options Settings for controlling reading behavior
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource to use for device memory allocation
+ *
+ * @return Parsed table, metadata, and JSON reader diagnostics
+ */
+json_reader_result read_json_with_diagnostics(host_span<std::unique_ptr<datasource>> sources,
+                                              json_reader_options const& options,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::device_async_resource_ref mr);
+
+/**
  * @brief Write an entire dataset to JSON format.
  *
  * @param sink Output sink

--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -924,6 +924,57 @@ table_with_metadata read_json(
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
+/**
+ * @brief Optional diagnostics produced by `read_json_with_diagnostics`.
+ *
+ * Reserved for signals that don't belong on the result `table_metadata` because
+ * they are reader-specific (and adding them to the shared `column_name_info` would
+ * change the public ABI for that struct, breaking downstream packages that have
+ * its destructor inlined into their binaries).
+ */
+struct json_reader_diagnostics {
+  /**
+   * @brief Top-level column names whose value tree contained at least one JSON node
+   * whose category (`NC_STRUCT` / `NC_LIST` / `NC_VAL`) did not match the requested
+   * schema type. Empty when the reader is invoked without a user-supplied schema or
+   * when no mismatches were observed.
+   *
+   * Consumers (e.g. spark-rapids-jni) can use this signal to implement their own
+   * per-column policy on schema mismatch (e.g. Spark's `JacksonParser` nulls the
+   * entire depth-1 ancestor field for such rows).
+   */
+  std::vector<std::string> top_level_columns_with_schema_mismatch;
+};
+
+/**
+ * @brief Result of `read_json_with_diagnostics`: the parsed table together with
+ * reader-specific diagnostics.
+ */
+struct json_reader_result {
+  table_with_metadata data;             ///< Parsed table and standard table metadata
+  json_reader_diagnostics diagnostics;  ///< Reader-specific diagnostics
+};
+
+/**
+ * @brief Reads a JSON dataset into a set of columns, additionally reporting reader
+ * diagnostics that do not belong on the standard `table_metadata`.
+ *
+ * Behaves identically to `read_json` for column construction. The additional
+ * `diagnostics` field carries reader-specific observations such as
+ * `top_level_columns_with_schema_mismatch`.
+ *
+ * @param options Settings for controlling reading behavior
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate device memory of the table in the returned
+ * result.
+ *
+ * @return The parsed table, its metadata, and reader diagnostics
+ */
+json_reader_result read_json_with_diagnostics(
+  json_reader_options options,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
 /** @} */  // end of group
 
 /**

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -242,6 +242,21 @@ table_with_metadata read_json(json_reader_options options,
   return json::detail::read_json(datasources, options, stream, mr);
 }
 
+json_reader_result read_json_with_diagnostics(json_reader_options options,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+
+  options.set_compression(infer_compression_type(options.get_compression(), options.get_source()));
+
+  auto datasources = make_datasources(options.get_source(),
+                                      options.get_byte_range_offset(),
+                                      options.get_byte_range_size_with_padding());
+
+  return json::detail::read_json_with_diagnostics(datasources, options, stream, mr);
+}
+
 void write_json(json_writer_options const& options, rmm::cuda_stream_view stream)
 {
   auto sinks = make_datasinks(options.get_sink());

--- a/cpp/src/io/json/host_tree_algorithms.cu
+++ b/cpp/src/io/json/host_tree_algorithms.cu
@@ -507,6 +507,14 @@ std::
     }
     return -1;
   };
+  // Collected during mark_is_pruned: each col_id whose JSON-tree category did not match the
+  // requested schema type (and was therefore pruned). After `construct_tree` returns we walk each
+  // entry up to its top-level ancestor and add that ancestor's name to
+  // `root.schema_mismatch_column_names`, which (when the caller invoked
+  // `device_parse_nested_json_with_diagnostics`) feeds
+  // `json_reader_diagnostics::top_level_columns_with_schema_mismatch`.
+  auto mismatched_col_ids = std::vector<NodeIndexT>{};
+
   // recursive lambda on schema to mark columns as pruned.
   std::function<void(NodeIndexT root, schema_element const& schema)> mark_is_pruned;
   mark_is_pruned = [&is_pruned,
@@ -515,7 +523,8 @@ std::
                     &lookup_names,
                     &column_categories,
                     &expected_types,
-                    &ignore_all_children](NodeIndexT root, schema_element const& schema) -> void {
+                    &ignore_all_children,
+                    &mismatched_col_ids](NodeIndexT root, schema_element const& schema) -> void {
     if (root == -1) return;
     bool pass =
       (schema.type == data_type{type_id::STRUCT} and column_categories[root] == NC_STRUCT) or
@@ -523,6 +532,11 @@ std::
       (schema.type != data_type{type_id::STRUCT} and schema.type != data_type{type_id::LIST} and
        column_categories[root] != NC_FN);
     if (!pass) {
+      // The JSON tree's actual category for this node disagrees with the requested schema type
+      // (e.g. JSON has a scalar where schema expects a struct). Record the col_id so that after
+      // `construct_tree` builds the device tree we can walk up to the top-level ancestor and
+      // record the diagnostic on `device_json_column::schema_mismatch_column_names`.
+      mismatched_col_ids.push_back(root);
       // ignore all children of this column and prune this column.
       is_pruned[root] = true;
       ignore_all_children(root);
@@ -654,6 +668,15 @@ std::
     is_enabled_lines
       ? adj[parent_node_sentinel][0]
       : (adj[adj[parent_node_sentinel][0]].empty() ? -1 : adj[adj[parent_node_sentinel][0]][0]);
+  auto add_top_level_schema_mismatch = [&](NodeIndexT col_id) {
+    while (col_id != parent_node_sentinel and col_id != -1) {
+      if (column_parent_ids[col_id] == named_level) {
+        root.schema_mismatch_column_names.insert(column_names[col_id]);
+        return;
+      }
+      col_id = column_parent_ids[col_id];
+    }
+  };
 
   // List children which are pruned mixed types, nullify parent list row.
   auto is_mixed_pruned = cudf::detail::make_host_vector<bool>(num_columns, stream);
@@ -841,6 +864,14 @@ std::
     if (expected_types[i] == NC_STR) {
       if (columns.count(i)) { columns.at(i).get().forced_as_string_column = true; }
     }
+  }
+
+  // For each schema-mismatched col_id (collected in `mark_is_pruned` above), record the name of
+  // its top-level output column on `root.schema_mismatch_column_names`. The diagnostic is only
+  // surfaced per top-level output column, so we do not need to mark intermediate ancestors'
+  // `device_json_column`s.
+  for (auto const mismatched_id : mismatched_col_ids) {
+    add_top_level_schema_mismatch(mismatched_id);
   }
   std::transform(expected_types.cbegin(),
                  expected_types.cend(),

--- a/cpp/src/io/json/json_column.cu
+++ b/cpp/src/io/json/json_column.cu
@@ -34,6 +34,8 @@
 #include <thrust/transform.h>
 #include <thrust/unique.h>
 
+#include <algorithm>
+
 namespace cudf::io::json::detail {
 
 auto to_cat = [](auto v) -> std::string {
@@ -504,10 +506,17 @@ std::pair<std::unique_ptr<column>, std::vector<column_name_info>> device_json_co
   }
 }
 
-table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
-                                             cudf::io::json_reader_options const& options,
-                                             rmm::cuda_stream_view stream,
-                                             rmm::device_async_resource_ref mr)
+namespace {
+
+// Shared body of `device_parse_nested_json` and `device_parse_nested_json_with_diagnostics`.
+// When `mismatched_columns_out` is non-null, the names of top-level output columns whose JSON
+// value tree contained a schema-mismatch are pushed onto it (deduplicated, order preserved by
+// the column order of the result). When null, schema-mismatch information is dropped.
+table_with_metadata device_parse_nested_json_impl(device_span<SymbolT const> d_input,
+                                                  cudf::io::json_reader_options const& options,
+                                                  rmm::cuda_stream_view stream,
+                                                  rmm::device_async_resource_ref mr,
+                                                  std::vector<std::string>* mismatched_columns_out)
 {
   CUDF_FUNC_RANGE();
 
@@ -605,7 +614,10 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
     CUDF_EXPECTS(prune_schema->child_types.size() == col_order.size(),
                  "Input schema column order size mismatch with input schema child types");
   }
-  auto root_col_size = root_struct_col.num_rows;
+  auto root_col_size              = root_struct_col.num_rows;
+  auto column_had_schema_mismatch = [&root_column](std::string const& col_name) {
+    return root_column.schema_mismatch_column_names.contains(col_name);
+  };
 
   // Iterate over the struct's child columns/column_order and convert to cudf column
   size_type column_index = 0;
@@ -668,6 +680,9 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
                    "prune_columns is enabled");
       // inserts all null column
       out_column_names.emplace_back(make_column_name_info(child_schema_element.value(), col_name));
+      if (mismatched_columns_out != nullptr && column_had_schema_mismatch(col_name)) {
+        mismatched_columns_out->push_back(col_name);
+      }
       auto all_null_column =
         make_all_nulls_column(child_schema_element.value(), root_col_size, stream, mr);
       out_columns.emplace_back(std::move(all_null_column));
@@ -694,6 +709,12 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
       // }
 
       out_column_names.back().children = std::move(col_name_info);
+      // When the caller requested diagnostics, surface the per-top-level-column schema-mismatch
+      // signal so they can implement their own policy (e.g. spark-rapids-jni nulls the depth-1
+      // ancestor for Spark-compat).
+      if (mismatched_columns_out != nullptr && column_had_schema_mismatch(col_name)) {
+        mismatched_columns_out->push_back(col_name);
+      }
       out_columns.emplace_back(std::move(cudf_col));
 
       column_index++;
@@ -701,6 +722,30 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
   }
 
   return table_with_metadata{std::make_unique<table>(std::move(out_columns)), {out_column_names}};
+}
+
+}  // namespace
+
+table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
+                                             cudf::io::json_reader_options const& options,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return device_parse_nested_json_impl(
+    d_input, options, stream, mr, /*mismatched_columns_out=*/nullptr);
+}
+
+device_parse_nested_json_result device_parse_nested_json_with_diagnostics(
+  device_span<SymbolT const> d_input,
+  cudf::io::json_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  std::vector<std::string> mismatched_columns;
+  auto data = device_parse_nested_json_impl(d_input, options, stream, mr, &mismatched_columns);
+  return device_parse_nested_json_result{std::move(data), std::move(mismatched_columns)};
 }
 
 }  // namespace cudf::io::json::detail

--- a/cpp/src/io/json/nested_json.hpp
+++ b/cpp/src/io/json/nested_json.hpp
@@ -11,6 +11,7 @@
 #include <cudf/utilities/export.hpp>
 
 #include <map>
+#include <unordered_set>
 #include <vector>
 
 // Forward declaration of parse_options from parsing_utils.cuh
@@ -159,6 +160,15 @@ struct device_json_column {
   row_offset_t num_rows = 0;
   // Force as string column
   bool forced_as_string_column{false};
+
+  // Top-level output column names that encountered a schema mismatch in any descendant. Stored
+  // only on the root column (empty on every non-root `device_json_column`). When the caller
+  // invokes the diagnostics-aware reader path, this set feeds
+  // `json_reader_diagnostics::top_level_columns_with_schema_mismatch` on the result. When the
+  // caller invokes the plain `read_json` path, this set is computed but discarded. Using a set
+  // (rather than a vector) keeps `add_top_level_schema_mismatch` and the metadata-emit lookup at
+  // O(1) and naturally deduplicates names.
+  std::unordered_set<std::string> schema_mismatch_column_names;
 
   /**
    * @brief Construct a new d json column object
@@ -425,6 +435,32 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> input,
                                              cudf::io::json_reader_options const& options,
                                              rmm::cuda_stream_view stream,
                                              rmm::device_async_resource_ref mr);
+
+/**
+ * @brief Result of `device_parse_nested_json_with_diagnostics`.
+ */
+struct device_parse_nested_json_result {
+  table_with_metadata data;
+  std::vector<std::string> top_level_columns_with_schema_mismatch;
+};
+
+/**
+ * @brief Same as `device_parse_nested_json`, but additionally reports the names of top-level
+ * output columns whose JSON value tree contained at least one schema mismatch against the
+ * user-supplied schema. Empty when no schema is supplied or no mismatches were observed.
+ *
+ * @param input The JSON input
+ * @param options Parsing options specifying the parsing behaviour
+ * @param stream The CUDA stream to which kernels are dispatched
+ * @param mr Optional, resource with which to allocate
+ * @return The parsed data plus the list of mismatched top-level column names
+ */
+CUDF_EXPORT
+device_parse_nested_json_result device_parse_nested_json_with_diagnostics(
+  device_span<SymbolT const> input,
+  cudf::io::json_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
 
 /**
  * @brief Create empty column of a given nested schema

--- a/cpp/src/io/json/read_json.cu
+++ b/cpp/src/io/json/read_json.cu
@@ -34,6 +34,7 @@
 
 #include <functional>
 #include <numeric>
+#include <unordered_set>
 
 namespace cudf::io::json::detail {
 
@@ -409,7 +410,8 @@ std::pair<table_with_metadata, std::optional<table_with_metadata>> read_batch(
   host_span<std::unique_ptr<datasource>> sources,
   json_reader_options const& reader_opts,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
+  rmm::device_async_resource_ref mr,
+  std::vector<std::string>* mismatched_cols_out = nullptr)
 {
   CUDF_FUNC_RANGE();
   // The second owning buffer in the pair returned by get_record_range_raw_input may not be
@@ -427,9 +429,22 @@ std::pair<table_with_metadata, std::optional<table_with_metadata>> read_batch(
     stream.synchronize();
   }
 
+  // Helper: parse one buffer, optionally appending top-level mismatched column names to
+  // `*mismatched_cols_out`. The two call sites below would otherwise duplicate this branching.
+  auto parse_buffer = [&](cudf::device_span<char const> buf) {
+    if (mismatched_cols_out != nullptr) {
+      auto result = device_parse_nested_json_with_diagnostics(buf, reader_opts, stream, mr);
+      mismatched_cols_out->insert(mismatched_cols_out->end(),
+                                  result.top_level_columns_with_schema_mismatch.begin(),
+                                  result.top_level_columns_with_schema_mismatch.end());
+      return std::move(result.data);
+    }
+    return device_parse_nested_json(buf, reader_opts, stream, mr);
+  };
+
   auto buffer = cudf::device_span<char const>(
     reinterpret_cast<char const*>(owning_buffers.first.data()), owning_buffers.first.size());
-  auto first_partial_table = device_parse_nested_json(buffer, reader_opts, stream, mr);
+  auto first_partial_table = parse_buffer(buffer);
   if (!owning_buffers.second.has_value())
     return std::make_pair(std::move(first_partial_table), std::nullopt);
 
@@ -444,7 +459,7 @@ std::pair<table_with_metadata, std::optional<table_with_metadata>> read_batch(
   buffer = cudf::device_span<char const>(
     reinterpret_cast<char const*>(owning_buffers.second.value().data()),
     owning_buffers.second.value().size());
-  auto second_partial_table = device_parse_nested_json(buffer, reader_opts, stream, mr);
+  auto second_partial_table = parse_buffer(buffer);
   return std::make_pair(std::move(first_partial_table), std::move(second_partial_table));
 }
 
@@ -461,7 +476,8 @@ std::pair<table_with_metadata, std::optional<table_with_metadata>> read_batch(
 table_with_metadata read_json_impl(host_span<std::unique_ptr<datasource>> sources,
                                    json_reader_options const& reader_opts,
                                    rmm::cuda_stream_view stream,
-                                   rmm::device_async_resource_ref mr)
+                                   rmm::device_async_resource_ref mr,
+                                   std::vector<std::string>* mismatched_cols_out = nullptr)
 {
   std::size_t const total_source_size = sources_size(sources, 0, 0);
 
@@ -589,8 +605,11 @@ table_with_metadata read_json_impl(host_span<std::unique_ptr<datasource>> source
 
   if (batch_offsets.size() <= 2) {
     // single batch
-    auto has_inserted = insert_partial_tables(
-      read_batch(sources, batched_reader_opts, stream, cudf::get_current_device_resource_ref()));
+    auto has_inserted = insert_partial_tables(read_batch(sources,
+                                                         batched_reader_opts,
+                                                         stream,
+                                                         cudf::get_current_device_resource_ref(),
+                                                         mismatched_cols_out));
     if (!has_inserted) {
       return table_with_metadata{std::make_unique<table>(std::vector<std::unique_ptr<column>>{}),
                                  {std::vector<column_name_info>{}}};
@@ -599,8 +618,11 @@ table_with_metadata read_json_impl(host_span<std::unique_ptr<datasource>> source
     // multiple batches
     batched_reader_opts.set_byte_range_offset(batch_offsets[0]);
     batched_reader_opts.set_byte_range_size(batch_offsets[1] - batch_offsets[0]);
-    insert_partial_tables(
-      read_batch(sources, batched_reader_opts, stream, cudf::get_current_device_resource_ref()));
+    insert_partial_tables(read_batch(sources,
+                                     batched_reader_opts,
+                                     stream,
+                                     cudf::get_current_device_resource_ref(),
+                                     mismatched_cols_out));
 
     auto& tbl = partial_tables.back().tbl;
     std::vector<column_view> children;
@@ -619,8 +641,11 @@ table_with_metadata read_json_impl(host_span<std::unique_ptr<datasource>> source
       batched_reader_opts.set_byte_range_offset(batch_offsets[batch_offset_pos]);
       batched_reader_opts.set_byte_range_size(batch_offsets[batch_offset_pos + 1] -
                                               batch_offsets[batch_offset_pos]);
-      auto has_inserted = insert_partial_tables(
-        read_batch(sources, batched_reader_opts, stream, cudf::get_current_device_resource_ref()));
+      auto has_inserted = insert_partial_tables(read_batch(sources,
+                                                           batched_reader_opts,
+                                                           stream,
+                                                           cudf::get_current_device_resource_ref(),
+                                                           mismatched_cols_out));
 
       if (!has_inserted) {
         CUDF_EXPECTS(batch_offset_pos == batch_offsets.size() - 2,
@@ -745,13 +770,18 @@ device_span<char> ingest_raw_input(device_span<char> buffer,
   return buffer.first(bytes_read + (delimiter_map.size() * num_delimiter_chars));
 }
 
-table_with_metadata read_json(host_span<std::unique_ptr<datasource>> sources,
-                              json_reader_options const& reader_opts,
-                              rmm::cuda_stream_view stream,
-                              rmm::device_async_resource_ref mr)
-{
-  CUDF_FUNC_RANGE();
+namespace {
 
+// Shared body of detail::read_json (no diagnostics) and detail::read_json_with_diagnostics. When
+// `mismatched_cols_out` is non-null, the names of top-level output columns whose JSON value tree
+// contained a schema-mismatch (against the user-supplied schema) are appended to it; in multi-
+// batch reads, entries are accumulated across batches and deduplicated below.
+table_with_metadata read_json_dispatch(host_span<std::unique_ptr<datasource>> sources,
+                                       json_reader_options const& reader_opts,
+                                       rmm::cuda_stream_view stream,
+                                       rmm::device_async_resource_ref mr,
+                                       std::vector<std::string>* mismatched_cols_out)
+{
   if (reader_opts.get_byte_range_offset() != 0 or reader_opts.get_byte_range_size() != 0) {
     CUDF_EXPECTS(reader_opts.is_enabled_lines(),
                  "Specifying a byte range is supported only for JSON Lines");
@@ -763,7 +793,7 @@ table_with_metadata read_json(host_span<std::unique_ptr<datasource>> sources,
   }
 
   if (reader_opts.get_compression() == compression_type::NONE)
-    return read_json_impl(sources, reader_opts, stream, mr);
+    return read_json_impl(sources, reader_opts, stream, mr, mismatched_cols_out);
 
   std::vector<std::unique_ptr<datasource>> compressed_sources;
   std::vector<std::future<std::unique_ptr<compressed_host_buffer_source>>> thread_tasks;
@@ -779,7 +809,39 @@ table_with_metadata read_json(host_span<std::unique_ptr<datasource>> sources,
                  [](auto& task) { return task.get(); });
   // in read_json_impl, we need the compressed source size to actually be the
   // uncompressed source size for correct batching
-  return read_json_impl(compressed_sources, reader_opts, stream, mr);
+  return read_json_impl(compressed_sources, reader_opts, stream, mr, mismatched_cols_out);
+}
+
+}  // namespace
+
+table_with_metadata read_json(host_span<std::unique_ptr<datasource>> sources,
+                              json_reader_options const& reader_opts,
+                              rmm::cuda_stream_view stream,
+                              rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return read_json_dispatch(sources, reader_opts, stream, mr, /*mismatched_cols_out=*/nullptr);
+}
+
+json_reader_result read_json_with_diagnostics(host_span<std::unique_ptr<datasource>> sources,
+                                              json_reader_options const& reader_opts,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  std::vector<std::string> mismatched_cols;
+  auto data = read_json_dispatch(sources, reader_opts, stream, mr, &mismatched_cols);
+
+  // In multi-batch reads the same top-level column may appear in more than one batch's
+  // mismatch list; deduplicate while preserving first-occurrence order.
+  std::unordered_set<std::string> seen;
+  std::vector<std::string> deduped;
+  deduped.reserve(mismatched_cols.size());
+  for (auto& name : mismatched_cols) {
+    if (seen.insert(name).second) { deduped.emplace_back(std::move(name)); }
+  }
+
+  return json_reader_result{std::move(data), json_reader_diagnostics{std::move(deduped)}};
 }
 
 }  // namespace cudf::io::json::detail

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -3675,6 +3675,121 @@ TEST_F(JsonReaderTest, DeviceWriteAsyncThrows)
   }
 }
 
+// Tests for the per-top-level-column schema-mismatch diagnostic surfaced by
+// `read_json_with_diagnostics`. Downstream callers (e.g. spark-rapids-jni) use this signal to
+// implement their own policy when a JSON value's node category does not match the requested
+// schema. cuDF itself does NOT change the column contents on mismatch (existing
+// CHILD_NULL_ONLY behavior); the diagnostic is reported on a separate side channel so the
+// public `column_name_info`/`table_metadata` ABI is unaffected.
+// See https://github.com/rapidsai/cudf/issues/22423.
+
+// Build schema for: struct<c1: int64, c2: list<struct<c3: int64, c4: string>>>.
+// Pin column order so cuDF emits columns in (c1, c2) regardless of JSON-encounter order.
+cudf::io::schema_element make_nested_mismatch_schema_st()
+{
+  cudf::io::schema_element st_c2_elem{
+    cudf::data_type{cudf::type_id::STRUCT},
+    {{"c3", cudf::io::schema_element{cudf::data_type{cudf::type_id::INT64}}},
+     {"c4", cudf::io::schema_element{cudf::data_type{cudf::type_id::STRING}}}},
+    std::vector<std::string>{"c3", "c4"}};
+  cudf::io::schema_element st_c2{
+    cudf::data_type{cudf::type_id::LIST}, {{"element", st_c2_elem}}, std::vector<std::string>{}};
+  return cudf::io::schema_element{
+    cudf::data_type{cudf::type_id::STRUCT},
+    {{"c1", cudf::io::schema_element{cudf::data_type{cudf::type_id::INT64}}}, {"c2", st_c2}},
+    std::vector<std::string>{"c1", "c2"}};
+}
+
+TEST_F(JsonReaderTest, SchemaMismatchDiagNoMismatchEmpty)
+{
+  // Well-formed nested JSON: schema matches everywhere, so the diagnostic list stays empty.
+  std::string const json = "{\"data\": {\"c2\": [{\"c3\": 19, \"c4\": \"x\"}], \"c1\": 123456}}\n";
+  cudf::io::schema_element root{cudf::data_type{cudf::type_id::STRUCT},
+                                {{"data", make_nested_mismatch_schema_st()}}};
+  auto opts = cudf::io::json_reader_options::builder(
+                cudf::io::source_info{cudf::host_span<std::byte const>{
+                  reinterpret_cast<std::byte const*>(json.data()), json.size()}})
+                .lines(true)
+                .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+                .dtypes(root)
+                .prune_columns(true)
+                .build();
+  auto result = cudf::io::read_json_with_diagnostics(opts);
+  ASSERT_EQ(result.data.metadata.schema_info.size(), 1u);
+  EXPECT_TRUE(result.diagnostics.top_level_columns_with_schema_mismatch.empty());
+}
+
+TEST_F(JsonReaderTest, SchemaMismatchDiagNestedMismatchListed)
+{
+  // df2 case from SPARK-33134: {"data": {"c2":[19],"c1":123456}}
+  // c2 expects list<struct> but JSON has list<int>; nested mismatch at depth 3.
+  // Diagnostic should list top-level "data" column. The cudf result table is unchanged
+  // (data row stays populated, partial — existing CHILD_NULL_ONLY behavior).
+  std::string const json = "{\"data\": {\"c2\": [19], \"c1\": 123456}}\n";
+  cudf::io::schema_element root{cudf::data_type{cudf::type_id::STRUCT},
+                                {{"data", make_nested_mismatch_schema_st()}}};
+  auto opts = cudf::io::json_reader_options::builder(
+                cudf::io::source_info{cudf::host_span<std::byte const>{
+                  reinterpret_cast<std::byte const*>(json.data()), json.size()}})
+                .lines(true)
+                .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+                .dtypes(root)
+                .prune_columns(true)
+                .build();
+  auto result = cudf::io::read_json_with_diagnostics(opts);
+  ASSERT_EQ(result.data.metadata.schema_info.size(), 1u);
+  EXPECT_EQ(result.diagnostics.top_level_columns_with_schema_mismatch,
+            std::vector<std::string>{"data"});
+  // Default cudf behavior: column itself is not nulled (caller applies policy).
+  EXPECT_EQ(result.data.tbl->get_column(0).null_count(), 0);
+}
+
+TEST_F(JsonReaderTest, SchemaMismatchDiagRootLevelMismatchListed)
+{
+  // c2 is a scalar while the schema requests list<struct>. This fully prunes c2 from the parsed
+  // device column tree, so the reader synthesizes it from the schema as an all-null top-level
+  // column. The diagnostic must still list "c2", while "c1" must not appear.
+  std::string const json = "{\"c2\": 19, \"c1\": 123456}\n";
+  auto root_schema       = make_nested_mismatch_schema_st();
+  auto opts              = cudf::io::json_reader_options::builder(
+                cudf::io::source_info{cudf::host_span<std::byte const>{
+                  reinterpret_cast<std::byte const*>(json.data()), json.size()}})
+                .lines(true)
+                .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+                .dtypes(root_schema)
+                .prune_columns(true)
+                .build();
+  auto result = cudf::io::read_json_with_diagnostics(opts);
+  ASSERT_EQ(result.data.metadata.schema_info.size(), 2u);
+  EXPECT_EQ(result.diagnostics.top_level_columns_with_schema_mismatch,
+            std::vector<std::string>{"c2"});
+  EXPECT_EQ(result.data.tbl->get_column(1).type().id(), cudf::type_id::LIST);
+  EXPECT_EQ(result.data.tbl->get_column(1).null_count(), 1);
+}
+
+TEST_F(JsonReaderTest, SchemaMismatchDiagPlainReadJsonUnaffected)
+{
+  // The plain `read_json` path does not pay the cost of collecting diagnostics: its result
+  // matches the pre-PR behavior bit-for-bit (column count, null counts, schema_info contents).
+  // The diagnostic side-channel is exposed only through `read_json_with_diagnostics`, so
+  // existing downstream consumers — including those that bake `column_name_info`'s destructor
+  // into their own binaries — see no observable change.
+  std::string const json = "{\"data\": {\"c2\": [19], \"c1\": 123456}}\n";
+  cudf::io::schema_element root{cudf::data_type{cudf::type_id::STRUCT},
+                                {{"data", make_nested_mismatch_schema_st()}}};
+  auto opts = cudf::io::json_reader_options::builder(
+                cudf::io::source_info{cudf::host_span<std::byte const>{
+                  reinterpret_cast<std::byte const*>(json.data()), json.size()}})
+                .lines(true)
+                .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+                .dtypes(root)
+                .prune_columns(true)
+                .build();
+  auto result = cudf::io::read_json(opts);
+  ASSERT_EQ(result.metadata.schema_info.size(), 1u);
+  EXPECT_EQ(result.tbl->get_column(0).null_count(), 0);
+}
+
 TEST_F(JsonReaderTest, MalformedFieldNameWithBrace)
 {
   // Garbled field name containing '{' creates structural ambiguity in the

--- a/cpp/tests/streams/io/json_test.cpp
+++ b/cpp/tests/streams/io/json_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,6 +30,20 @@ TEST_F(JSONTest, JSONreader)
       .lines(true);
   cudf::io::table_with_metadata result =
     cudf::io::read_json(in_options, cudf::test::get_default_stream());
+}
+
+TEST_F(JSONTest, JSONreaderWithDiagnostics)
+{
+  std::string data = "[1, 1.1]\n[2, 2.2]\n[3, 3.3]\n";
+  cudf::io::json_reader_options in_options =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+      .dtypes(std::vector<cudf::data_type>{cudf::data_type{cudf::type_id::INT32},
+                                           cudf::data_type{cudf::type_id::FLOAT64}})
+      .lines(true);
+  cudf::io::json_reader_result result =
+    cudf::io::read_json_with_diagnostics(in_options, cudf::test::get_default_stream());
 }
 
 TEST_F(JSONTest, JSONwriter)


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.