### PR TITLE
Add rolling window tests that exercise overflow-like edge cases for SUM

### DIFF
--- a/cpp/tests/rolling/grouped_rolling_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_test.cpp
@@ -429,6 +429,8 @@ class GroupedRollingTest : public cudf::test::BaseFixture {
 
 class GroupedRollingErrorTest : public cudf::test::BaseFixture {};
 
+class GroupedRollingSumEdgeCaseTest : public cudf::test::BaseFixture {};
+
 // negative sizes
 TEST_F(GroupedRollingErrorTest, NegativeMinPeriods)
 {
@@ -622,6 +624,56 @@ TYPED_TEST(GroupedRollingTest, ZeroWindow)
 }
 
 using GroupedRollingTestInts = GroupedRollingTest<int32_t>;
+
+TEST_F(GroupedRollingSumEdgeCaseTest, SumFloatNonFinite)
+{
+  auto const nan = std::numeric_limits<double>::quiet_NaN();
+  auto const inf = std::numeric_limits<double>::infinity();
+
+  auto const input =
+    cudf::test::fixed_width_column_wrapper<double>{{nan, 1.0, 2.0, inf, -inf, 4.0, 5.0}};
+  auto const keys          = cudf::test::fixed_width_column_wrapper<int32_t>{{0, 0, 0, 1, 1, 1, 1}};
+  auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{keys}};
+  auto const expected =
+    cudf::test::fixed_width_column_wrapper<double>{{nan, nan, 3.0, inf, nan, -inf, 9.0}};
+
+  auto const result = cudf::grouped_rolling_window(
+    grouping_keys, input, 2, 0, 1, *cudf::make_sum_aggregation<cudf::rolling_aggregation>());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+}
+
+TEST_F(GroupedRollingSumEdgeCaseTest, SumFloatFiniteCancellation)
+{
+  auto const input =
+    cudf::test::fixed_width_column_wrapper<double>{{1e20, 1.0, 2.0, 3.0, 1e20, 4.0, 5.0, 6.0}};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{{0, 0, 0, 0, 1, 1, 1, 1}};
+  auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{keys}};
+  auto const expected =
+    cudf::test::fixed_width_column_wrapper<double>{{1e20, 1e20, 3.0, 5.0, 1e20, 1e20, 9.0, 11.0}};
+
+  auto const result = cudf::grouped_rolling_window(
+    grouping_keys, input, 2, 0, 1, *cudf::make_sum_aggregation<cudf::rolling_aggregation>());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+}
+
+TEST_F(GroupedRollingSumEdgeCaseTest, SumInt64PrefixOverflow)
+{
+  auto constexpr max = std::numeric_limits<int64_t>::max();
+
+  auto const input = cudf::test::fixed_width_column_wrapper<int64_t>{
+    {max, int64_t{-1}, int64_t{2}, max, int64_t{-1}, int64_t{2}}};
+  auto const keys          = cudf::test::fixed_width_column_wrapper<int32_t>{{0, 0, 0, 1, 1, 1}};
+  auto const grouping_keys = cudf::table_view{std::vector<cudf::column_view>{keys}};
+  auto const expected      = cudf::test::fixed_width_column_wrapper<int64_t>{
+    {max, max - int64_t{1}, int64_t{1}, max, max - int64_t{1}, int64_t{1}}};
+
+  auto const result = cudf::grouped_rolling_window(
+    grouping_keys, input, 2, 0, 1, *cudf::make_sum_aggregation<cudf::rolling_aggregation>());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+}
 
 TEST_F(GroupedRollingTestInts, SumLargeWindow)
 {

--- a/cpp/tests/rolling/rolling_test.cpp
+++ b/cpp/tests/rolling/rolling_test.cpp
@@ -615,6 +615,8 @@ class RollingtVarStdTestUntyped : public cudf::test::BaseFixture {};
 
 class RollingErrorTest : public cudf::test::BaseFixture {};
 
+class RollingSumEdgeCaseTest : public cudf::test::BaseFixture {};
+
 // negative sizes
 TEST_F(RollingErrorTest, NegativeMinPeriods)
 {
@@ -821,6 +823,48 @@ TYPED_TEST(RollingTest, SimpleStatic)
 
   // static sizes
   this->run_test_col_agg(input, window, window, 1);
+}
+
+TEST_F(RollingSumEdgeCaseTest, SumFloatNonFinite)
+{
+  auto const nan = std::numeric_limits<double>::quiet_NaN();
+  auto const inf = std::numeric_limits<double>::infinity();
+
+  auto const input =
+    cudf::test::fixed_width_column_wrapper<double>{{nan, 1.0, 2.0, inf, -inf, 4.0, 5.0}};
+  auto const expected =
+    cudf::test::fixed_width_column_wrapper<double>{{nan, nan, 3.0, inf, nan, -inf, 9.0}};
+
+  auto const result =
+    cudf::rolling_window(input, 2, 0, 1, *cudf::make_sum_aggregation<cudf::rolling_aggregation>());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+}
+
+TEST_F(RollingSumEdgeCaseTest, SumFloatFiniteCancellation)
+{
+  auto const input    = cudf::test::fixed_width_column_wrapper<double>{{1e20, 1.0, 2.0, 3.0}};
+  auto const expected = cudf::test::fixed_width_column_wrapper<double>{{1e20, 1e20, 3.0, 5.0}};
+
+  auto const result =
+    cudf::rolling_window(input, 2, 0, 1, *cudf::make_sum_aggregation<cudf::rolling_aggregation>());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+}
+
+TEST_F(RollingSumEdgeCaseTest, SumInt64PrefixOverflow)
+{
+  auto constexpr max = std::numeric_limits<int64_t>::max();
+
+  auto const input =
+    cudf::test::fixed_width_column_wrapper<int64_t>{{max, int64_t{-1}, int64_t{2}}};
+  auto const expected =
+    cudf::test::fixed_width_column_wrapper<int64_t>{{max, max - int64_t{1}, int64_t{1}}};
+
+  auto const result =
+    cudf::rolling_window(input, 2, 0, 1, *cudf::make_sum_aggregation<cudf::rolling_aggregation>());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
 }
 
 TYPED_TEST(RollingVarStdTest, SimpleStaticVarianceStd)


### PR DESCRIPTION
## Description
A plausible optimisation strategy for rolling windows with a sum aggregation is to compute a prefix scan of the input column and then compute scan[upper_window] - scan[lower_window]. However, this fails to be correct as soon as we're dealing with finite arithmetic since for floating point values, once we saturate at inf or nan, we can't invert things any more.

If working with integral values, as long as we can mandate twos-complement overflow behaviour, the scan-based approach is guaranteed to produce the correct answer if no single window would overflow the aggregation. Since addition mod N forms a group. Since twos-complement is only guaranteed once we're on C++23, add a test of this too.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
