### PR TITLE
Remove deprecated strings::like string_scalar API

### DIFF
--- a/cpp/include/cudf/strings/contains.hpp
+++ b/cpp/include/cudf/strings/contains.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -155,31 +155,6 @@ std::unique_ptr<column> like(
   std::string_view const& escape_character = "",
   rmm::cuda_stream_view stream             = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr        = cudf::get_current_device_resource_ref());
-
-/**
- * @brief Returns a boolean column identifying rows which
- * match the given like pattern
- *
- * @deprecated in 25.12 and to be removed in a future release. Use like(strings_column_view,
- * std::string_view, std::string_view, rmm::cuda_stream_view, rmm::device_async_resource_ref)
- *
- * @throw std::invalid_argument if `pattern` or `escape_character` is invalid
- * @throw std::invalid_argument if `escape_character` contains more than on byte
- *
- * @param input Strings instance for this operation
- * @param pattern Like pattern to match within each string
- * @param escape_character Optional character specifies the escape prefix.
- *                         Default is no escape character.
- * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned column's device memory
- * @return New boolean column
- */
-[[deprecated]] std::unique_ptr<column> like(
-  strings_column_view const& input,
-  string_scalar const& pattern,
-  string_scalar const& escape_character = string_scalar(""),
-  rmm::cuda_stream_view stream          = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr     = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Returns a boolean column identifying rows which

--- a/cpp/src/strings/like.cu
+++ b/cpp/src/strings/like.cu
@@ -407,16 +407,6 @@ std::unique_ptr<column> like(strings_column_view const& input,
 // external API
 
 std::unique_ptr<column> like(strings_column_view const& input,
-                             string_scalar const& pattern,
-                             string_scalar const& escape_character,
-                             rmm::cuda_stream_view stream,
-                             rmm::device_async_resource_ref mr)
-{
-  CUDF_FUNC_RANGE();
-  return detail::like(input, pattern, escape_character, stream, mr);
-}
-
-std::unique_ptr<column> like(strings_column_view const& input,
                              std::string_view const& pattern,
                              std::string_view const& escape_character,
                              rmm::cuda_stream_view stream,


### PR DESCRIPTION
## Description
Removes the `string_scalar` overload for the `cudf::strings::like()` API. This was deprecated in 25.12 and all code logic has been moved to call the replacement `std::string_view` overload version.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
