### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/cpp/benchmarks/io/orc/orc_reader_input.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_input.cpp
@@ -83,6 +83,8 @@ void BM_orc_read_data(nvbench::state& state, nvbench::type_list<nvbench::enum_ty
   cudf::size_type const cardinality = state.get_int64("cardinality");
   cudf::size_type const run_length  = state.get_int64("run_length");
   auto const source_type            = retrieve_io_type_enum(state.get_string("io_type"));
+  auto const stripe_size_bytes      = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows       = state.get_int64("stripe_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
@@ -94,6 +96,9 @@ void BM_orc_read_data(nvbench::state& state, nvbench::type_list<nvbench::enum_ty
 
     cudf::io::orc_writer_options opts =
       cudf::io::orc_writer_options::builder(source_sink.make_sink_info(), view);
+    // Sentinel 0 == use cuDF default.
+    if (stripe_size_bytes > 0) opts.set_stripe_size_bytes(stripe_size_bytes);
+    if (stripe_size_rows > 0) opts.set_stripe_size_rows(stripe_size_rows);
     cudf::io::write_orc(opts);
     return view.num_rows();
   }();
@@ -122,6 +127,8 @@ void orc_read_io_compression(nvbench::state& state)
               static_cast<cudf::size_type>(state.get_int64("run_length"))};
     }
   }();
+  auto const stripe_size_bytes = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows  = state.get_int64("stripe_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
@@ -134,6 +141,8 @@ void orc_read_io_compression(nvbench::state& state)
     cudf::io::orc_writer_options opts =
       cudf::io::orc_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(compression);
+    if (stripe_size_bytes > 0) opts.set_stripe_size_bytes(stripe_size_bytes);
+    if (stripe_size_rows > 0) opts.set_stripe_size_rows(stripe_size_rows);
     cudf::io::write_orc(opts);
     return view.num_rows();
   }();
@@ -165,7 +174,9 @@ NVBENCH_BENCH_TYPES(BM_orc_read_data, NVBENCH_TYPE_AXES(d_type_list))
   .add_string_axis("io_type", {"DEVICE_BUFFER"})
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
-  .add_int64_axis("run_length", {1, 32});
+  .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(BM_orc_read_io_compression)
   .set_name("orc_read_io_compression")
@@ -173,7 +184,9 @@ NVBENCH_BENCH(BM_orc_read_io_compression)
   .add_string_axis("compression_type", {"SNAPPY", "ZSTD", "ZLIB", "LZ4", "NONE"})
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
-  .add_int64_axis("run_length", {1, 32});
+  .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 // Should have the same parameters as `BM_orc_read_io_compression` for comparison.
 NVBENCH_BENCH(BM_orc_chunked_read_io_compression)
@@ -184,4 +197,6 @@ NVBENCH_BENCH(BM_orc_chunked_read_io_compression)
   // The input has approximately 520MB and 127K rows.
   // The limits below are given in MBs.
   .add_int64_axis("chunk_read_limit_MB", {50, 250, 700})
-  .add_int64_axis("pass_read_limit_MB", {50, 250, 700});
+  .add_int64_axis("pass_read_limit_MB", {50, 250, 700})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});

--- a/cpp/benchmarks/io/orc/orc_reader_multithreaded.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_multithreaded.cpp
@@ -45,6 +45,8 @@ std::tuple<std::vector<cuio_source_sink_pair>, size_t, size_t> write_file_data(
   auto const num_cols             = state.get_int64("num_cols");
   size_t const num_files          = get_num_read_threads(state);
   size_t const per_file_data_size = get_read_size(state);
+  auto const stripe_size_bytes    = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows     = state.get_int64("stripe_size_rows");
 
   std::vector<cuio_source_sink_pair> source_sink_vector;
 
@@ -59,9 +61,12 @@ std::tuple<std::vector<cuio_source_sink_pair>, size_t, size_t> write_file_data(
       data_profile_builder().cardinality(cardinality).avg_run_length(run_length));
     auto const view = tbl->view();
 
-    cudf::io::orc_writer_options const write_opts =
+    cudf::io::orc_writer_options write_opts =
       cudf::io::orc_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(cudf::io::compression_type::SNAPPY);
+    // Sentinel 0 == use cuDF default.
+    if (stripe_size_bytes > 0) write_opts.set_stripe_size_bytes(stripe_size_bytes);
+    if (stripe_size_rows > 0) write_opts.set_stripe_size_rows(stripe_size_rows);
 
     cudf::io::write_orc(write_opts);
     total_file_size += source_sink.size();
@@ -247,7 +252,9 @@ NVBENCH_BENCH(BM_orc_multithreaded_read_mixed)
   .add_int64_axis("total_data_size", total_data_size)
   .add_int64_axis("num_threads", thread_range)
   .add_int64_axis("num_cols", {4})
-  .add_int64_axis("run_length", {8});
+  .add_int64_axis("run_length", {8})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(BM_orc_multithreaded_read_fixed_width)
   .set_name("orc_multithreaded_read_decode_fixed_width")
@@ -256,7 +263,9 @@ NVBENCH_BENCH(BM_orc_multithreaded_read_fixed_width)
   .add_int64_axis("total_data_size", total_data_size)
   .add_int64_axis("num_threads", thread_range)
   .add_int64_axis("num_cols", {4})
-  .add_int64_axis("run_length", {8});
+  .add_int64_axis("run_length", {8})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(BM_orc_multithreaded_read_string)
   .set_name("orc_multithreaded_read_decode_string")
@@ -265,7 +274,9 @@ NVBENCH_BENCH(BM_orc_multithreaded_read_string)
   .add_int64_axis("total_data_size", total_data_size)
   .add_int64_axis("num_threads", thread_range)
   .add_int64_axis("num_cols", {4})
-  .add_int64_axis("run_length", {8});
+  .add_int64_axis("run_length", {8})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(BM_orc_multithreaded_read_list)
   .set_name("orc_multithreaded_read_decode_list")
@@ -274,7 +285,9 @@ NVBENCH_BENCH(BM_orc_multithreaded_read_list)
   .add_int64_axis("total_data_size", total_data_size)
   .add_int64_axis("num_threads", thread_range)
   .add_int64_axis("num_cols", {4})
-  .add_int64_axis("run_length", {8});
+  .add_int64_axis("run_length", {8})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 // mixed data types: fixed width, strings
 NVBENCH_BENCH(BM_orc_multithreaded_read_chunked_mixed)
@@ -286,7 +299,9 @@ NVBENCH_BENCH(BM_orc_multithreaded_read_chunked_mixed)
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
   .add_int64_axis("input_limit", {640 * 1024 * 1024})
-  .add_int64_axis("output_limit", {640 * 1024 * 1024});
+  .add_int64_axis("output_limit", {640 * 1024 * 1024})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(BM_orc_multithreaded_read_chunked_fixed_width)
   .set_name("orc_multithreaded_read_decode_chunked_fixed_width")
@@ -297,7 +312,9 @@ NVBENCH_BENCH(BM_orc_multithreaded_read_chunked_fixed_width)
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
   .add_int64_axis("input_limit", {640 * 1024 * 1024})
-  .add_int64_axis("output_limit", {640 * 1024 * 1024});
+  .add_int64_axis("output_limit", {640 * 1024 * 1024})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(BM_orc_multithreaded_read_chunked_string)
   .set_name("orc_multithreaded_read_decode_chunked_string")
@@ -308,7 +325,9 @@ NVBENCH_BENCH(BM_orc_multithreaded_read_chunked_string)
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
   .add_int64_axis("input_limit", {640 * 1024 * 1024})
-  .add_int64_axis("output_limit", {640 * 1024 * 1024});
+  .add_int64_axis("output_limit", {640 * 1024 * 1024})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(BM_orc_multithreaded_read_chunked_list)
   .set_name("orc_multithreaded_read_decode_chunked_list")
@@ -319,4 +338,6 @@ NVBENCH_BENCH(BM_orc_multithreaded_read_chunked_list)
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
   .add_int64_axis("input_limit", {640 * 1024 * 1024})
-  .add_int64_axis("output_limit", {640 * 1024 * 1024});
+  .add_int64_axis("output_limit", {640 * 1024 * 1024})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});

--- a/cpp/benchmarks/io/orc/orc_reader_options.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_options.cpp
@@ -51,6 +51,9 @@ void BM_orc_read_varying_options(nvbench::state& state,
   auto const use_np_dtypes = UsesNumpyDType == uses_numpy_dtype::YES;
   auto const ts_type       = cudf::data_type{Timestamp};
 
+  auto const stripe_size_bytes = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows  = state.get_int64("stripe_size_rows");
+
   // skip_rows is not supported on nested types
   auto const data_types =
     dtypes_for_column_selection(get_type_or_group({static_cast<int32_t>(data_type::INTEGRAL_SIGNED),
@@ -65,6 +68,9 @@ void BM_orc_read_varying_options(nvbench::state& state,
   cuio_source_sink_pair source_sink(io_type::HOST_BUFFER);
   cudf::io::orc_writer_options options =
     cudf::io::orc_writer_options::builder(source_sink.make_sink_info(), view);
+  // Sentinel 0 == use cuDF default.
+  if (stripe_size_bytes > 0) options.set_stripe_size_bytes(stripe_size_bytes);
+  if (stripe_size_rows > 0) options.set_stripe_size_rows(stripe_size_rows);
   cudf::io::write_orc(options);
 
   auto const cols_to_read =
@@ -79,6 +85,9 @@ void BM_orc_read_varying_options(nvbench::state& state,
 
   auto const num_stripes =
     cudf::io::read_orc_metadata(source_sink.make_source_info()).num_stripes();
+  CUDF_EXPECTS(RowSelection != row_selection::STRIPES || num_stripes >= num_chunks,
+               "STRIPES option requires at least one stripe per read chunk");
+
   auto const chunk_row_cnt = cudf::util::div_rounding_up_unsafe(view.num_rows(), num_chunks);
 
   auto mem_stats_logger = cudf::memory_stats_logger();
@@ -133,7 +142,9 @@ NVBENCH_BENCH_TYPES(BM_orc_read_varying_options,
   .set_name("orc_read_column_selection")
   .set_type_axes_names(
     {"column_selection", "row_selection", "uses_index", "uses_numpy_dtype", "timestamp_type"})
-  .set_min_samples(4);
+  .set_min_samples(4)
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 using row_selections =
   nvbench::enum_type_list<row_selection::ALL, row_selection::NROWS, row_selection::STRIPES>;
@@ -146,7 +157,11 @@ NVBENCH_BENCH_TYPES(BM_orc_read_varying_options,
   .set_name("orc_read_row_selection")
   .set_type_axes_names(
     {"column_selection", "row_selection", "uses_index", "uses_numpy_dtype", "timestamp_type"})
-  .set_min_samples(4);
+  .set_min_samples(4)
+  // NOTE: row_selection::STRIPES reads a fraction of stripes; non-zero
+  // stripe sizing values here change what each chunk reads.
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH_TYPES(
   BM_orc_read_varying_options,
@@ -159,4 +174,6 @@ NVBENCH_BENCH_TYPES(
   .set_name("orc_read_misc_options")
   .set_type_axes_names(
     {"column_selection", "row_selection", "uses_index", "uses_numpy_dtype", "timestamp_type"})
-  .set_min_samples(4);
+  .set_min_samples(4)
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});

--- a/cpp/benchmarks/io/orc/orc_writer.cpp
+++ b/cpp/benchmarks/io/orc/orc_writer.cpp
@@ -39,6 +39,8 @@ void BM_orc_write_encode(nvbench::state& state, nvbench::type_list<nvbench::enum
   cudf::size_type const run_length  = state.get_int64("run_length");
   auto const compression            = cudf::io::compression_type::SNAPPY;
   auto const sink_type              = io_type::VOID;
+  auto const stripe_size_bytes      = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows       = state.get_int64("stripe_size_rows");
 
   auto const tbl =
     create_random_table(cycle_dtypes(d_type, num_cols),
@@ -58,6 +60,9 @@ void BM_orc_write_encode(nvbench::state& state, nvbench::type_list<nvbench::enum
                cudf::io::orc_writer_options options =
                  cudf::io::orc_writer_options::builder(source_sink.make_sink_info(), view)
                    .compression(compression);
+               // Sentinel 0 == use cuDF default.
+               if (stripe_size_bytes > 0) options.set_stripe_size_bytes(stripe_size_bytes);
+               if (stripe_size_rows > 0) options.set_stripe_size_rows(stripe_size_rows);
                cudf::io::write_orc(options);
                timer.stop();
 
@@ -85,6 +90,8 @@ void BM_orc_write_io_compression(nvbench::state& state)
   cudf::size_type const run_length  = state.get_int64("run_length");
   auto const sink_type              = retrieve_io_type_enum(state.get_string("io_type"));
   auto const compression = retrieve_compression_type_enum(state.get_string("compression_type"));
+  auto const stripe_size_bytes = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows  = state.get_int64("stripe_size_rows");
 
   auto const tbl =
     create_random_table(cycle_dtypes(d_type, num_cols),
@@ -104,6 +111,8 @@ void BM_orc_write_io_compression(nvbench::state& state)
                cudf::io::orc_writer_options options =
                  cudf::io::orc_writer_options::builder(source_sink.make_sink_info(), view)
                    .compression(compression);
+               if (stripe_size_bytes > 0) options.set_stripe_size_bytes(stripe_size_bytes);
+               if (stripe_size_rows > 0) options.set_stripe_size_rows(stripe_size_rows);
                cudf::io::write_orc(options);
                timer.stop();
 
@@ -130,6 +139,8 @@ void BM_orc_write_statistics(nvbench::state& state,
 
   auto const compression = retrieve_compression_type_enum(state.get_string("compression_type"));
   auto const stats_freq  = Statistics;
+  auto const stripe_size_bytes = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows  = state.get_int64("stripe_size_rows");
 
   auto const tbl  = create_random_table(d_type, table_size_bytes{data_size});
   auto const view = tbl->view();
@@ -143,10 +154,12 @@ void BM_orc_write_statistics(nvbench::state& state,
                cuio_source_sink_pair source_sink(io_type::FILEPATH);
 
                timer.start();
-               cudf::io::orc_writer_options const options =
+               cudf::io::orc_writer_options options =
                  cudf::io::orc_writer_options::builder(source_sink.make_sink_info(), view)
                    .compression(compression)
                    .enable_statistics(stats_freq);
+               if (stripe_size_bytes > 0) options.set_stripe_size_bytes(stripe_size_bytes);
+               if (stripe_size_rows > 0) options.set_stripe_size_rows(stripe_size_rows);
                cudf::io::write_orc(options);
                timer.stop();
 
@@ -177,7 +190,9 @@ NVBENCH_BENCH_TYPES(BM_orc_write_encode, NVBENCH_TYPE_AXES(d_type_list))
   .set_type_axes_names({"data_type"})
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
-  .add_int64_axis("run_length", {1, 32});
+  .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(BM_orc_write_io_compression)
   .set_name("orc_write_io_compression")
@@ -185,10 +200,14 @@ NVBENCH_BENCH(BM_orc_write_io_compression)
   .add_string_axis("compression_type", {"SNAPPY", "ZSTD", "ZLIB", "LZ4", "NONE"})
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
-  .add_int64_axis("run_length", {1, 32});
+  .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH_TYPES(BM_orc_write_statistics, NVBENCH_TYPE_AXES(stats_list))
   .set_name("orc_write_statistics")
   .set_type_axes_names({"statistics"})
   .add_string_axis("compression_type", {"SNAPPY", "ZSTD", "ZLIB", "LZ4", "NONE"})
-  .set_min_samples(4);
+  .set_min_samples(4)
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});

--- a/cpp/benchmarks/io/orc/orc_writer_chunks.cpp
+++ b/cpp/benchmarks/io/orc/orc_writer_chunks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,7 +23,9 @@ constexpr int64_t data_size = 512 << 20;
 
 void nvbench_orc_write(nvbench::state& state)
 {
-  cudf::size_type num_cols = state.get_int64("num_columns");
+  cudf::size_type num_cols     = state.get_int64("num_columns");
+  auto const stripe_size_bytes = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows  = state.get_int64("stripe_size_rows");
 
   auto tbl = create_random_table(
     cycle_dtypes(get_type_or_group({static_cast<int32_t>(data_type::INTEGRAL_SIGNED),
@@ -52,6 +54,9 @@ void nvbench_orc_write(nvbench::state& state)
 
                cudf::io::orc_writer_options opts =
                  cudf::io::orc_writer_options::builder(source_sink.make_sink_info(), view);
+               // Sentinel 0 == use cuDF default.
+               if (stripe_size_bytes > 0) opts.set_stripe_size_bytes(stripe_size_bytes);
+               if (stripe_size_rows > 0) opts.set_stripe_size_rows(stripe_size_rows);
                cudf::io::write_orc(opts);
 
                timer.stop();
@@ -65,8 +70,10 @@ void nvbench_orc_write(nvbench::state& state)
 
 void nvbench_orc_chunked_write(nvbench::state& state)
 {
-  cudf::size_type num_cols   = state.get_int64("num_columns");
-  cudf::size_type num_tables = state.get_int64("num_chunks");
+  cudf::size_type num_cols     = state.get_int64("num_columns");
+  cudf::size_type num_tables   = state.get_int64("num_chunks");
+  auto const stripe_size_bytes = state.get_int64("stripe_size_bytes");
+  auto const stripe_size_rows  = state.get_int64("stripe_size_rows");
 
   std::vector<std::unique_ptr<cudf::table>> tables;
   for (cudf::size_type idx = 0; idx < num_tables; idx++) {
@@ -104,6 +111,8 @@ void nvbench_orc_chunked_write(nvbench::state& state)
 
       cudf::io::chunked_orc_writer_options opts =
         cudf::io::chunked_orc_writer_options::builder(source_sink.make_sink_info());
+      if (stripe_size_bytes > 0) opts.set_stripe_size_bytes(stripe_size_bytes);
+      if (stripe_size_rows > 0) opts.set_stripe_size_rows(stripe_size_rows);
       cudf::io::orc_chunked_writer writer(opts);
       std::for_each(tables.begin(),
                     tables.end(),
@@ -122,10 +131,14 @@ void nvbench_orc_chunked_write(nvbench::state& state)
 NVBENCH_BENCH(nvbench_orc_write)
   .set_name("orc_write")
   .set_min_samples(4)
-  .add_int64_axis("num_columns", {8, 64});
+  .add_int64_axis("num_columns", {8, 64})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});
 
 NVBENCH_BENCH(nvbench_orc_chunked_write)
   .set_name("orc_chunked_write")
   .set_min_samples(4)
   .add_int64_axis("num_columns", {8, 64})
-  .add_int64_axis("num_chunks", {8, 64});
+  .add_int64_axis("num_chunks", {8, 64})
+  .add_int64_axis("stripe_size_bytes", {0})
+  .add_int64_axis("stripe_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_multithread.cpp
+++ b/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_multithread.cpp
@@ -45,6 +45,8 @@ std::tuple<std::vector<cuio_source_sink_pair>, size_t, size_t> write_file_data(
   cudf::size_type const num_cols    = state.get_int64("num_cols");
   size_t const num_files            = state.get_int64("num_threads");
   size_t const per_file_data_size   = state.get_int64("total_data_size") / num_files;
+  auto const rg_size_bytes          = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows           = state.get_int64("row_group_size_rows");
 
   std::vector<cuio_source_sink_pair> source_sink_vector;
 
@@ -64,6 +66,9 @@ std::tuple<std::vector<cuio_source_sink_pair>, size_t, size_t> write_file_data(
         .compression(cudf::io::compression_type::SNAPPY)
         .max_page_size_rows(50000)
         .max_page_size_bytes(1024 * 1024);
+    // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
 
     if (write_page_index) {
       write_opts.set_stats_level(cudf::io::statistics_freq::STATISTICS_COLUMN);
@@ -182,4 +187,6 @@ NVBENCH_BENCH(BM_hybrid_scan_multithreaded_read)
   .add_int64_axis("num_iterations", {1})
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/parquet_reader_chunks.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_chunks.cpp
@@ -25,6 +25,8 @@ void BM_parquet_read_chunks(nvbench::state& state, nvbench::type_list<nvbench::e
   auto const source_type      = retrieve_io_type_enum(state.get_string("io_type"));
   auto const data_size        = static_cast<size_t>(state.get_int64("data_size"));
   auto const compression      = cudf::io::compression_type::SNAPPY;
+  auto const rg_size_bytes    = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows     = state.get_int64("row_group_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
@@ -37,7 +39,9 @@ void BM_parquet_read_chunks(nvbench::state& state, nvbench::type_list<nvbench::e
     cudf::io::parquet_writer_options write_opts =
       cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(compression);
-
+    // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
     cudf::io::write_parquet(write_opts);
     return view.num_rows();
   }();
@@ -83,6 +87,8 @@ void BM_parquet_read_subrowgroup_chunks(nvbench::state& state,
   auto const source_type      = retrieve_io_type_enum(state.get_string("io_type"));
   auto const data_size        = static_cast<size_t>(state.get_int64("data_size"));
   auto const compression      = cudf::io::compression_type::SNAPPY;
+  auto const rg_size_bytes    = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows     = state.get_int64("row_group_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
@@ -95,7 +101,8 @@ void BM_parquet_read_subrowgroup_chunks(nvbench::state& state,
     cudf::io::parquet_writer_options write_opts =
       cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(compression);
-
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
     cudf::io::write_parquet(write_opts);
     return view.num_rows();
   }();
@@ -146,7 +153,9 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_chunks, NVBENCH_TYPE_AXES(d_type_list))
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32})
   .add_int64_axis("chunk_read_limit", {0, 500'000})
-  .add_int64_axis("data_size", {512 << 20});
+  .add_int64_axis("data_size", {512 << 20})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH_TYPES(BM_parquet_read_subrowgroup_chunks, NVBENCH_TYPE_AXES(d_type_list))
   .set_name("parquet_read_subrowgroup_chunks")
@@ -156,4 +165,6 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_subrowgroup_chunks, NVBENCH_TYPE_AXES(d_type
   .add_int64_axis("run_length", {1, 32})
   .add_int64_axis("chunk_read_limit", {0, 500'000})
   .add_int64_axis("pass_read_limit", {0, 500'000})
-  .add_int64_axis("data_size", {512 << 20});
+  .add_int64_axis("data_size", {512 << 20})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/parquet_reader_compressed.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_compressed.cpp
@@ -27,11 +27,13 @@ void BM_parquet_read_io_compression(nvbench::state& state)
                                          static_cast<int32_t>(data_type::LIST),
                                          static_cast<int32_t>(data_type::STRUCT)});
 
-  auto const cardinality = static_cast<cudf::size_type>(state.get_int64("cardinality"));
-  auto const run_length  = static_cast<cudf::size_type>(state.get_int64("run_length"));
-  auto const source_type = retrieve_io_type_enum(state.get_string("io_type"));
-  auto const compression = retrieve_compression_type_enum(state.get_string("compression_type"));
-  auto const data_size   = static_cast<size_t>(state.get_int64("data_size"));
+  auto const cardinality   = static_cast<cudf::size_type>(state.get_int64("cardinality"));
+  auto const run_length    = static_cast<cudf::size_type>(state.get_int64("run_length"));
+  auto const source_type   = retrieve_io_type_enum(state.get_string("io_type"));
+  auto const compression   = retrieve_compression_type_enum(state.get_string("compression_type"));
+  auto const data_size     = static_cast<size_t>(state.get_int64("data_size"));
+  auto const rg_size_bytes = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows  = state.get_int64("row_group_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
@@ -44,6 +46,8 @@ void BM_parquet_read_io_compression(nvbench::state& state)
     cudf::io::parquet_writer_options write_opts =
       cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(compression);
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
     cudf::io::write_parquet(write_opts);
     return view.num_rows();
   }();
@@ -58,4 +62,6 @@ NVBENCH_BENCH(BM_parquet_read_io_compression)
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32})
-  .add_int64_axis("data_size", {512 << 20});
+  .add_int64_axis("data_size", {512 << 20})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/parquet_reader_filter.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_filter.cpp
@@ -180,6 +180,8 @@ void BM_parquet_read_filter(nvbench::state& state)
   auto const nullable       = state.get_string("nullable") == "true";
   auto const use_jit        = state.get_string("executor") == "jit";
   auto const num_input_cols = static_cast<cudf::size_type>(state.get_int64("num_cols"));
+  auto const rg_size_bytes  = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows   = state.get_int64("row_group_size_rows");
 
   CUDF_EXPECTS(num_input_cols >= 1, "Invalid number of input columns");
   CUDF_EXPECTS(selectivity > 0.0F && selectivity <= 1.0F, "Invalid selectivity");
@@ -227,6 +229,9 @@ void BM_parquet_read_filter(nvbench::state& state)
       .compression(cudf::io::compression_type::AUTO)
       .dictionary_policy(cudf::io::dictionary_policy::ALWAYS)
       .stats_level(cudf::io::statistics_freq::STATISTICS_NONE);
+  // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+  if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+  if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
   cudf::io::write_parquet(write_opts);
 
   cudf::io::parquet_reader_options read_opts =
@@ -268,7 +273,9 @@ void BM_parquet_read_filter(nvbench::state& state)
     .add_int64_axis("num_rows", {100'000, 1'000'000, 10'000'000})           \
     .add_float64_axis("selectivity", {0.5, 0.8})                            \
     .add_string_axis("nullable", {"true"})                                  \
-    .add_string_axis("executor", {"jit", "ast"})
+    .add_string_axis("executor", {"jit", "ast"})                            \
+    .add_int64_axis("row_group_size_bytes", {0})                            \
+    .add_int64_axis("row_group_size_rows", {0})
 
 PARQUET_READER_FILTER_BENCHMARK_DEFINE(parquet_read_filter_i32, int32_t);
 

--- a/cpp/benchmarks/io/parquet/parquet_reader_input.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_input.cpp
@@ -20,10 +20,12 @@ void BM_parquet_read_data_common(nvbench::state& state,
                                  data_profile const& profile,
                                  nvbench::type_list<nvbench::enum_type<DataType>>)
 {
-  auto const d_type      = get_type_or_group(static_cast<int32_t>(DataType));
-  auto const source_type = retrieve_io_type_enum(state.get_string("io_type"));
-  auto const data_size   = static_cast<size_t>(state.get_int64("data_size"));
-  auto const compression = retrieve_compression_type_enum(state.get_string("compression_type"));
+  auto const d_type        = get_type_or_group(static_cast<int32_t>(DataType));
+  auto const source_type   = retrieve_io_type_enum(state.get_string("io_type"));
+  auto const data_size     = static_cast<size_t>(state.get_int64("data_size"));
+  auto const compression   = retrieve_compression_type_enum(state.get_string("compression_type"));
+  auto const rg_size_bytes = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows  = state.get_int64("row_group_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
@@ -34,6 +36,9 @@ void BM_parquet_read_data_common(nvbench::state& state,
     cudf::io::parquet_writer_options write_opts =
       cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(compression);
+    // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
     cudf::io::write_parquet(write_opts);
     return view.num_rows();
   }();
@@ -72,10 +77,12 @@ void BM_parquet_read_io_small_mixed(nvbench::state& state)
   auto const d_type =
     std::pair<cudf::type_id, cudf::type_id>{cudf::type_id::STRING, cudf::type_id::INT32};
 
-  auto const cardinality = static_cast<cudf::size_type>(state.get_int64("cardinality"));
-  auto const run_length  = static_cast<cudf::size_type>(state.get_int64("run_length"));
-  auto const num_strings = static_cast<cudf::size_type>(state.get_int64("num_string_cols"));
-  auto const source_type = retrieve_io_type_enum(state.get_string("io_type"));
+  auto const cardinality   = static_cast<cudf::size_type>(state.get_int64("cardinality"));
+  auto const run_length    = static_cast<cudf::size_type>(state.get_int64("run_length"));
+  auto const num_strings   = static_cast<cudf::size_type>(state.get_int64("num_string_cols"));
+  auto const source_type   = retrieve_io_type_enum(state.get_string("io_type"));
+  auto const rg_size_bytes = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows  = state.get_int64("row_group_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   // want 80 pages total, across 4 columns, so 20 pages per column
@@ -94,6 +101,8 @@ void BM_parquet_read_io_small_mixed(nvbench::state& state)
       cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
         .max_page_size_rows(10'000)
         .compression(cudf::io::compression_type::NONE);
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
     cudf::io::write_parquet(write_opts);
   }
 
@@ -118,7 +127,9 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_data, NVBENCH_TYPE_AXES(d_type_list))
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32})
-  .add_int64_axis("data_size", {512 << 20});
+  .add_int64_axis("data_size", {512 << 20})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_read_io_small_mixed)
   .set_name("parquet_read_io_small_mixed")
@@ -127,7 +138,9 @@ NVBENCH_BENCH(BM_parquet_read_io_small_mixed)
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32})
   .add_int64_axis("num_string_cols", {1, 2, 3})
-  .add_int64_axis("data_size", {512 << 20});
+  .add_int64_axis("data_size", {512 << 20})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 // a benchmark for structs that only contain fixed-width types
 using d_type_list_struct_only = nvbench::enum_type_list<data_type::STRUCT>;
@@ -139,4 +152,6 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_fixed_width_struct, NVBENCH_TYPE_AXES(d_type
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32})
-  .add_int64_axis("data_size", {512 << 20});
+  .add_int64_axis("data_size", {512 << 20})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/parquet_reader_multithread.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_multithread.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -47,6 +47,8 @@ std::tuple<std::vector<cuio_source_sink_pair>, size_t, size_t> write_file_data(
   cudf::size_type const num_cols    = state.get_int64("num_cols");
   size_t const num_files            = get_num_reads(state);
   size_t const per_file_data_size   = get_read_size(state);
+  auto const rg_size_bytes          = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows           = state.get_int64("row_group_size_rows");
 
   std::vector<cuio_source_sink_pair> source_sink_vector;
 
@@ -66,6 +68,9 @@ std::tuple<std::vector<cuio_source_sink_pair>, size_t, size_t> write_file_data(
         .compression(cudf::io::compression_type::SNAPPY)
         .max_page_size_rows(50000)
         .max_page_size_bytes(1024 * 1024);
+    // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
 
     cudf::io::write_parquet(write_opts);
     total_file_size += source_sink.size();
@@ -270,7 +275,9 @@ NVBENCH_BENCH(BM_parquet_multithreaded_read_mixed)
   .add_int64_axis("num_iterations", {1})
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_multithreaded_read_fixed_width)
   .set_name("parquet_multithreaded_read_decode_fixed_width")
@@ -281,7 +288,9 @@ NVBENCH_BENCH(BM_parquet_multithreaded_read_fixed_width)
   .add_int64_axis("num_iterations", {1})
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_multithreaded_read_string)
   .set_name("parquet_multithreaded_read_decode_string")
@@ -292,7 +301,9 @@ NVBENCH_BENCH(BM_parquet_multithreaded_read_string)
   .add_int64_axis("num_iterations", {1})
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_multithreaded_read_list)
   .set_name("parquet_multithreaded_read_decode_list")
@@ -303,7 +314,9 @@ NVBENCH_BENCH(BM_parquet_multithreaded_read_list)
   .add_int64_axis("num_iterations", {1})
   .add_int64_axis("num_cols", {4})
   .add_int64_axis("run_length", {8})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 // mixed data types: fixed width, strings
 NVBENCH_BENCH(BM_parquet_multithreaded_read_chunked_mixed)
@@ -317,7 +330,9 @@ NVBENCH_BENCH(BM_parquet_multithreaded_read_chunked_mixed)
   .add_int64_axis("run_length", {8})
   .add_int64_axis("input_limit", {640 * 1024 * 1024})
   .add_int64_axis("output_limit", {640 * 1024 * 1024})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_multithreaded_read_chunked_fixed_width)
   .set_name("parquet_multithreaded_read_decode_chunked_fixed_width")
@@ -330,7 +345,9 @@ NVBENCH_BENCH(BM_parquet_multithreaded_read_chunked_fixed_width)
   .add_int64_axis("run_length", {8})
   .add_int64_axis("input_limit", {640 * 1024 * 1024})
   .add_int64_axis("output_limit", {640 * 1024 * 1024})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_multithreaded_read_chunked_string)
   .set_name("parquet_multithreaded_read_decode_chunked_string")
@@ -343,7 +360,9 @@ NVBENCH_BENCH(BM_parquet_multithreaded_read_chunked_string)
   .add_int64_axis("run_length", {8})
   .add_int64_axis("input_limit", {640 * 1024 * 1024})
   .add_int64_axis("output_limit", {640 * 1024 * 1024})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_multithreaded_read_chunked_list)
   .set_name("parquet_multithreaded_read_decode_chunked_list")
@@ -356,4 +375,6 @@ NVBENCH_BENCH(BM_parquet_multithreaded_read_chunked_list)
   .add_int64_axis("run_length", {8})
   .add_int64_axis("input_limit", {640 * 1024 * 1024})
   .add_int64_axis("output_limit", {640 * 1024 * 1024})
-  .add_string_axis("io_type", {"PINNED_BUFFER"});
+  .add_string_axis("io_type", {"PINNED_BUFFER"})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/parquet_reader_options.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_options.cpp
@@ -52,6 +52,9 @@ void BM_parquet_read_options(nvbench::state& state,
 
   auto const ts_type = cudf::data_type{Timestamp};
 
+  auto const rg_size_bytes = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows  = state.get_int64("row_group_size_rows");
+
   auto const data_types =
     dtypes_for_column_selection(get_type_or_group({static_cast<int32_t>(data_type::INTEGRAL),
                                                    static_cast<int32_t>(data_type::FLOAT),
@@ -69,6 +72,9 @@ void BM_parquet_read_options(nvbench::state& state,
   cuio_source_sink_pair source_sink(io_type::HOST_BUFFER);
   cudf::io::parquet_writer_options options =
     cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view);
+  // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+  if (rg_size_bytes > 0) options.set_row_group_size_bytes(rg_size_bytes);
+  if (rg_size_rows > 0) options.set_row_group_size_rows(rg_size_rows);
   cudf::io::write_parquet(options);
 
   auto const cols_to_read =
@@ -82,7 +88,10 @@ void BM_parquet_read_options(nvbench::state& state,
       .timestamp_type(ts_type);
 
   auto const num_row_groups = read_parquet_metadata(source_sink.make_source_info()).num_rowgroups();
-  auto const chunk_row_cnt  = cudf::util::div_rounding_up_unsafe(view.num_rows(), num_chunks);
+  CUDF_EXPECTS(RowSelection != row_selection::ROW_GROUPS || num_row_groups >= num_chunks,
+               "ROW_GROUPS option requires at least one row group per read chunk");
+
+  auto const chunk_row_cnt = cudf::util::div_rounding_up_unsafe(view.num_rows(), num_chunks);
 
   auto mem_stats_logger = cudf::memory_stats_logger();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
@@ -137,7 +146,11 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_options,
                         "str_to_categories",
                         "uses_pandas_metadata",
                         "timestamp_type"})
-  .set_min_samples(4);
+  .set_min_samples(4)
+  // NOTE: row_selection::ROW_GROUPS reads a fraction of row groups; non-zero
+  // RG sizing values here change what each chunk reads.
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 using col_selections = nvbench::enum_type_list<column_selection::ALL,
                                                column_selection::ALTERNATE,
@@ -155,7 +168,9 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_options,
                         "str_to_categories",
                         "uses_pandas_metadata",
                         "timestamp_type"})
-  .set_min_samples(4);
+  .set_min_samples(4)
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH_TYPES(
   BM_parquet_read_options,
@@ -170,4 +185,6 @@ NVBENCH_BENCH_TYPES(
                         "str_to_categories",
                         "uses_pandas_metadata",
                         "timestamp_type"})
-  .set_min_samples(4);
+  .set_min_samples(4)
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/parquet_reader_strings.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_strings.cpp
@@ -20,9 +20,11 @@ void BM_parquet_read_long_strings(nvbench::state& state)
   auto const cardinality = static_cast<cudf::size_type>(state.get_int64("cardinality"));
   auto const data_size   = static_cast<size_t>(state.get_int64("data_size"));
 
-  auto const d_type      = get_type_or_group(static_cast<int32_t>(data_type::STRING));
-  auto const source_type = retrieve_io_type_enum(state.get_string("io_type"));
-  auto const compression = cudf::io::compression_type::SNAPPY;
+  auto const d_type        = get_type_or_group(static_cast<int32_t>(data_type::STRING));
+  auto const source_type   = retrieve_io_type_enum(state.get_string("io_type"));
+  auto const compression   = cudf::io::compression_type::SNAPPY;
+  auto const rg_size_bytes = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows  = state.get_int64("row_group_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const avg_string_length = static_cast<cudf::size_type>(state.get_int64("avg_string_length"));
@@ -50,6 +52,9 @@ void BM_parquet_read_long_strings(nvbench::state& state)
     cudf::io::parquet_writer_options write_opts =
       cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(compression);
+    // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
     cudf::io::write_parquet(write_opts);
     return view.num_rows();
   }();
@@ -118,8 +123,9 @@ NVBENCH_BENCH(BM_parquet_read_long_strings)
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("data_size", {512 << 20})
-  .add_int64_power_of_two_axis("avg_string_length",
-                               nvbench::range(4, 16, 2));  // 16, 64, ... -> 64k
+  .add_int64_power_of_two_axis("avg_string_length", nvbench::range(4, 16, 2))  // 16, 64, ... -> 64k
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_read_file_shape)
   .set_name("parquet_read_file_shape")

--- a/cpp/benchmarks/io/parquet/parquet_reader_wide.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_wide.cpp
@@ -26,6 +26,8 @@ void BM_parquet_read_wide_tables(nvbench::state& state,
   auto const cardinality     = static_cast<cudf::size_type>(state.get_int64("cardinality"));
   auto const run_length      = static_cast<cudf::size_type>(state.get_int64("run_length"));
   auto const source_type     = io_type::DEVICE_BUFFER;
+  auto const rg_size_bytes   = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows    = state.get_int64("row_group_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
@@ -38,6 +40,9 @@ void BM_parquet_read_wide_tables(nvbench::state& state,
     cudf::io::parquet_writer_options write_opts =
       cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(cudf::io::compression_type::NONE);
+    // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
     cudf::io::write_parquet(write_opts);
     return view.num_rows();
   }();
@@ -60,6 +65,8 @@ void BM_parquet_read_wide_tables_mixed(nvbench::state& state)
   auto const cardinality     = static_cast<cudf::size_type>(state.get_int64("cardinality"));
   auto const run_length      = static_cast<cudf::size_type>(state.get_int64("run_length"));
   auto const source_type     = io_type::DEVICE_BUFFER;
+  auto const rg_size_bytes   = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows    = state.get_int64("row_group_size_rows");
   cuio_source_sink_pair source_sink(source_type);
 
   auto const num_rows_written = [&]() {
@@ -72,6 +79,8 @@ void BM_parquet_read_wide_tables_mixed(nvbench::state& state)
     cudf::io::parquet_writer_options write_opts =
       cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
         .compression(cudf::io::compression_type::NONE);
+    if (rg_size_bytes > 0) write_opts.set_row_group_size_bytes(rg_size_bytes);
+    if (rg_size_rows > 0) write_opts.set_row_group_size_rows(rg_size_rows);
     cudf::io::write_parquet(write_opts);
     return view.num_rows();
   }();
@@ -87,7 +96,9 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_wide_tables, NVBENCH_TYPE_AXES(d_type_list_w
   .add_int64_axis("data_size", {1024L << 20, 2048L << 20})
   .add_int64_axis("num_cols", {256, 512, 1024})
   .add_int64_axis("cardinality", {0, 1000})
-  .add_int64_axis("run_length", {1, 32});
+  .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parquet_read_wide_tables_mixed)
   .set_name("parquet_read_wide_tables_mixed")
@@ -95,4 +106,6 @@ NVBENCH_BENCH(BM_parquet_read_wide_tables_mixed)
   .add_int64_axis("data_size", {1024L << 20, 2048L << 20})
   .add_int64_axis("num_cols", {256, 512, 1024})
   .add_int64_axis("cardinality", {0, 1000})
-  .add_int64_axis("run_length", {1, 32});
+  .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/parquet_writer.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_writer.cpp
@@ -39,6 +39,8 @@ void BM_parq_write_encode(nvbench::state& state, nvbench::type_list<nvbench::enu
   cudf::size_type const run_length  = state.get_int64("run_length");
   auto const compression            = cudf::io::compression_type::SNAPPY;
   auto const sink_type              = io_type::VOID;
+  auto const rg_size_bytes          = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows           = state.get_int64("row_group_size_rows");
 
   auto const tbl =
     create_random_table(cycle_dtypes(data_types, num_cols),
@@ -58,6 +60,9 @@ void BM_parq_write_encode(nvbench::state& state, nvbench::type_list<nvbench::enu
                cudf::io::parquet_writer_options opts =
                  cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
                    .compression(compression);
+               // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+               if (rg_size_bytes > 0) opts.set_row_group_size_bytes(rg_size_bytes);
+               if (rg_size_rows > 0) opts.set_row_group_size_rows(rg_size_rows);
                cudf::io::write_parquet(opts);
                timer.stop();
 
@@ -86,7 +91,9 @@ void BM_parq_write_io_compression(nvbench::state& state)
   cudf::size_type const cardinality = state.get_int64("cardinality");
   cudf::size_type const run_length  = state.get_int64("run_length");
   auto const sink_type              = retrieve_io_type_enum(state.get_string("io_type"));
-  auto const compression = retrieve_compression_type_enum(state.get_string("compression_type"));
+  auto const compression   = retrieve_compression_type_enum(state.get_string("compression_type"));
+  auto const rg_size_bytes = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows  = state.get_int64("row_group_size_rows");
 
   auto const tbl =
     create_random_table(cycle_dtypes(data_types, num_cols),
@@ -106,6 +113,8 @@ void BM_parq_write_io_compression(nvbench::state& state)
                cudf::io::parquet_writer_options opts =
                  cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
                    .compression(compression);
+               if (rg_size_bytes > 0) opts.set_row_group_size_bytes(rg_size_bytes);
+               if (rg_size_rows > 0) opts.set_row_group_size_rows(rg_size_rows);
                cudf::io::write_parquet(opts);
                timer.stop();
 
@@ -123,9 +132,11 @@ template <cudf::io::statistics_freq Statistics>
 void BM_parq_write_varying_options(nvbench::state& state,
                                    nvbench::type_list<nvbench::enum_type<Statistics>>)
 {
-  auto const enable_stats = Statistics;
-  auto const compression  = retrieve_compression_type_enum(state.get_string("compression_type"));
-  auto const file_path    = state.get_string("file_path");
+  auto const enable_stats  = Statistics;
+  auto const compression   = retrieve_compression_type_enum(state.get_string("compression_type"));
+  auto const file_path     = state.get_string("file_path");
+  auto const rg_size_bytes = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows  = state.get_int64("row_group_size_rows");
 
   auto const data_types = get_type_or_group({static_cast<int32_t>(data_type::INTEGRAL_SIGNED),
                                              static_cast<int32_t>(data_type::FLOAT),
@@ -148,11 +159,13 @@ void BM_parq_write_varying_options(nvbench::state& state,
                cuio_source_sink_pair source_sink(io_type::FILEPATH);
 
                timer.start();
-               cudf::io::parquet_writer_options const options =
+               cudf::io::parquet_writer_options options =
                  cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
                    .compression(compression)
                    .stats_level(enable_stats)
                    .column_chunks_file_paths({file_path});
+               if (rg_size_bytes > 0) options.set_row_group_size_bytes(rg_size_bytes);
+               if (rg_size_rows > 0) options.set_row_group_size_rows(rg_size_rows);
                cudf::io::write_parquet(options);
                timer.stop();
 
@@ -186,7 +199,9 @@ NVBENCH_BENCH_TYPES(BM_parq_write_encode, NVBENCH_TYPE_AXES(d_type_list))
   .set_type_axes_names({"data_type"})
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000, 10'000, 100'000})
-  .add_int64_axis("run_length", {1, 8, 32});
+  .add_int64_axis("run_length", {1, 8, 32})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(BM_parq_write_io_compression)
   .set_name("parquet_write_io_compression")
@@ -194,11 +209,15 @@ NVBENCH_BENCH(BM_parq_write_io_compression)
   .add_string_axis("compression_type", {"SNAPPY", "ZSTD", "LZ4", "NONE"})
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
-  .add_int64_axis("run_length", {1, 32});
+  .add_int64_axis("run_length", {1, 32})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH_TYPES(BM_parq_write_varying_options, NVBENCH_TYPE_AXES(stats_list))
   .set_name("parquet_write_options")
   .set_type_axes_names({"statistics"})
   .add_string_axis("compression_type", {"SNAPPY", "ZSTD", "LZ4", "NONE"})
   .set_min_samples(4)
-  .add_string_axis("file_path", {"unused_path.parquet", ""});
+  .add_string_axis("file_path", {"unused_path.parquet", ""})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/benchmarks/io/parquet/parquet_writer_chunks.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_writer_chunks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,6 +22,8 @@ constexpr int64_t data_size = 512 << 20;
 void PQ_write(nvbench::state& state)
 {
   cudf::size_type const num_cols = state.get_int64("num_cols");
+  auto const rg_size_bytes       = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows        = state.get_int64("row_group_size_rows");
 
   auto const tbl  = create_random_table(cycle_dtypes({cudf::type_id::INT32}, num_cols),
                                        table_size_bytes{data_size});
@@ -38,6 +40,9 @@ void PQ_write(nvbench::state& state)
                timer.start();
                cudf::io::parquet_writer_options opts =
                  cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view);
+               // Sentinel 0 == use cuDF default (parquet bytes default is size_t::max).
+               if (rg_size_bytes > 0) opts.set_row_group_size_bytes(rg_size_bytes);
+               if (rg_size_rows > 0) opts.set_row_group_size_rows(rg_size_rows);
                cudf::io::write_parquet(opts);
                timer.stop();
 
@@ -55,6 +60,8 @@ void PQ_write_chunked(nvbench::state& state)
 {
   cudf::size_type const num_cols   = state.get_int64("num_cols");
   cudf::size_type const num_tables = state.get_int64("num_chunks");
+  auto const rg_size_bytes         = state.get_int64("row_group_size_bytes");
+  auto const rg_size_rows          = state.get_int64("row_group_size_rows");
 
   std::vector<std::unique_ptr<cudf::table>> tables;
   for (cudf::size_type idx = 0; idx < num_tables; idx++) {
@@ -73,6 +80,8 @@ void PQ_write_chunked(nvbench::state& state)
       timer.start();
       cudf::io::chunked_parquet_writer_options opts =
         cudf::io::chunked_parquet_writer_options::builder(source_sink.make_sink_info());
+      if (rg_size_bytes > 0) opts.set_row_group_size_bytes(rg_size_bytes);
+      if (rg_size_rows > 0) opts.set_row_group_size_rows(rg_size_rows);
       cudf::io::chunked_parquet_writer writer(opts);
       std::for_each(tables.begin(),
                     tables.end(),
@@ -93,10 +102,14 @@ void PQ_write_chunked(nvbench::state& state)
 NVBENCH_BENCH(PQ_write)
   .set_name("parquet_write_num_cols")
   .set_min_samples(4)
-  .add_int64_axis("num_cols", {8, 1024});
+  .add_int64_axis("num_cols", {8, 1024})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});
 
 NVBENCH_BENCH(PQ_write_chunked)
   .set_name("parquet_chunked_write")
   .set_min_samples(4)
   .add_int64_axis("num_cols", {8, 1024})
-  .add_int64_axis("num_chunks", {8, 64});
+  .add_int64_axis("num_chunks", {8, 64})
+  .add_int64_axis("row_group_size_bytes", {0})
+  .add_int64_axis("row_group_size_rows", {0});

--- a/cpp/include/cudf/join/mark_join.hpp
+++ b/cpp/include/cudf/join/mark_join.hpp
@@ -68,24 +68,6 @@ class mark_join {
   mark_join& operator=(mark_join&&)      = delete;
 
   /**
-   * @brief Constructs a mark join object by building a hash table from the build table.
-   *
-   * @deprecated Deprecated in the current release. Use the overload accepting
-   *             `cudf::join_prefilter` instead. This overload will be removed in the next release.
-   *
-   * @param build The build table (typically the left table)
-   * @param compare_nulls Controls whether null join-key values should match or not
-   * @param stream CUDA stream used for device memory operations and kernel launches
-   */
-  // rapids-pre-commit-hooks: disable-next-line
-  [[deprecated(
-    "Use the overload accepting cudf::join_prefilter instead."
-    " This overload will be removed in the next release.")]]
-  mark_join(cudf::table_view const& build,
-            cudf::null_equality compare_nulls = null_equality::EQUAL,
-            rmm::cuda_stream_view stream      = cudf::get_default_stream());
-
-  /**
    * @brief Constructs a mark join object with explicit prefilter selection.
    *
    * @param build The build table (typically the left table)
@@ -96,26 +78,6 @@ class mark_join {
   mark_join(cudf::table_view const& build,
             cudf::null_equality compare_nulls,
             cudf::join_prefilter prefilter,
-            rmm::cuda_stream_view stream = cudf::get_default_stream());
-
-  /**
-   * @brief Constructs a mark join object with a specified load factor.
-   *
-   * @deprecated Deprecated in the current release. Use the overload accepting
-   *             `cudf::join_prefilter` instead. This overload will be removed in the next release.
-   *
-   * @param build The build table (typically the left table)
-   * @param compare_nulls Controls whether null join-key values should match or not
-   * @param load_factor Hash table load factor in range (0,1]
-   * @param stream CUDA stream used for device memory operations and kernel launches
-   */
-  // rapids-pre-commit-hooks: disable-next-line
-  [[deprecated(
-    "Use the overload accepting cudf::join_prefilter instead."
-    " This overload will be removed in the next release.")]]
-  mark_join(cudf::table_view const& build,
-            cudf::null_equality compare_nulls,
-            double load_factor,
             rmm::cuda_stream_view stream = cudf::get_default_stream());
 
   /**

--- a/cpp/src/groupby/streaming_groupby/common.cuh
+++ b/cpp/src/groupby/streaming_groupby/common.cuh
@@ -86,7 +86,11 @@ struct n_table_comparator {
   key_location_t const* key_loc;  ///< {batch_id, row_in_compacted} per dense ID
   size_type max_distinct_keys;  ///< Threshold: idx >= max_distinct_keys is a transient batch value
 
-  __device__ bool operator()(size_type lhs, size_type rhs) const noexcept
+#ifndef NDEBUG
+  __attribute__((noinline))
+#endif
+  __device__ bool
+  operator()(size_type lhs, size_type rhs) const noexcept
   {
     bool const lhs_is_batch = (lhs >= max_distinct_keys);
     bool const rhs_is_batch = (rhs >= max_distinct_keys);

--- a/cpp/src/join/mark_join.cu
+++ b/cpp/src/join/mark_join.cu
@@ -810,27 +810,10 @@ mark_join::~mark_join() = default;
 
 mark_join::mark_join(cudf::table_view const& build,
                      cudf::null_equality compare_nulls,
-                     rmm::cuda_stream_view stream)
-  : _impl{std::make_unique<detail::mark_join>(
-      build, compare_nulls, detail::CUCO_DESIRED_LOAD_FACTOR, join_prefilter::NO, stream)}
-{
-}
-
-mark_join::mark_join(cudf::table_view const& build,
-                     cudf::null_equality compare_nulls,
                      cudf::join_prefilter prefilter,
                      rmm::cuda_stream_view stream)
   : _impl{std::make_unique<detail::mark_join>(
       build, compare_nulls, detail::CUCO_DESIRED_LOAD_FACTOR, prefilter, stream)}
-{
-}
-
-mark_join::mark_join(cudf::table_view const& build,
-                     cudf::null_equality compare_nulls,
-                     double load_factor,
-                     rmm::cuda_stream_view stream)
-  : _impl{std::make_unique<detail::mark_join>(
-      build, compare_nulls, load_factor, join_prefilter::NO, stream)}
 {
 }
 

--- a/cpp/src/join/mixed_join_common_utils.cuh
+++ b/cpp/src/join/mixed_join_common_utils.cuh
@@ -128,8 +128,13 @@ template <bool has_nulls>
 struct pair_expression_equality : public expression_equality<has_nulls> {
   using expression_equality<has_nulls>::expression_equality;
 
-  __device__ __forceinline__ bool operator()(pair_type const& left_row,
-                                             pair_type const& right_row) const noexcept
+#ifndef NDEBUG
+  __attribute__((noinline))
+#else
+  __forceinline__
+#endif
+  __device__ bool
+  operator()(pair_type const& left_row, pair_type const& right_row) const noexcept
   {
     using cudf::detail::row::lhs_index_type;
     using cudf::detail::row::rhs_index_type;


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.