### PR TITLE
Adjust cudf-polars test timeouts

### DIFF
--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -71,7 +71,7 @@ for version in "${VERSIONS[@]}"; do
         COVERAGE_ARGS=(--no-cov)
     fi
 
-    timeout 25m ./ci/run_cudf_polars_pytests.sh \
+    timeout 35m ./ci/run_cudf_polars_pytests.sh \
         "${COVERAGE_ARGS[@]}" \
         --numprocesses=8 \
         --dist=worksteal \

--- a/python/cudf_polars/tests/streaming/test_scan.py
+++ b/python/cudf_polars/tests/streaming/test_scan.py
@@ -35,6 +35,7 @@ def df():
         ("parquet", pl.scan_parquet),
     ],
 )
+@pytest.mark.timeout(90)
 def test_parallel_scan(tmp_path, df, fmt, scan_fn, streaming_engine):
     make_partitioned_source(df, tmp_path, fmt, n_files=3)
     q = scan_fn(tmp_path)


### PR DESCRIPTION
## Description

- Higher per-test timeout for `test_parallel_scan` timeout, which hit the default 45s timeout for some parameter combinations (fixes https://github.com/rapidsai/cudf/actions/runs/26560674690/job/78242678694#step:13:13133, https://github.com/rapidsai/cudf/actions/runs/26560674690/job/78242678488)
- Bump the job timeout from 25m to 35m (fixes https://github.com/rapidsai/cudf/actions/runs/26560674690/job/78242678485#step:13:12354, https://github.com/rapidsai/cudf/actions/runs/26560674690/job/78242678638)
