### PR TITLE
Reduce MixedInnerJoinTest.LargeDataMultiBlockCoordination to a single type

### DIFF
--- a/ci/test_cpp_memcheck.sh
+++ b/ci/test_cpp_memcheck.sh
@@ -11,7 +11,7 @@ source ./ci/test_cpp_common.sh
 
 rapids-logger "Memcheck gtests with rmm_mode=cuda"
 
-timeout 3.5h ./ci/run_cudf_memcheck_ctests.sh && EXITCODE=$? || EXITCODE=$?;
+timeout 4h ./ci/run_cudf_memcheck_ctests.sh && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 # shellcheck disable=SC2086

--- a/cpp/tests/join/mixed_join_tests.cu
+++ b/cpp/tests/join/mixed_join_tests.cu
@@ -602,9 +602,11 @@ TYPED_TEST(MixedInnerJoinTest, BasicInequality)
 // This test is designed to prevent https://github.com/NVIDIA/spark-rapids/issues/13416 from
 // happening again, where the block atomic counter was improperly set, causing illegal memory access
 // when the input data is large enough that multiple blocks are needed for the kernel.
-TYPED_TEST(MixedInnerJoinTest, LargeDataMultiBlockCoordination)
+struct MixedInnerJoinTestInt32 : public MixedInnerJoinTest<int32_t> {};
+TEST_F(MixedInnerJoinTestInt32, LargeDataMultiBlockCoordination)
 {
-  using T = TypeParam;
+  using TypeParam = int32_t;
+  using T         = TypeParam;
 
   // These sizes are large enough to ensure the kernel launches with multiple blocks
   constexpr int left_size  = 5000;


### PR DESCRIPTION
## Description
Changes the `MixedInnerJoinTest.LargeDataMultiBlockCoordination` to use a single integer type rather than repeat it for all integer types (8 of them). The description implies the large input is to ensure multiple blocks are needed by the CUDA kernel. A single type is sufficient to check this behavior.

Using a single type helps reduce the test execution time which is most noticeable with the nightly memcheck runner.
Each usage of this test can run several minutes:
```
MixedInnerJoinTest/7.LargeDataMultiBlockCoordination (742315 ms)
MixedInnerJoinTest/6.LargeDataMultiBlockCoordination (698609 ms)
MixedInnerJoinTest/5.LargeDataMultiBlockCoordination (497589 ms)
MixedInnerJoinTest/4.LargeDataMultiBlockCoordination (383197 ms)
MixedInnerJoinTest/3.LargeDataMultiBlockCoordination (288021 ms)
MixedInnerJoinTest/2.LargeDataMultiBlockCoordination (202237 ms)
MixedInnerJoinTest/1.LargeDataMultiBlockCoordination (137849 ms)
MixedInnerJoinTest/0.LargeDataMultiBlockCoordination (71909 ms)

```

The memcheck test timeout is also increased by 30 minutes in this PR.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
