### PR TITLE
Add noinline to n_table_comparator::operator()

### DIFF
--- a/cpp/src/groupby/streaming_groupby/common.cuh
+++ b/cpp/src/groupby/streaming_groupby/common.cuh
@@ -86,11 +86,7 @@ struct n_table_comparator {
   key_location_t const* key_loc;  ///< {batch_id, row_in_compacted} per dense ID
   size_type max_distinct_keys;  ///< Threshold: idx >= max_distinct_keys is a transient batch value
 
-#ifndef NDEBUG
-  __attribute__((noinline))
-#endif
-  __device__ bool
-  operator()(size_type lhs, size_type rhs) const noexcept
+  __attribute__((noinline)) __device__ bool operator()(size_type lhs, size_type rhs) const noexcept
   {
     bool const lhs_is_batch = (lhs >= max_distinct_keys);
     bool const rhs_is_batch = (rhs >= max_distinct_keys);


### PR DESCRIPTION
## Description
Adds the `noinline` declaration to the `n_table_comparator::operator()` function.
This is based on the discussion and results here: https://github.com/rapidsai/cudf/pull/22675#issuecomment-4557913407

The attribute was necessary for the debug build but showed no issue in runtime for a release build. This PR makes the declaration non-conditional to make the code simpler to maintain.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
