### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - cuda-python>=12.9.2,<13.0
 - cuda-sanitizer-api
 - cuda-version=12.9
-- cupy>=13.6.0,!=14.0.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - cuda-python>=12.9.2,<13.0
 - cuda-sanitizer-api
 - cuda-version=12.9
-- cupy>=13.6.0,!=14.0.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - cuda-python>=13.0.1,<14.0
 - cuda-sanitizer-api
 - cuda-version=13.2
-- cupy>=13.6.0,!=14.0.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - cuda-python>=13.0.1,<14.0
 - cuda-sanitizer-api
 - cuda-version=13.2
-- cupy>=13.6.0,!=14.0.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -89,7 +89,7 @@ requirements:
   run:
     - python
     - pandas >=2.0,<2.4.0
-    - cupy >=13.6.0,!=14.0.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - numba-cuda >=0.22.2,<0.29.0
     - numba >=0.60.0,<0.65.0
     - numpy >=1.26,<3.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1159,7 +1159,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=13.6.0,!=14.0.0
+          - cupy>=13.6.0,!=14.0.0,!=14.1.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -1169,11 +1169,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0,!=14.0.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0,!=14.0.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
   depends_on_libkvikio:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -935,11 +935,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x!=14.0.0
+              - cupy-cuda12x!=14.0.0,!=14.1.0
           - matrix:
               cuda: "13.*"
             packages:
-              - cupy-cuda13x!=14.0.0
+              - cupy-cuda13x!=14.0.0,!=14.1.0
           - matrix:
             packages:
   test_python_dask_cudf:

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.11"
 dependencies = [
     "cachetools",
     "cuda-python>=13.0.1,<14.0",
-    "cupy-cuda13x>=13.6.0,!=14.0.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "fsspec>=0.6.0",
     "libcudf==26.6.*,>=0.0.0a0",
     "numba-cuda>=0.22.2,<0.29.0",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -22,7 +22,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
     "cudf==26.6.*,>=0.0.0a0",
-    "cupy-cuda13x>=13.6.0,!=14.0.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "fsspec>=0.6.0",
     "numpy>=1.26,<3.0",
     "nvidia-ml-py>=12",

--- a/python/pylibcudf/pyproject.toml
+++ b/python/pylibcudf/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "cupy-cuda13x>=13.6.0,!=14.0.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "fastavro>=0.22.9",
     "mmh3",
     "nanoarrow",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
