### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/.agents/skills/debug-cudf-pandas/SKILL.md
+++ b/.agents/skills/debug-cudf-pandas/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: debug-cudf-pandas
+description: Debug and fix pandas test suite failures under the cudf.pandas compatibility layer. Use when given pytest node IDs of failing pandas tests that need to be fixed for cudf.pandas compatibility.
+---
+
+# Debug cudf.pandas Compatibility Failures
+
+## Overview
+
+`cudf.pandas` is a zero-code-change GPU accelerator for pandas. It intercepts `import pandas` via a Python `MetaPathFinder` (`python/cudf/cudf/pandas/module_accelerator.py`) and wraps all pandas objects and functions in proxy types that try the cudf (GPU) path first, falling back to pandas (CPU) if cudf raises an exception.
+
+When the pandas test suite is run with `-p cudf.pandas`, test failures indicate one of:
+- A **cudf implementation bug** — cudf's DataFrame/Series/Column/Index behavior differs from pandas for an edge case
+- A **proxy/dispatch bug** — the wrapping/unwrapping mechanism doesn't correctly handle a type or operation
+- A **missing proxy registration** — a pandas type or return value has no registered cudf equivalent
+- A **to/from_pandas conversion bug** — data is corrupted or lost when converting between cudf and pandas objects
+- A **test setup bug** — the testing scripts or conftest-patch introduce an issue
+- A **pandas bug** — rarely, the expected behavior in the pandas test itself is wrong
+
+Your job is to find the root cause and implement the fix.
+
+## Unacceptable Fix Patterns
+
+The following patterns are prohibited regardless of whether they make a test pass. Stop immediately and ask the user if the only apparent solution falls into one of these categories.
+
+- **Esoteric/test-specific special cases**: Do not implement narrow, brittle logic targeting only the specific failing node IDs (e.g. special-casing a single dtype/shape combination). If a test is failing, find the general API contract mismatch and fix it at that level.
+- **Pandas CPU fallback as a fix**: Typically you should not make tests pass by simply raising an exception inside cudf to force CPU fallback. Falling back to pandas/CPU is only an acceptable fix if attempting to fix the bug leads to discovering that large features must be implemented in cudf to support the change (e.g. a completely new class).
+- **Private pandas APIs**: Do not import or call any symbol from `pandas.core`, `pandas.compat`, or any underscored pandas module (e.g. `pandas._libs.tslibs.parsing`). These are explicitly unstable per the pandas API policy. Use public pandas APIs or write equivalent local logic instead.
+- **PyArrow as a CPU execution backend**: Do not route GPU operations through `pyarrow.compute` on CPU as a substitute for cudf/libcudf semantics. Arrow is an interchange format; it is not an acceptable execution backend for cudf operations.
+- **Returning pandas objects from cudf APIs**: cudf public methods (`Series`, `Index`, `DataFrame` operations and accessors) must return cudf-native objects, not `pd.Series`, `pd.Index`, or `pd.DataFrame`. Use `_return_or_inplace` and the existing cudf container reconstruction helpers.
+
+---
+
+## Prerequisites
+
+Before starting, verify you are at the repository root. All commands in this skill assume the working directory is the cudf repository root.
+
+**Clean up any previous test run state.** The test runner appends `conftest-patch.py` to the pandas conftest on every invocation. If `pandas-testing/pandas-tests/` already exists from a prior run, the conftest will have duplicate hook registrations and cause spurious errors. Always delete it before running:
+
+```bash
+rm -rf pandas-testing/pandas-tests/
+```
+
+The cudf Python package is almost entirely pure Python. For **inplace installs** (e.g. `pip install -e .`), changes to `.py` files take effect immediately — no rebuild is needed. For non-inplace installs (e.g. `./build.sh`), you must either reinstall or copy changed files to site-packages.
+
+---
+
+## Input Format
+
+Input is one or more pytest node IDs, relative to the `pandas-tests/` directory inside the test harness:
+
+```
+tests/groupby/test_reductions.py::test_first_last_skipna[Float64-False-False-first]
+tests/frame/methods/test_fillna.py::test_fillna_inplace
+```
+
+Node IDs with parameters like `[Float64-False-False-first]` target a specific parametrized case. When multiple node IDs are provided, check whether they share a root cause before attempting separate fixes.
+
+---
+
+## Step 0 — Update conftest-patch.py
+
+The file `python/cudf/cudf/pandas/scripts/conftest-patch.py` contains three dictionaries that gate how tests are handled:
+
+- **`NODEIDS_THAT_FAIL`** — tests marked `xfail` (expected to fail). Keys are alphabetically sorted.
+- **`NODEIDS_TO_SKIP`** — tests marked `skip` (not run at all). Keys are alphabetically sorted.
+- **`NODEIDS_PATHS_TO_SKIP`** — prefix-based path skips covering entire modules.
+
+Because the test runner sets `xfail_strict = true`, a test listed in `NODEIDS_THAT_FAIL` that unexpectedly *passes* is reported as `XPASS` — which is also a failure. You must remove the entry before testing your fix, or you will never see a genuine pass.
+
+Search for the node ID:
+
+```bash
+grep -n "tests/groupby/test_reductions.py::test_first_last_skipna" \
+    python/cudf/cudf/pandas/scripts/conftest-patch.py
+```
+
+If found, remove the line. Keys must remain in alphabetical order after the edit. Then validate the file still parses:
+
+```bash
+python -c "exec(open('python/cudf/cudf/pandas/scripts/conftest-patch.py').read())"
+```
+
+If the node ID is *not* found in any dictionary, you are dealing with a new regression — proceed directly to Step 1.
+
+---
+
+## Step 1 — Reproduce the Failure
+
+Run from the repo root:
+
+```bash
+rm -rf pandas-testing/pandas-tests/
+bash python/cudf/cudf/pandas/scripts/run-pandas-tests.sh \
+    "tests/groupby/test_reductions.py::test_first_last_skipna[Float64-False-False-first]" \
+    -xvs
+```
+
+The script clones the matching pandas version, copies tests, appends the conftest patch, and runs pytest with `-p cudf.pandas`. Substitute your actual node ID.
+
+**If the test passes**: the xfail entry was stale. Commit only the `conftest-patch.py` change and stop.
+
+**If the test fails**: read the failure output carefully — the assertion message tells you the exact behavioral difference. Proceed to Step 2.
+
+---
+
+## Step 2 — Understand the Test
+
+After the first run, the test file exists at:
+
+```
+pandas-testing/pandas-tests/tests/<module>/<test_file>.py
+```
+
+Read the test. Identify:
+- Which pandas API is being exercised (method name, class, module)
+- What the test asserts — this is the exact behavior cudf must match
+- Whether parameters narrow the scope (e.g. only `Float64` dtype, only `skipna=False`)
+
+The assertion error output from Step 1 tells you what cudf produced vs. what was expected. Use both together to understand the gap.
+
+---
+
+## Step 3 — Diagnose Root Cause
+
+**Always check cudf's direct behavior first.** Do not jump to proxy investigation.
+
+### 3a. Direct cudf test (most important step)
+
+Write a minimal script that exercises the API using cudf directly, without going through `cudf.pandas`. This is strictly an example — adapt the structure to match what the failing test actually does (comparisons, exception checks, dtype validation, etc.):
+
+```python
+import cudf
+import pandas as pd
+
+# Mirror the test setup
+pdf = pd.DataFrame({"value": [1.0, None, 2.0, 3.0]}, dtype="Float64")
+cdf = cudf.from_pandas(pdf)
+
+pd_result = pdf.groupby(level=0).first(skipna=False)
+cudf_result = cdf.groupby(level=0).first(skipna=False)
+
+print("pandas:", pd_result)
+print("cudf:  ", cudf_result)
+print("match:", pd_result.equals(cudf_result.to_pandas()))
+```
+
+For tests that assert exceptions are raised, structure your script to verify both cudf and pandas raise the same exception type and message.
+
+Save to a temporary file (e.g. `test_debug.py`) and run:
+
+```bash
+python test_debug.py
+```
+
+Results:
+- **cudf result differs from pandas** → cudf implementation bug → go to Step 4a
+- **cudf raises an exception** → missing feature or bug → evaluate scope; may need user input if the feature is large. Note: this may be OK if the test is verifying that an exception *should* be raised.
+- **cudf result matches pandas** → proxy/dispatch bug → go to Step 4b
+
+**Classify the root cause before writing any fix.** Ask yourself: Is this a specific method/keyword handling bug? A broad dtype casting mismatch affecting many operations? A proxy/wrapping issue? A missing cudf capability? For broad issues, the fix should be applied at the shared/base layer, not patched per individual method. If the only apparent fix is test-shaped (i.e. it looks like it exists to make exactly these node IDs pass), step back and re-examine the general API contract.
+
+### 3b. Environment variable diagnostics (run through cudf.pandas)
+
+Use these env vars to trace what is happening at the proxy layer:
+
+| Variable | Effect |
+|----------|--------|
+| `CUDF_PANDAS_FAIL_ON_FALLBACK=1` | Raises instead of silently falling back — shows exactly which operation triggers fallback |
+| `LOG_FAST_FALLBACK=1` | Logs every fallback with function name and exception |
+| `CUDF_PANDAS_DEBUGGING=1` | Runs both cudf and pandas paths in parallel, warns on result divergence |
+
+```bash
+CUDF_PANDAS_FAIL_ON_FALLBACK=1 bash python/cudf/cudf/pandas/scripts/run-pandas-tests.sh \
+    "<node_id>" -xvs
+```
+
+```bash
+LOG_FAST_FALLBACK=1 bash python/cudf/cudf/pandas/scripts/run-pandas-tests.sh \
+    "<node_id>" -xvs 2>&1 | grep -i fallback
+```
+
+**Fallback is a diagnostic signal, not a fix.** If `CUDF_PANDAS_FAIL_ON_FALLBACK=1` causes the test to fail, routing the operation to pandas CPU is not acceptable as a final solution unless adding GPU support would require implementing large, entirely unsupported features. Bug fixes for cudf's behavior (e.g. to add support for a particular dtype to a function) are the expected path.
+
+### 3c. Standalone instrumented script
+
+For deeper investigation, copy the relevant test body into a temporary script (e.g. `test_debug.py`), add print statements or assertions at intermediate steps, then run through the proxy layer or try to write matching pandas code to see the differences in behaviors and fix them:
+
+```bash
+python -m cudf.pandas test_debug.py
+```
+
+This gives you full control to narrow down exactly where the divergence begins.
+
+---
+
+## Step 4a — Fix a cudf Implementation Bug
+
+The fix must be **tightly scoped** and try to keep it minimal. Fixing one edge case can break another test. Do not refactor surrounding code while fixing, and do not add `mode.pandas_compatible` guards (ask the user first).
+
+**Classify the failure mode** before writing a fix: is it a specific issue (e.g. one method handles a keyword incorrectly) or a broad failure mode (e.g. dtype casting inconsistency that affects many operations)? For broad issues, consider whether the fix should be applied at a shared/base level rather than patching individual methods.
+
+Common fix locations:
+
+| What fails | Where to look |
+|---|---|
+| DataFrame method | `python/cudf/cudf/core/dataframe.py` |
+| Series method | `python/cudf/cudf/core/series.py` |
+| Index operation | `python/cudf/cudf/core/index.py` |
+| Shared DataFrame/Series method | `python/cudf/cudf/core/indexed_frame.py` |
+| Column-level operation | `python/cudf/cudf/core/column/*.py` |
+| GroupBy operation | `python/cudf/cudf/core/groupby/` |
+| IO operation | `python/cudf/cudf/io/` |
+
+Note: `mode.pandas_compatible` is automatically set to `True` when cudf.pandas is active. Account for this in any conditional logic, but do not add new guards for it without explicit user approval.
+
+If the bug is not in cudf core, move to cudf.pandas-specific fixes.
+
+**Prohibited in cudf implementation fixes:**
+- Do not call `pandas._libs.*` or any other private/underscored pandas module. Use public pandas APIs (`pd.Timestamp`, `pd.to_datetime`, `pd.DateOffset`, etc.) and write equivalent local logic if needed.
+- Do not convert to pyarrow and use `pyarrow.compute` as a substitute for libcudf behavior. If libcudf doesn't support the exact semantics, consult the user before adding a pyarrow fallback.
+- Do not construct and return `pd.Series(...)`, `pd.Index(...)`, or `pd.DataFrame(...)` from cudf public methods. Use `_return_or_inplace`, `_from_column`, or other cudf container reconstruction helpers so that return types remain cudf-native.
+
+---
+
+## Step 4b — Fix a Proxy/Dispatch Bug
+
+Only reach this step after Step 3a has confirmed that cudf itself is correct. Some of the common cases you should consider at this stage:
+
+**Most common cause**: a pandas object in a particular state is not round-tripping correctly through cudf's conversion APIs. `cudf.from_pandas()` and `<object>.to_pandas()` are culprits here. To debug this case, set up the standalone instrumented script as described in step 3c. Then instrument the code to perform direct modifications and testing of the proxy state, for instance by accessing the `_fsproxy_fast` and `_fsproxy_slow` attributes of the relevant objects and calling `cudf.from_pandas` and `<object>.to_pandas` to see if information is being lost or corrupted in one of the conversions.
+
+**Next most common cause**: a pandas return type has no registered cudf proxy. Check `python/cudf/cudf/pandas/_wrappers/pandas.py` — this file registers which pandas types map to which cudf types using `make_final_proxy_type()` and related functions. If a new pandas type needs wrapping, add the registration here.
+
+**`fast_slow_proxy.py` and `module_accelerator.py`** are core infrastructure files. Fix them only if you believe the bug is in one of them.
+
+---
+
+## Step 5 — Verify the Fix
+
+Three checks are required. Run them in order.
+
+**a. Target test passes:**
+
+```bash
+bash python/cudf/cudf/pandas/scripts/run-pandas-tests.sh "<node_id>" -xvs
+```
+
+Expected: exit code 0, test shows `PASSED`.
+
+**b. Fix runs on GPU (no silent fallback):**
+
+```bash
+CUDF_PANDAS_FAIL_ON_FALLBACK=1 bash python/cudf/cudf/pandas/scripts/run-pandas-tests.sh \
+    "<node_id>" -xvs
+```
+
+Expected: test still passes. If this fails, the fix works by falling back to pandas rather than actually fixing cudf — that is not acceptable.
+
+Exception: some tests intentionally validate fallback behavior. If `FAIL_ON_FALLBACK` causes this test to fail but the test logic requires fallback, skip this check for that specific test and note the justification.
+
+**c. No regressions in the module:**
+
+```bash
+bash python/cudf/cudf/pandas/scripts/run-pandas-tests.sh \
+    "tests/<module_directory>/" --tb=line -q
+```
+
+Replace `<module_directory>` with the directory containing your test (e.g. `tests/groupby/`). Any new failures that are not already listed in `conftest-patch.py` must be investigated before committing.
+
+**d. Add unit tests (where appropriate):**
+
+If your fix changes cudf behavior, add a unit test in `cudf` classic or `cudf.pandas` depending on where the fix lives. When adding tests:
+- Prefer adding to existing test parameterizations if a related test already exists
+- If no related test exists, write a test that compares cudf output to pandas (using `assert_eq` or `assert_exceptions_equal`)
+- Place cudf classic tests alongside existing tests in `python/cudf/cudf/tests/`
+- Place cudf.pandas-specific tests in `python/cudf/cudf_pandas_tests/`
+
+---
+
+## Step 6 — Commit
+
+Stage only the intended files — never anything from `pandas-testing/`:
+
+```bash
+git add python/cudf/cudf/          # source fix (if applicable)
+git add python/cudf/cudf/pandas/scripts/conftest-patch.py   # xfail removal
+git status                          # verify nothing from pandas-testing/ is staged
+git commit -m "fix(cudf.pandas): <short description>
+
+Fixes the following failing pandas tests:
+- tests/groupby/test_reductions.py::test_first_last_skipna[Float64-False-False-first]"
+```
+
+If many node IDs share the same root cause, summarize them in the commit message rather than listing every parametrized variant. Commit message should convey what was wrong and what was fixed.
+
+---
+
+## STOP Conditions
+
+Stop immediately and report findings to the user when any of the following apply:
+
+- The fix requires modifying `.pyx`, `.cu`, `.cuh`, or `CMakeLists.txt` files — this requires compilation, which is outside the scope of this skill
+- Investigation reveals the behavioral divergence is **intentional** — cudf was deliberately designed to differ from pandas
+- You have been through 3 or more investigation cycles without converging on a fix
+- The fix would add a new `mode.pandas_compatible` conditional
+
+For intentional divergence: stop and ask the user. In most cases, the goal is to make cudf match pandas. Only when the divergence has significant performance implications should `mode.pandas_compatible` be used — and even then, sparingly. cudf already overuses this flag; the default behavior should agree with pandas.
+
+---
+
+## Important Notes
+
+- `mode.pandas_compatible` is automatically set to `True` when `cudf.pandas` is active. This is done at the end of `python/cudf/cudf/pandas/_wrappers/pandas.py`.
+- cudf Python is almost entirely pure Python — for inplace installs, changes to `.py` files take effect immediately without rebuilding.
+- `pandas-testing/pandas-tests/` must be deleted before each test run to avoid duplicate conftest hook registrations (the script appends the patch file on every run).
+- Keys in all three `conftest-patch.py` dictionaries must remain in alphabetical order.
+- Never write comments that explain what old code was replaced — write comments about what the code does and why.
+- Never modify the pandas test files themselves — fix cudf, not pandas.
+- Never fix the testing APIs (like `assert_frame_equal`, `assert_series_equal`) — fix the actual APIs that produce wrong results.
+- First see if the problem is in cudf classic and fix it there; if not, then move over to cudf.pandas.
+- Tests run with `xfail_strict = true` — a test listed in `NODEIDS_THAT_FAIL` that unexpectedly passes is reported as `XPASS` (also a failure). Remove from the list before testing.

--- a/ci/test_cpp_memcheck.sh
+++ b/ci/test_cpp_memcheck.sh
@@ -11,7 +11,7 @@ source ./ci/test_cpp_common.sh
 
 rapids-logger "Memcheck gtests with rmm_mode=cuda"
 
-timeout 3.5h ./ci/run_cudf_memcheck_ctests.sh && EXITCODE=$? || EXITCODE=$?;
+timeout 4h ./ci/run_cudf_memcheck_ctests.sh && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 # shellcheck disable=SC2086

--- a/cpp/src/groupby/streaming_groupby/common.cuh
+++ b/cpp/src/groupby/streaming_groupby/common.cuh
@@ -86,11 +86,7 @@ struct n_table_comparator {
   key_location_t const* key_loc;  ///< {batch_id, row_in_compacted} per dense ID
   size_type max_distinct_keys;  ///< Threshold: idx >= max_distinct_keys is a transient batch value
 
-#ifndef NDEBUG
-  __attribute__((noinline))
-#endif
-  __device__ bool
-  operator()(size_type lhs, size_type rhs) const noexcept
+  __attribute__((noinline)) __device__ bool operator()(size_type lhs, size_type rhs) const noexcept
   {
     bool const lhs_is_batch = (lhs >= max_distinct_keys);
     bool const rhs_is_batch = (rhs >= max_distinct_keys);

--- a/cpp/src/jit/row_ir.cpp
+++ b/cpp/src/jit/row_ir.cpp
@@ -146,13 +146,14 @@ int32_t instance_context::add_input(input in)
   auto id     = static_cast<int32_t>(inputs_.size());
   auto id_str = std::format("in_{}", id);
 
-  data_type type{type_id::EMPTY, 0};
-  if (auto* col = std::get_if<column_input>(&in)) {
-    type = col->column.type();
-  } else {
-    auto& scalar = std::get<scalar_input>(in);
-    type         = scalar.scalar_column->type();
-  }
+  data_type const type = [&in] {
+    if (auto* col = std::get_if<column_input>(&in)) {
+      return col->column.type();
+    } else {
+      auto& scalar = std::get<scalar_input>(in);
+      return scalar.scalar_column->type();
+    }
+  }();
   inputs_.emplace_back(std::move(in));
   input_vars_.emplace_back(std::move(id_str), type);
   return id;
@@ -309,7 +310,7 @@ void node::instantiate(instance_context& ctx)
       CUDF_EXPECTS(args_[0]->get_type().id() == type_id::BOOL8,
                    "Predicate operator requires a boolean argument.",
                    std::runtime_error);
-      type_ = data_type{type_id::BOOL8, 0};
+      type_ = data_type{type_id::BOOL8};
     } break;
     default: {
       std::vector<data_type> arg_types;

--- a/cpp/tests/join/mixed_join_tests.cu
+++ b/cpp/tests/join/mixed_join_tests.cu
@@ -602,9 +602,11 @@ TYPED_TEST(MixedInnerJoinTest, BasicInequality)
 // This test is designed to prevent https://github.com/NVIDIA/spark-rapids/issues/13416 from
 // happening again, where the block atomic counter was improperly set, causing illegal memory access
 // when the input data is large enough that multiple blocks are needed for the kernel.
-TYPED_TEST(MixedInnerJoinTest, LargeDataMultiBlockCoordination)
+struct MixedInnerJoinTestInt32 : public MixedInnerJoinTest<int32_t> {};
+TEST_F(MixedInnerJoinTestInt32, LargeDataMultiBlockCoordination)
 {
-  using T = TypeParam;
+  using TypeParam = int32_t;
+  using T         = TypeParam;
 
   // These sizes are large enough to ensure the kernel launches with multiple blocks
   constexpr int left_size  = 5000;

--- a/python/cudf_polars/cudf_polars/engine/core.py
+++ b/python/cudf_polars/cudf_polars/engine/core.py
@@ -39,7 +39,7 @@ from cudf_polars.utils.config import get_total_device_memory
 if TYPE_CHECKING:
     import uuid
     from collections.abc import Callable, MutableMapping
-    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import Executor, ThreadPoolExecutor
 
     import rapidsmpf.config
     from rapidsmpf.communicator.communicator import Communicator
@@ -599,6 +599,7 @@ def allgather_stats(
     br: BufferResource,
     ir: IR,
     config_options: ConfigOptions[StreamingExecutor],
+    executor: Executor,
 ) -> StatsCollector:
     """
     Collect scan statistics on rank 0 and distribute to all ranks.
@@ -616,16 +617,19 @@ def allgather_stats(
         Root of the pre-lowered IR graph (same object on every rank).
     config_options
         Executor configuration.
+    executor: concurrent.futures.Executor
+        Executor to use for IO operations. This function does not start
+        or shutdown the executor.
 
     Returns
     -------
     A :class:`StatsCollector` valid for the local rank's IR node objects.
     """
     if comm.nranks == 1:
-        return collect_statistics(ir, config_options)
+        return collect_statistics(ir, config_options, executor)
 
     if comm.rank == 0:
-        stats = collect_statistics(ir, config_options)
+        stats = collect_statistics(ir, config_options, executor)
         data = json.dumps(stats.serialize(ir)).encode()
     else:
         data = b""
@@ -680,7 +684,7 @@ def evaluate_on_rank(
     metadata
         Collected channel metadata.
     """
-    stats = allgather_stats(comm, ctx.br(), ir, config_options)
+    stats = allgather_stats(comm, ctx.br(), ir, config_options, py_executor)
     ir, partition_info = lower_ir_graph(ir, config_options, stats)
 
     if comm.rank == 0:

--- a/python/cudf_polars/cudf_polars/streaming/explain.py
+++ b/python/cudf_polars/cudf_polars/streaming/explain.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import contextlib
 import dataclasses
 import datetime
 import functools
@@ -59,6 +61,7 @@ def explain_query(
     engine: pl.GPUEngine,
     *,
     physical: bool = True,
+    executor: concurrent.futures.Executor | None = None,
 ) -> str:
     """
     Return a formatted string representation of the IR plan.
@@ -72,23 +75,38 @@ def explain_query(
     physical : bool, default True
         If True, show the physical (lowered) plan.
         If False, show the logical (pre-lowering) plan.
+    executor
+        Optional executor to use for IO operations. This function does not start
+        or shutdown the executor. If not provided, a new thread pool executor
+        is created and used.
 
     Returns
     -------
     str
         A string representation of the IR plan.
     """
+    cm: contextlib.AbstractContextManager[concurrent.futures.Executor]
+
+    if executor is None:
+        cm = executor = concurrent.futures.ThreadPoolExecutor()
+    else:
+        # we only shut down the executor if we created it.
+        cm = contextlib.nullcontext(executor)
+
     config = ConfigOptions.from_polars_engine(engine)
     ir = Translator(q._ldf.visit(), engine).translate_ir()
 
     if physical:
-        stats = collect_statistics(ir, config)
+        with cm:
+            stats = collect_statistics(ir, config, executor)
         lowered_ir, partition_info = lower_ir_graph(ir, config, stats)
         return _repr_ir_tree(lowered_ir, partition_info)
     else:
         if config.executor.name == "streaming":
             # Include row-count statistics for the logical plan
-            return _repr_ir_tree(ir, stats=collect_statistics(ir, config))
+            with cm:
+                stats = collect_statistics(ir, config, executor)
+            return _repr_ir_tree(ir, stats=stats)
         else:
             return _repr_ir_tree(ir)
 
@@ -423,7 +441,12 @@ class SerializablePlan:
 
     @classmethod
     def from_ir(
-        cls, ir: IR, *, config_options: ConfigOptions, lowered: bool = False
+        cls,
+        ir: IR,
+        *,
+        config_options: ConfigOptions,
+        lowered: bool = False,
+        executor: concurrent.futures.Executor | None = None,
     ) -> Self:
         """
         Construct a serializable plan from an IR node.
@@ -436,6 +459,10 @@ class SerializablePlan:
             The configuration options.
         lowered
             If True, lower the IR to the physical plan and include partition info.
+        executor
+            Optional executor to use for IO operations. This function does not start
+            or shutdown the executor. If not provided, a new thread pool executor
+            is created and used.
 
         Returns
         -------
@@ -443,8 +470,16 @@ class SerializablePlan:
             A serializable representation of the query plan.
         """
         partition_info_dict: dict[str, SerializablePartitionInfo] | None = None
+        cm: contextlib.AbstractContextManager[concurrent.futures.Executor]
+
+        if executor is None:
+            cm = executor = concurrent.futures.ThreadPoolExecutor()
+        else:
+            cm = contextlib.nullcontext(executor)
+
         if lowered:
-            stats = collect_statistics(ir, config_options)
+            with cm:
+                stats = collect_statistics(ir, config_options, executor)
             ir, partition_info_d = lower_ir_graph(ir, config_options, stats)
             partition_info_dict = {}
 

--- a/python/cudf_polars/cudf_polars/streaming/statistics.py
+++ b/python/cudf_polars/cudf_polars/streaming/statistics.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 from typing import TYPE_CHECKING
 
 from cudf_polars.dsl.ir import DataFrameScan, Scan
@@ -23,8 +24,21 @@ from cudf_polars.dsl.tracing import nvtx_annotate_cudf_polars
 def collect_statistics(
     root: IR,
     config_options: ConfigOptions[StreamingExecutor],
+    executor: concurrent.futures.Executor,
 ) -> StatsCollector:
-    """Collect DataSourceInfo for each leaf Scan/DataFrameScan node."""
+    """
+    Collect DataSourceInfo for each leaf Scan/DataFrameScan node.
+
+    Parameters
+    ----------
+    root: IR
+        The root of the IR graph.
+    config_options: ConfigOptions[StreamingExecutor]
+        The configuration options.
+    executor: concurrent.futures.Executor
+        Executor to use for IO operations. This function does not start
+        or shutdown the executor.
+    """
     # Group parquet Scan nodes by paths, accumulating the union of needed columns
     # across all Scan nodes that read the same files.
     parquet_groups: dict[tuple[str, ...], tuple[set[str], list[Scan]]] = {}
@@ -42,15 +56,26 @@ def collect_statistics(
 
     stats = StatsCollector()
 
-    # Parquet sources
-    for needed_cols, scan_nodes in parquet_groups.values():
-        source = _build_source_info(
+    future_to_scan_nodes = {
+        executor.submit(
+            _build_source_info,
             scan_nodes[0],
             config_options,
             needed_cols=frozenset(needed_cols),
-        )
-        for node in scan_nodes:
-            stats.scan_stats[node] = source
+        ): scan_nodes
+        for needed_cols, scan_nodes in parquet_groups.values()
+    }
+
+    try:
+        for future in concurrent.futures.as_completed(future_to_scan_nodes):
+            scan_nodes = future_to_scan_nodes[future]
+            source = future.result()
+            for node in scan_nodes:
+                stats.scan_stats[node] = source
+    except Exception:
+        for pending in future_to_scan_nodes:
+            pending.cancel()
+        raise
 
     # DataFrameScan sources
     for node in dataframe_scans:

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import concurrent.futures
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -389,3 +390,9 @@ def pytest_collection_modifyitems(
             else marker.kwargs.get("reason", "unsupported on streaming engine")
         )
         item.add_marker(pytest.mark.skip(reason=reason))
+
+
+@pytest.fixture(scope="module")
+def parquet_stats_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """A thread pool to use for cudf-polars status collection."""
+    return concurrent.futures.ThreadPoolExecutor()

--- a/python/cudf_polars/tests/streaming/test_dataframescan.py
+++ b/python/cudf_polars/tests/streaming/test_dataframescan.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import pickle
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -16,6 +17,9 @@ from cudf_polars.streaming.parallel import lower_ir_graph
 from cudf_polars.streaming.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
+
+if TYPE_CHECKING:
+    import concurrent.futures
 
 
 def _assert_stable_ids_match(orig, loaded) -> None:
@@ -35,7 +39,12 @@ def df():
 
 
 @pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
-def test_parallel_dataframescan(df, streaming_engine_factory, max_rows_per_partition):
+def test_parallel_dataframescan(
+    df,
+    streaming_engine_factory,
+    max_rows_per_partition,
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
+):
     streaming_engine = streaming_engine_factory(
         StreamingOptions(max_rows_per_partition=max_rows_per_partition),
     )
@@ -51,7 +60,13 @@ def test_parallel_dataframescan(df, streaming_engine_factory, max_rows_per_parti
     qir = Translator(df._ldf.visit(), _engine).translate_ir()
     config_options = ConfigOptions.from_polars_engine(_engine)
     ir, info = lower_ir_graph(
-        qir, config_options, collect_statistics(qir, config_options)
+        qir,
+        config_options,
+        collect_statistics(
+            qir,
+            config_options,
+            parquet_stats_executor,
+        ),
     )
     count = info[ir].count
     if max_rows_per_partition < total_row_count:
@@ -78,7 +93,10 @@ def test_dataframescan_concat(request, df, streaming_engine_factory):
     assert_gpu_result_equal(df2, engine=streaming_engine)
 
 
-def test_join_in_memory_lazy_stable_id_pickle(streaming_engine_factory):
+def test_join_in_memory_lazy_stable_id_pickle(
+    streaming_engine_factory,
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
+):
     engine = streaming_engine_factory(
         StreamingOptions(max_rows_per_partition=1_000, raise_on_fail=True),
     )
@@ -88,11 +106,21 @@ def test_join_in_memory_lazy_stable_id_pickle(streaming_engine_factory):
     right = pl.LazyFrame({"k": [2, 3, 4], "y": [1, 2, 3]}).collect(engine=engine).lazy()
     qir = Translator(left.join(right, on="k")._ldf.visit(), engine).translate_ir()
     config_options = ConfigOptions.from_polars_engine(engine)
-    ir, _ = lower_ir_graph(qir, config_options, collect_statistics(qir, config_options))
+    ir, _ = lower_ir_graph(
+        qir,
+        config_options,
+        collect_statistics(
+            qir,
+            config_options,
+            parquet_stats_executor,
+        ),
+    )
     _assert_stable_ids_match(ir, pickle.loads(pickle.dumps(ir)))
 
 
-def test_dataframescan_pickle(df):
+def test_dataframescan_pickle(
+    df, parquet_stats_executor: concurrent.futures.ThreadPoolExecutor
+):
     _engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
@@ -100,7 +128,15 @@ def test_dataframescan_pickle(df):
     )
     qir = Translator(df._ldf.visit(), _engine).translate_ir()
     config_options = ConfigOptions.from_polars_engine(_engine)
-    ir, _ = lower_ir_graph(qir, config_options, collect_statistics(qir, config_options))
+    ir, _ = lower_ir_graph(
+        qir,
+        config_options,
+        collect_statistics(
+            qir,
+            config_options,
+            parquet_stats_executor,
+        ),
+    )
 
     # Pickle and unpickle the IR (which contains DataFrameScan)
     pickled = pickle.dumps(ir)

--- a/python/cudf_polars/tests/streaming/test_hstack.py
+++ b/python/cudf_polars/tests/streaming/test_hstack.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 import polars as pl
@@ -22,6 +24,9 @@ from cudf_polars.streaming.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.testing.engine_utils import warns_on_spmd
 from cudf_polars.utils.config import ConfigOptions, StreamingFallbackMode
+
+if TYPE_CHECKING:
+    import concurrent.futures
 
 
 @pytest.fixture
@@ -77,7 +82,9 @@ def test_hstack_non_scalar_cse_fallback(df, engine):
         assert_gpu_result_equal(q, engine=engine)
 
 
-def test_hstack_non_pointwise_redirect_covers_parallel_hstack_handler(engine):
+def test_hstack_non_pointwise_redirect_covers_parallel_hstack_handler(
+    engine, parquet_stats_executor: concurrent.futures.ThreadPoolExecutor
+):
     """Filter → rec(HStack) so standalone non-pointwise HStack hits redirect to Select."""
     base = Translator(
         pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]})._ldf.visit(), engine
@@ -101,7 +108,15 @@ def test_hstack_non_pointwise_redirect_covers_parallel_hstack_handler(engine):
     mask = expr.NamedExpr("m", expr.Literal(DataType(pl.Boolean()), value=True))
     root = Filter(hstack_schema, mask, hstack)
     config_options = ConfigOptions.from_polars_engine(engine)
-    lower_ir_graph(root, config_options, collect_statistics(root, config_options))
+    lower_ir_graph(
+        root,
+        config_options,
+        collect_statistics(
+            root,
+            config_options,
+            parquet_stats_executor,
+        ),
+    )
 
 
 def test_with_columns_scalar_upstream_20981(engine):
@@ -112,7 +127,11 @@ def test_with_columns_scalar_upstream_20981(engine):
 
 
 @pytest.mark.parametrize("comm_subexpr_elim", [True, False])
-def test_cse_agg_shared_decomposition(engine, comm_subexpr_elim):
+def test_cse_agg_shared_decomposition(
+    engine,
+    comm_subexpr_elim,
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
+):
     df = pl.LazyFrame({"a": [1, 2, 3, 4, 5, 6]})
     q = df.with_columns(
         pl.col("a").sum().alias("s"),
@@ -132,13 +151,15 @@ def test_cse_agg_shared_decomposition(engine, comm_subexpr_elim):
 
     config_options = ConfigOptions.from_polars_engine(engine)
     lowered, _ = lower_ir_graph(
-        ir, config_options, collect_statistics(ir, config_options)
+        ir,
+        config_options,
+        collect_statistics(ir, config_options, parquet_stats_executor),
     )
 
     # Both paths must lower to a single Repartition computing one aggregation.
     repartitions = [n for n in traversal([lowered]) if isinstance(n, Repartition)]
     assert len(repartitions) == 1
-    assert len(repartitions[0].children[0].exprs) == 1
+    assert len(repartitions[0].children[0].exprs) == 1  # type: ignore[attr-defined]
     assert_gpu_result_equal(q, engine=engine, collect_kwargs={"optimizations": opts})
 
 

--- a/python/cudf_polars/tests/streaming/test_join.py
+++ b/python/cudf_polars/tests/streaming/test_join.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 import polars as pl
@@ -21,6 +23,9 @@ from cudf_polars.streaming.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.testing.engine_utils import warns_on_spmd
 from cudf_polars.utils.config import ConfigOptions, StreamingExecutor
+
+if TYPE_CHECKING:
+    import concurrent.futures
 
 
 @pytest.fixture
@@ -273,7 +278,12 @@ def test_join_maintain_order_fallback_streaming(
 
 
 @pytest.mark.parametrize("broadcast_limit", [1, 48, 128, 1024])
-def test_broadcast_limit(left, right, broadcast_limit):
+def test_broadcast_limit(
+    left,
+    right,
+    broadcast_limit,
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
+):
     engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
@@ -309,7 +319,11 @@ def test_broadcast_limit(left, right, broadcast_limit):
         for node in lower_ir_graph(
             ir,
             config_options,
-            collect_statistics(ir, config_options),
+            collect_statistics(
+                ir,
+                config_options,
+                parquet_stats_executor,
+            ),
         )[1]
         if isinstance(node, Shuffle)
     ]
@@ -325,7 +339,9 @@ def test_broadcast_limit(left, right, broadcast_limit):
         assert len(shuffle_nodes) == 0
 
 
-def test_cache_preserves_partitioning_join():
+def test_cache_preserves_partitioning_join(
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
+):
     engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
@@ -350,7 +366,9 @@ def test_cache_preserves_partitioning_join():
     config_options = ConfigOptions.from_polars_engine(engine)
     ir = Translator(q._ldf.visit(), engine).translate_ir()
     lowered_ir, partition_info = lower_ir_graph(
-        ir, config_options, collect_statistics(ir, config_options)
+        ir,
+        config_options,
+        collect_statistics(ir, config_options, parquet_stats_executor),
     )
 
     # Cache should preserve partitioning on 'key'

--- a/python/cudf_polars/tests/streaming/test_scan.py
+++ b/python/cudf_polars/tests/streaming/test_scan.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 import polars as pl
@@ -14,6 +16,9 @@ from cudf_polars.streaming.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.testing.io import make_partitioned_source
 from cudf_polars.utils.config import ConfigOptions
+
+if TYPE_CHECKING:
+    import concurrent.futures
 
 
 @pytest.fixture(scope="module")
@@ -84,7 +89,12 @@ def test_split_scan_predicate(tmp_path, df, mask, streaming_engine_factory):
 @pytest.mark.parametrize("n_files", [2, 3])
 @pytest.mark.parametrize("blocksize", [1_000, 10_000, 1_000_000])
 def test_target_partition_size(
-    tmp_path, df, blocksize, n_files, streaming_engine_factory
+    tmp_path,
+    df,
+    blocksize,
+    n_files,
+    streaming_engine_factory,
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
 ):
     streaming_engine = streaming_engine_factory(
         StreamingOptions(target_partition_size=blocksize),
@@ -102,7 +112,13 @@ def test_target_partition_size(
     qir = Translator(q._ldf.visit(), _engine).translate_ir()
     config_options = ConfigOptions.from_polars_engine(_engine)
     ir, info = lower_ir_graph(
-        qir, config_options, collect_statistics(qir, config_options)
+        qir,
+        config_options,
+        collect_statistics(
+            qir,
+            config_options,
+            parquet_stats_executor,
+        ),
     )
     count = info[ir].count
     if blocksize <= 12_000:

--- a/python/cudf_polars/tests/streaming/test_stats.py
+++ b/python/cudf_polars/tests/streaming/test_stats.py
@@ -27,6 +27,7 @@ from cudf_polars.testing.io import make_lazy_frame, make_partitioned_source
 from cudf_polars.utils.config import ConfigOptions
 
 if TYPE_CHECKING:
+    import concurrent.futures
     import pathlib
 
 
@@ -54,11 +55,15 @@ def stats_engine():
     )
 
 
-def test_base_stats_dataframescan(df, stats_engine):
+def test_base_stats_dataframescan(
+    df, stats_engine, parquet_stats_executor: concurrent.futures.ThreadPoolExecutor
+):
     row_count = df.height
     q = pl.LazyFrame(df)
     ir = Translator(q._ldf.visit(), stats_engine).translate_ir()
-    stats = collect_statistics(ir, ConfigOptions.from_polars_engine(stats_engine))
+    stats = collect_statistics(
+        ir, ConfigOptions.from_polars_engine(stats_engine), parquet_stats_executor
+    )
 
     source = stats.scan_stats[ir]
     assert source.row_count == row_count
@@ -78,6 +83,7 @@ def test_base_stats_parquet(
     row_group_size,
     max_footer_samples,
     max_row_group_samples,
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
 ):
     _clear_source_info_cache()
     make_partitioned_source(
@@ -98,7 +104,9 @@ def test_base_stats_parquet(
         },
     )
     ir = Translator(q._ldf.visit(), engine).translate_ir()
-    stats = collect_statistics(ir, ConfigOptions.from_polars_engine(engine))
+    stats = collect_statistics(
+        ir, ConfigOptions.from_polars_engine(engine), parquet_stats_executor
+    )
     source = stats.scan_stats[ir]
 
     if max_footer_samples:
@@ -113,11 +121,15 @@ def test_base_stats_parquet(
         assert source.column_storage_size("y") is None
 
 
-def test_dataframescan_stats_pickle(stats_engine):
+def test_dataframescan_stats_pickle(
+    stats_engine, parquet_stats_executor: concurrent.futures.ThreadPoolExecutor
+):
     df = pl.DataFrame({"x": range(100), "y": [1, 2] * 50})
     q = pl.LazyFrame(df)
     ir = Translator(q._ldf.visit(), stats_engine).translate_ir()
-    stats = collect_statistics(ir, ConfigOptions.from_polars_engine(stats_engine))
+    stats = collect_statistics(
+        ir, ConfigOptions.from_polars_engine(stats_engine), parquet_stats_executor
+    )
 
     # Pickle and unpickle the stats collector
     pickled = pickle.dumps(stats)
@@ -224,12 +236,15 @@ def test_parquet_empty_per_file_means() -> None:
     assert info.per_file_means == {}
 
 
-def test_serialize_stats_roundtrip_dataframescan(stats_engine: pl.GPUEngine) -> None:
+def test_serialize_stats_roundtrip_dataframescan(
+    stats_engine: pl.GPUEngine,
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
+) -> None:
     df = pl.DataFrame({"x": range(200), "y": [1, 2] * 100})
     q = pl.LazyFrame(df)
     ir = Translator(q._ldf.visit(), stats_engine).translate_ir()
     config = ConfigOptions.from_polars_engine(stats_engine)
-    stats = collect_statistics(ir, config)
+    stats = collect_statistics(ir, config, parquet_stats_executor)
 
     serialized = stats.serialize(ir)
     wire = json.loads(json.dumps(serialized))
@@ -243,7 +258,9 @@ def test_serialize_stats_roundtrip_dataframescan(stats_engine: pl.GPUEngine) -> 
 
 
 def test_serialize_stats_roundtrip_parquet(
-    tmp_path: pathlib.Path, df: pl.DataFrame
+    tmp_path: pathlib.Path,
+    df: pl.DataFrame,
+    parquet_stats_executor: concurrent.futures.ThreadPoolExecutor,
 ) -> None:
     _clear_source_info_cache()
     make_partitioned_source(df, tmp_path, "parquet", n_files=3)
@@ -256,7 +273,7 @@ def test_serialize_stats_roundtrip_parquet(
     q = pl.scan_parquet(tmp_path)
     ir = Translator(q._ldf.visit(), engine).translate_ir()
     config = ConfigOptions.from_polars_engine(engine)
-    stats = collect_statistics(ir, config)
+    stats = collect_statistics(ir, config, parquet_stats_executor)
 
     serialized = stats.serialize(ir)
     wire = json.loads(json.dumps(serialized))


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.