### PR TITLE
docs: fix linked locations for notebooks after docs refactor

### DIFF
--- a/notebooks/10min.ipynb
+++ b/notebooks/10min.ipynb
@@ -1,1 +1,1 @@
-../docs/cudf/source/user_guide/10min.ipynb
+../docs/cudf/source/cudf/10min.ipynb

--- a/notebooks/cupy-interop.ipynb
+++ b/notebooks/cupy-interop.ipynb
@@ -1,1 +1,1 @@
-../docs/cudf/source/user_guide/cupy-interop.ipynb
+../docs/cudf/source/cudf/cupy-interop.ipynb

--- a/notebooks/guide-to-udfs.ipynb
+++ b/notebooks/guide-to-udfs.ipynb
@@ -1,1 +1,1 @@
-../docs/cudf/source/user_guide/guide-to-udfs.ipynb
+../docs/cudf/source/cudf/guide-to-udfs.ipynb

--- a/notebooks/missing-data.ipynb
+++ b/notebooks/missing-data.ipynb
@@ -1,1 +1,1 @@
-../docs/cudf/source/user_guide/missing-data.ipynb
+../docs/cudf/source/cudf/missing-data.ipynb

--- a/notebooks/performance-comparisons
+++ b/notebooks/performance-comparisons
@@ -1,1 +1,1 @@
-../docs/cudf/source/user_guide/performance-comparisons/
+../docs/cudf/source/cudf/performance-comparisons/


### PR DESCRIPTION
xref rapidsai/docker#885

the docs were reorganized but these links from the `notebooks` directory weren't updated