### PR TITLE
Improve Parquet case-insensitive column selection semantics

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -617,6 +617,7 @@ add_library(
   src/io/orc/writer_impl.cu
   src/io/parquet/arrow_schema_writer.cpp
   src/io/parquet/bloom_filter_reader.cu
+  src/io/parquet/column_path_helpers.cpp
   src/io/parquet/compact_protocol_reader.cpp
   src/io/parquet/compact_protocol_writer.cpp
   src/io/parquet/decode_preprocess.cu

--- a/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
@@ -8,15 +8,25 @@
 #include <benchmarks/io/cuio_common.hpp>
 #include <benchmarks/io/nvbench_helpers.hpp>
 
+#include <cudf/ast/expressions.hpp>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/parquet_metadata.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
 #include <cuda/iterator>
 
 #include <nvbench/nvbench.cuh>
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
 
 // Common mixed dtypes used by all benchmarks in this file
 auto const mixed_dtypes = get_type_or_group({static_cast<int32_t>(data_type::STRING),
@@ -207,6 +217,135 @@ void BM_parquet_column_selection(nvbench::state& state)
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }
 
+// Benchmark Parquet filter column-name resolution during reader construction.
+//
+// This isolates `named_to_reference_converter`:
+// - builds a name -> column index map for all schema columns: O(num_cols)
+// - resolves column names used by the filter: O(num_filter_refs)
+//
+// `heavy_filter` controls filter size:
+// - false: filter references only `col0`
+// - true: filter references every column: `col0 OR col1 OR ...`
+//
+// No `column_names` are set, so the reader takes the cheap "read all columns" path.
+// This avoids measuring `select_columns` name scanning and keeps the benchmark focused
+// on filter name resolution.
+//
+// `case_sensitive` toggles matching mode. In case-insensitive mode, query names are
+// upper-cased to force lookup-time normalization.
+//
+// Uses only public APIs so the same benchmark can run on main and feature branches.
+
+void BM_parquet_filter_name_resolution(nvbench::state& state)
+{
+  auto const num_cols       = static_cast<cudf::size_type>(state.get_int64("num_cols"));
+  auto const case_sensitive = state.get_int64("case_sensitive") != 0;
+  auto const heavy_filter   = state.get_int64("heavy_filter") != 0;
+  auto const source_type    = retrieve_io_type_enum(state.get_string("io_type"));
+
+  cuio_source_sink_pair source_sink(source_type);
+
+  // Flat, single-row table of INT32 columns with deterministic names col0..col{n-1}. INT32 keeps
+  // the filter literal trivially type-correct; name-resolution cost is independent of dtype.
+  constexpr cudf::size_type num_rows = 1;
+  auto const tbl =
+    create_random_table(cycle_dtypes({cudf::type_id::INT32}, num_cols),
+                        row_count{num_rows},
+                        data_profile_builder().cardinality(0).avg_run_length(1).no_validity());
+  auto const view = tbl->view();
+
+  cudf::io::table_input_metadata input_meta(view);
+  std::vector<std::string> file_names(num_cols);
+  for (cudf::size_type i = 0; i < num_cols; i++) {
+    file_names[i] = "col" + std::to_string(i);
+    input_meta.column_metadata[i].set_name(file_names[i]);
+  }
+
+  cudf::io::parquet_writer_options write_opts =
+    cudf::io::parquet_writer_options::builder(source_sink.make_sink_info(), view)
+      .metadata(std::move(input_meta))
+      .compression(cudf::io::compression_type::NONE);
+  cudf::io::write_parquet(write_opts);
+
+  // Query name: exact when case-sensitive, upper-cased when case-insensitive so the converter must
+  // normalize on lookup.
+  auto const to_query_case = [case_sensitive](std::string s) {
+    if (not case_sensitive) {
+      std::transform(
+        s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::toupper(c); });
+    }
+    return s;
+  };
+
+  // Always-true filter. `heavy_filter` controls how many columns it references:
+  //   light: `col0 >= MIN`                                  (converter resolves 1 name reference)
+  //   heavy: `(col0 >= MIN) OR (col1 >= MIN) OR ...`         (one reference per column)
+  // The heavy OR tree is built balanced (depth ~log2(num_cols)) to keep visitor recursion shallow.
+  cudf::numeric_scalar<int32_t> filter_literal_value{std::numeric_limits<int32_t>::min()};
+  cudf::ast::tree expr;
+  auto const& lit_expr      = expr.push(cudf::ast::literal(filter_literal_value));
+  auto const make_predicate = [&](cudf::size_type col) -> cudf::ast::expression const& {
+    auto const& col_ref =
+      expr.push(cudf::ast::column_name_reference(to_query_case(file_names[col])));
+    return expr.push(
+      cudf::ast::operation(cudf::ast::ast_operator::GREATER_EQUAL, col_ref, lit_expr));
+  };
+
+  cudf::ast::expression const* filter_root = nullptr;
+  if (not heavy_filter) {
+    filter_root = &make_predicate(0);
+  } else {
+    std::vector<cudf::ast::expression const*> level;
+    level.reserve(num_cols);
+    for (cudf::size_type i = 0; i < num_cols; i++) {
+      level.push_back(&make_predicate(i));
+    }
+    while (level.size() > 1) {
+      std::vector<cudf::ast::expression const*> next;
+      next.reserve((level.size() + 1) / 2);
+      for (std::size_t i = 0; i + 1 < level.size(); i += 2) {
+        next.push_back(&expr.push(
+          cudf::ast::operation(cudf::ast::ast_operator::LOGICAL_OR, *level[i], *level[i + 1])));
+      }
+      if (level.size() % 2 == 1) { next.push_back(level.back()); }
+      level = std::move(next);
+    }
+    filter_root = level.front();
+  }
+  auto const& filter_expr = *filter_root;
+
+  auto constexpr chunk_read_limit = 0;
+  auto constexpr pass_read_limit  = 0;
+
+  auto read_opts = cudf::io::parquet_reader_options::builder(source_sink.make_source_info())
+                     .use_arrow_schema(false)
+                     .build();
+  read_opts.enable_case_sensitive_names(case_sensitive);
+  read_opts.set_filter(filter_expr);
+
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.exec(
+    nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
+      auto const source_info = source_sink.make_source_info();
+      drop_page_cache_if_enabled(source_info.filepaths());
+      auto sources   = cudf::io::make_datasources(source_info);
+      auto metadatas = cudf::io::read_parquet_footers(sources);
+
+      // Reader construction resolves all referenced filter column names
+      // (named_to_reference_converter) and runs column selection. Construction throws if a
+      // referenced name is missing, so successful construction is the validation; has_next() is
+      // intentionally not called so per-sample timing is not perturbed by row-group filter
+      // evaluation over the wide predicate.
+      timer.start();
+      [[maybe_unused]] auto const reader = cudf::io::chunked_parquet_reader(
+        chunk_read_limit, pass_read_limit, std::move(sources), std::move(metadatas), read_opts);
+      timer.stop();
+    });
+
+  auto const time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
+  state.add_element_count(static_cast<double>(num_cols) / time, "cols_per_sec");
+}
+
 NVBENCH_BENCH(BM_parquet_read_footer)
   .set_name("parquet_read_footer")
   .set_min_samples(4)
@@ -228,3 +367,11 @@ NVBENCH_BENCH(BM_parquet_column_selection)
   .set_min_samples(4)
   .add_string_axis("io_type", {"FILEPATH"})
   .add_int64_axis("num_cols", {64, 512, 2048});
+
+NVBENCH_BENCH(BM_parquet_filter_name_resolution)
+  .set_name("parquet_filter_name_resolution")
+  .set_min_samples(4)
+  .add_string_axis("io_type", {"FILEPATH"})
+  .add_int64_axis("num_cols", {64, 128, 256, 512, 1024, 1536, 2048, 4096})
+  .add_int64_axis("case_sensitive", {1, 0})
+  .add_int64_axis("heavy_filter", {0, 1});

--- a/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
@@ -84,6 +84,27 @@ auto write_file_data(cudf::size_type num_cols,
   return source_sink;
 }
 
+// Combines `operands` into a balanced AST tree using `op`: pairing adjacent operands gives a tree
+// of depth ceil(log2(n)) rather than the n-deep chain a left fold would produce.
+[[nodiscard]] cudf::ast::expression const* reduce_balanced(
+  cudf::ast::tree& tree,
+  cudf::ast::ast_operator op,
+  std::vector<cudf::ast::expression const*> operands)
+{
+  CUDF_EXPECTS(not operands.empty(), "Cannot reduce an empty set of operands");
+  while (operands.size() > 1) {
+    std::vector<cudf::ast::expression const*> next;
+    next.reserve((operands.size() + 1) / 2);
+    for (std::size_t i = 0; i + 1 < operands.size(); i += 2) {
+      next.push_back(&tree.push(cudf::ast::operation(op, *operands[i], *operands[i + 1])));
+    }
+    // Carry an odd trailing operand up to the next level unchanged.
+    if (operands.size() % 2 == 1) { next.push_back(operands.back()); }
+    operands = std::move(next);
+  }
+  return operands.front();
+}
+
 }  // namespace
 
 // Benchmark to measure parquet footer read time
@@ -291,28 +312,16 @@ void BM_parquet_filter_name_resolution(nvbench::state& state)
       cudf::ast::operation(cudf::ast::ast_operator::GREATER_EQUAL, col_ref, lit_expr));
   };
 
-  cudf::ast::expression const* filter_root = nullptr;
-  if (not heavy_filter) {
-    filter_root = &make_predicate(0);
-  } else {
-    std::vector<cudf::ast::expression const*> level;
-    level.reserve(num_cols);
-    for (cudf::size_type i = 0; i < num_cols; i++) {
-      level.push_back(&make_predicate(i));
-    }
-    while (level.size() > 1) {
-      std::vector<cudf::ast::expression const*> next;
-      next.reserve((level.size() + 1) / 2);
-      for (std::size_t i = 0; i + 1 < level.size(); i += 2) {
-        next.push_back(&expr.push(
-          cudf::ast::operation(cudf::ast::ast_operator::LOGICAL_OR, *level[i], *level[i + 1])));
-      }
-      if (level.size() % 2 == 1) { next.push_back(level.back()); }
-      level = std::move(next);
-    }
-    filter_root = level.front();
+  auto const num_predicates = heavy_filter ? num_cols : cudf::size_type{1};
+  std::vector<cudf::ast::expression const*> predicates;
+  predicates.reserve(num_predicates);
+  for (cudf::size_type col = 0; col < num_predicates; col++) {
+    predicates.push_back(&make_predicate(col));
   }
-  auto const& filter_expr = *filter_root;
+  // Reduce the per-column predicates into a single balanced OR tree so the AST depth stays
+  // logarithmic in the column count (see reduce_balanced).
+  auto const& filter_expr =
+    *reduce_balanced(expr, cudf::ast::ast_operator::LOGICAL_OR, std::move(predicates));
 
   auto constexpr chunk_read_limit = 0;
   auto constexpr pass_read_limit  = 0;

--- a/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
@@ -239,24 +239,6 @@ void BM_parquet_column_selection(nvbench::state& state)
 }
 
 // Benchmark Parquet filter column-name resolution during reader construction.
-//
-// This isolates `named_to_reference_converter`:
-// - builds a name -> column index map for all schema columns: O(num_cols)
-// - resolves column names used by the filter: O(num_filter_refs)
-//
-// `heavy_filter` controls filter size:
-// - false: filter references only `col0`
-// - true: filter references every column: `col0 OR col1 OR ...`
-//
-// No `column_names` are set, so the reader takes the cheap "read all columns" path.
-// This avoids measuring `select_columns` name scanning and keeps the benchmark focused
-// on filter name resolution.
-//
-// `case_sensitive` toggles matching mode. In case-insensitive mode, query names are
-// upper-cased to force lookup-time normalization.
-//
-// Uses only public APIs so the same benchmark can run on main and feature branches.
-
 void BM_parquet_filter_name_resolution(nvbench::state& state)
 {
   auto const num_cols       = static_cast<cudf::size_type>(state.get_int64("num_cols"));
@@ -326,6 +308,8 @@ void BM_parquet_filter_name_resolution(nvbench::state& state)
   auto constexpr chunk_read_limit = 0;
   auto constexpr pass_read_limit  = 0;
 
+  // No column projection is requested, so the reader reads all columns; this isolates filter name
+  // resolution (named_to_reference_converter) from select_columns name scanning.
   auto read_opts = cudf::io::parquet_reader_options::builder(source_sink.make_source_info())
                      .use_arrow_schema(false)
                      .build();
@@ -354,6 +338,7 @@ void BM_parquet_filter_name_resolution(nvbench::state& state)
 
   auto const time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
   state.add_element_count(static_cast<double>(num_cols) / time, "cols_per_sec");
+  // Should be 0, but adding for completeness
   state.add_buffer_size(
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }

--- a/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_metadata.cpp
@@ -324,6 +324,7 @@ void BM_parquet_filter_name_resolution(nvbench::state& state)
   read_opts.set_filter(filter_expr);
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  auto const mem_stats_logger = cudf::memory_stats_logger();
   state.exec(
     nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
       auto const source_info = source_sink.make_source_info();
@@ -344,6 +345,8 @@ void BM_parquet_filter_name_resolution(nvbench::state& state)
 
   auto const time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
   state.add_element_count(static_cast<double>(num_cols) / time, "cols_per_sec");
+  state.add_buffer_size(
+    mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }
 
 NVBENCH_BENCH(BM_parquet_read_footer)

--- a/cpp/src/io/parquet/column_path_helpers.cpp
+++ b/cpp/src/io/parquet/column_path_helpers.cpp
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "column_path_helpers.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <string>
+#include <string_view>
+
+namespace cudf::io::parquet::detail {
+
+std::string normalize_column_path(std::string_view col_path, bool case_sensitive_names)
+{
+  if (case_sensitive_names) { return std::string{col_path}; }
+  auto normalized_path = std::string(col_path.size(), '\0');
+  std::transform(col_path.begin(), col_path.end(), normalized_path.begin(), [](unsigned char c) {
+    return std::tolower(c);
+  });
+  return normalized_path;
+}
+
+bool are_column_paths_equal(std::string_view lhs, std::string_view rhs, bool case_sensitive)
+{
+  if (lhs.size() != rhs.size()) { return false; }
+  if (case_sensitive) { return lhs == rhs; }
+  // Optimize by normalizing and comparing char-by-char instead of whole strings
+  return std::equal(
+    lhs.begin(), lhs.end(), rhs.begin(), [](unsigned char lhs_char, unsigned char rhs_char) {
+      return std::equal_to<>{}(std::tolower(lhs_char), std::tolower(rhs_char));
+    });
+}
+
+}  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/column_path_helpers.cpp
+++ b/cpp/src/io/parquet/column_path_helpers.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <functional>
 #include <string>
 #include <string_view>
@@ -32,6 +33,22 @@ bool are_column_paths_equal(std::string_view lhs, std::string_view rhs, bool cas
     lhs.begin(), lhs.end(), rhs.begin(), [](unsigned char lhs_char, unsigned char rhs_char) {
       return std::equal_to<>{}(std::tolower(lhs_char), std::tolower(rhs_char));
     });
+}
+
+std::size_t column_path_hash::operator()(std::string_view path) const
+{
+  return std::hash<std::string>{}(normalize_column_path(path, case_sensitive_names));
+}
+
+bool column_path_equal::operator()(std::string_view lhs, std::string_view rhs) const
+{
+  return are_column_paths_equal(lhs, rhs, case_sensitive_names);
+}
+
+column_path_set make_column_path_set(bool case_sensitive_names, std::size_t bucket_hint)
+{
+  return column_path_set(
+    bucket_hint, column_path_hash{case_sensitive_names}, column_path_equal{case_sensitive_names});
 }
 
 }  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/column_path_helpers.hpp
+++ b/cpp/src/io/parquet/column_path_helpers.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <cstddef>
-#include <functional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -50,10 +49,7 @@ struct column_path_hash {
 
   bool case_sensitive_names{true};
 
-  std::size_t operator()(std::string_view path) const
-  {
-    return std::hash<std::string>{}(normalize_column_path(path, case_sensitive_names));
-  }
+  std::size_t operator()(std::string_view path) const;
 };
 
 /**
@@ -66,10 +62,7 @@ struct column_path_equal {
 
   bool case_sensitive_names{true};
 
-  bool operator()(std::string_view lhs, std::string_view rhs) const
-  {
-    return are_column_paths_equal(lhs, rhs, case_sensitive_names);
-  }
+  bool operator()(std::string_view lhs, std::string_view rhs) const;
 };
 
 /**
@@ -90,12 +83,8 @@ using column_path_map = std::unordered_map<std::string, Value, column_path_hash,
  * @param bucket_hint Optional initial bucket count
  * @return An empty `column_path_set` using the requested policy
  */
-[[nodiscard]] inline column_path_set make_column_path_set(bool case_sensitive_names,
-                                                          std::size_t bucket_hint = 0)
-{
-  return column_path_set(
-    bucket_hint, column_path_hash{case_sensitive_names}, column_path_equal{case_sensitive_names});
-}
+[[nodiscard]] column_path_set make_column_path_set(bool case_sensitive_names,
+                                                   std::size_t bucket_hint = 0);
 
 /**
  * @brief Constructs an empty `column_path_map` whose hash/equality use the given policy.

--- a/cpp/src/io/parquet/column_path_helpers.hpp
+++ b/cpp/src/io/parquet/column_path_helpers.hpp
@@ -46,7 +46,6 @@ namespace cudf::io::parquet::detail {
  */
 struct column_path_hash {
   using is_transparent = void;
-
   bool case_sensitive_names{true};
 
   std::size_t operator()(std::string_view path) const;
@@ -59,7 +58,6 @@ struct column_path_hash {
  */
 struct column_path_equal {
   using is_transparent = void;
-
   bool case_sensitive_names{true};
 
   bool operator()(std::string_view lhs, std::string_view rhs) const;
@@ -71,12 +69,6 @@ struct column_path_equal {
 using column_path_set = std::unordered_set<std::string, column_path_hash, column_path_equal>;
 
 /**
- * @brief A map keyed by column path matched with a configurable case-sensitivity policy.
- */
-template <typename Value>
-using column_path_map = std::unordered_map<std::string, Value, column_path_hash, column_path_equal>;
-
-/**
  * @brief Constructs an empty `column_path_set` whose hash/equality use the given policy.
  *
  * @param case_sensitive_names Whether column-path matching is case-sensitive
@@ -85,6 +77,12 @@ using column_path_map = std::unordered_map<std::string, Value, column_path_hash,
  */
 [[nodiscard]] column_path_set make_column_path_set(bool case_sensitive_names,
                                                    std::size_t bucket_hint = 0);
+
+/**
+ * @brief A map keyed by column path matched with a configurable case-sensitivity policy.
+ */
+template <typename Value>
+using column_path_map = std::unordered_map<std::string, Value, column_path_hash, column_path_equal>;
 
 /**
  * @brief Constructs an empty `column_path_map` whose hash/equality use the given policy.

--- a/cpp/src/io/parquet/column_path_helpers.hpp
+++ b/cpp/src/io/parquet/column_path_helpers.hpp
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace cudf::io::parquet::detail {
+
+/**
+ * @brief Returns a normalized (lowercased) column name or path when case-insensitive matching is
+ * enabled
+ *
+ * @param col_path The column name or path to normalize
+ * @param case_sensitive_names Whether to normalize the column path case-insensitively
+ *
+ * @return The normalized column path
+ */
+[[nodiscard]] std::string normalize_column_path(std::string_view col_path,
+                                                bool case_sensitive_names);
+
+/**
+ * @brief Compares two column paths with specified case sensitivity
+ *
+ * @param lhs The left-hand side column path
+ * @param rhs The right-hand side column path
+ * @param case_sensitive Whether to compare the column paths case-sensitively
+ *
+ * @return Boolean indicating if the column paths are equal
+ */
+[[nodiscard]] bool are_column_paths_equal(std::string_view lhs,
+                                          std::string_view rhs,
+                                          bool case_sensitive);
+
+/**
+ * @brief Transparent hash for column paths that honors a case-sensitivity policy.
+ *
+ * Hashes the column path according to `case_sensitive_names`, so that two paths that compare equal
+ * under `are_column_paths_equal` also hash equally.
+ */
+struct column_path_hash {
+  using is_transparent = void;
+
+  bool case_sensitive_names{true};
+
+  std::size_t operator()(std::string_view path) const
+  {
+    return std::hash<std::string>{}(normalize_column_path(path, case_sensitive_names));
+  }
+};
+
+/**
+ * @brief Transparent equality for column paths that honors a case-sensitivity policy.
+ *
+ * Delegates to `are_column_paths_equal`, keeping the comparison consistent with `column_path_hash`.
+ */
+struct column_path_equal {
+  using is_transparent = void;
+
+  bool case_sensitive_names{true};
+
+  bool operator()(std::string_view lhs, std::string_view rhs) const
+  {
+    return are_column_paths_equal(lhs, rhs, case_sensitive_names);
+  }
+};
+
+/**
+ * @brief A set of column paths matched with a configurable case-sensitivity policy.
+ */
+using column_path_set = std::unordered_set<std::string, column_path_hash, column_path_equal>;
+
+/**
+ * @brief A map keyed by column path matched with a configurable case-sensitivity policy.
+ */
+template <typename Value>
+using column_path_map = std::unordered_map<std::string, Value, column_path_hash, column_path_equal>;
+
+/**
+ * @brief Constructs an empty `column_path_set` whose hash/equality use the given policy.
+ *
+ * @param case_sensitive_names Whether column-path matching is case-sensitive
+ * @param bucket_hint Optional initial bucket count
+ * @return An empty `column_path_set` using the requested policy
+ */
+[[nodiscard]] inline column_path_set make_column_path_set(bool case_sensitive_names,
+                                                          std::size_t bucket_hint = 0)
+{
+  return column_path_set(
+    bucket_hint, column_path_hash{case_sensitive_names}, column_path_equal{case_sensitive_names});
+}
+
+/**
+ * @brief Constructs an empty `column_path_map` whose hash/equality use the given policy.
+ *
+ * @tparam Value Mapped value type
+ * @param case_sensitive_names Whether column-path matching is case-sensitive
+ * @param bucket_hint Optional initial bucket count
+ * @return An empty `column_path_map` using the requested policy
+ */
+template <typename Value>
+[[nodiscard]] column_path_map<Value> make_column_path_map(bool case_sensitive_names,
+                                                          std::size_t bucket_hint = 0)
+{
+  return column_path_map<Value>(
+    bucket_hint, column_path_hash{case_sensitive_names}, column_path_equal{case_sensitive_names});
+}
+
+}  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -5,6 +5,7 @@
 
 #include "hybrid_scan_helpers.hpp"
 
+#include "io/parquet/column_path_helpers.hpp"
 #include "io/parquet/compact_protocol_reader.hpp"
 #include "io/parquet/expression_transform_helpers.hpp"
 #include "io/parquet/reader_impl_helpers.hpp"

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -663,11 +663,9 @@ named_to_reference_converter::named_to_reference_converter(
   // Map column names to their indices
   _column_name_to_index =
     cudf::io::parquet::detail::make_column_path_map<cudf::size_type>(case_sensitive_names);
-  std::transform(metadata.schema_info.cbegin(),
-                 metadata.schema_info.cend(),
-                 cuda::counting_iterator<std::size_t>{0},
-                 std::inserter(_column_name_to_index, _column_name_to_index.end()),
-                 [](auto const& sch, auto index) { return std::make_pair(sch.name, index); });
+  for (cudf::size_type index = 0; auto const& sch : metadata.schema_info) {
+    _column_name_to_index.insert({sch.name, index++});
+  }
 
   expr.value().get().accept(*this);
 }

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -276,14 +276,10 @@ aggregate_reader_metadata::select_payload_columns(
 
   std::vector<std::string> valid_payload_columns;
 
-  using cudf::io::parquet::detail::normalize_column_path;
-
   // Helper lambda to construct a set of normalized column names for O(1) lookup
   auto construct_filter_columns_set = [](auto const& names, bool case_sensitive_names) {
-    std::unordered_set<std::string> filter_columns_set;
-    for (auto const& name : names) {
-      filter_columns_set.insert(normalize_column_path(name, case_sensitive_names));
-    }
+    auto filter_columns_set = cudf::io::parquet::detail::make_column_path_set(case_sensitive_names);
+    filter_columns_set.insert(names.begin(), names.end());
     return filter_columns_set;
   };
 
@@ -299,10 +295,7 @@ aggregate_reader_metadata::select_payload_columns(
       valid_payload_columns.erase(
         std::remove_if(valid_payload_columns.begin(),
                        valid_payload_columns.end(),
-                       [&](auto const& col) {
-                         return filter_columns_set.count(
-                                  normalize_column_path(col, case_sensitive_names)) > 0;
-                       }),
+                       [&](auto const& col) { return filter_columns_set.count(col) > 0; }),
         valid_payload_columns.end());
     }
     // Call the base `select_columns()` method with valid payload columns
@@ -326,9 +319,7 @@ aggregate_reader_metadata::select_payload_columns(
     auto const& schema_elem     = get_schema(schema_idx);
     std::string const curr_path = path_till_now + schema_elem.name;
     // TODO: Add children when AST filter expressions start supporting nested struct columns
-    if (filter_columns_set.count(normalize_column_path(curr_path, case_sensitive_names)) == 0) {
-      valid_payload_columns.push_back(curr_path);
-    }
+    if (filter_columns_set.count(curr_path) == 0) { valid_payload_columns.push_back(curr_path); }
   };
 
   if (not filter_column_names->empty()) {
@@ -666,21 +657,17 @@ named_to_reference_converter::named_to_reference_converter(
 {
   if (!expr.has_value()) { return; }
 
-  _case_sensitive_names = case_sensitive_names;
-
   _column_indices_to_names = cudf::io::parquet::detail::map_column_indices_to_names(
     options, schema_tree, case_sensitive_names);
 
   // Map column names to their indices
-  std::transform(
-    metadata.schema_info.cbegin(),
-    metadata.schema_info.cend(),
-    cuda::counting_iterator<std::size_t>{0},
-    std::inserter(_column_name_to_index, _column_name_to_index.end()),
-    [&](auto const& sch, auto index) {
-      return std::make_pair(
-        cudf::io::parquet::detail::normalize_column_path(sch.name, case_sensitive_names), index);
-    });
+  _column_name_to_index =
+    cudf::io::parquet::detail::make_column_path_map<cudf::size_type>(case_sensitive_names);
+  std::transform(metadata.schema_info.cbegin(),
+                 metadata.schema_info.cend(),
+                 cuda::counting_iterator<std::size_t>{0},
+                 std::inserter(_column_name_to_index, _column_name_to_index.end()),
+                 [](auto const& sch, auto index) { return std::make_pair(sch.name, index); });
 
   expr.value().get().accept(*this);
 }

--- a/cpp/src/io/parquet/expression_transform_helpers.cpp
+++ b/cpp/src/io/parquet/expression_transform_helpers.cpp
@@ -89,7 +89,7 @@ named_to_reference_converter::named_to_reference_converter(
   std::optional<std::reference_wrapper<ast::expression const>> expr,
   table_metadata const& metadata,
   bool case_sensitive_names)
-  : _case_sensitive_names(case_sensitive_names)
+  : _column_name_to_index(make_column_path_map<size_type>(case_sensitive_names))
 {
   if (!expr.has_value()) { return; }
   // create map for column name.
@@ -97,10 +97,7 @@ named_to_reference_converter::named_to_reference_converter(
                  metadata.schema_info.cend(),
                  cuda::counting_iterator<std::size_t>{0},
                  std::inserter(_column_name_to_index, _column_name_to_index.end()),
-                 [case_sensitive_names](auto const& sch, auto index) {
-                   return std::make_pair(normalize_column_path(sch.name, case_sensitive_names),
-                                         index);
-                 });
+                 [](auto const& sch, auto index) { return std::make_pair(sch.name, index); });
 
   expr.value().get().accept(*this);
 }
@@ -123,8 +120,7 @@ std::reference_wrapper<ast::expression const> named_to_reference_converter::visi
   ast::column_name_reference const& expr)
 {
   // check if column name is in metadata
-  auto const col_name = normalize_column_path(expr.get_column_name(), _case_sensitive_names);
-  auto col_index_it   = _column_name_to_index.find(col_name);
+  auto col_index_it = _column_name_to_index.find(expr.get_column_name());
   CUDF_EXPECTS(col_index_it != _column_name_to_index.end(),
                "Column name in the filter expression not found in the "
                "metadata of selected columns. Note that only top-level "
@@ -170,13 +166,9 @@ names_from_expression::names_from_expression(
   std::vector<std::string> const& skip_names,
   cudf::io::parquet_reader_options const& options,
   std::vector<SchemaElement> const& schema_tree)
-  : _case_sensitive_names(options.is_enabled_case_sensitive_names())
+  : _skip_names(make_column_path_set(options.is_enabled_case_sensitive_names()))
 {
-  std::transform(
-    skip_names.cbegin(),
-    skip_names.cend(),
-    std::inserter(_skip_names, _skip_names.end()),
-    [&](auto const& skip_name) { return normalize_column_path(skip_name, _case_sensitive_names); });
+  _skip_names.insert(skip_names.cbegin(), skip_names.cend());
 
   if (!expr.has_value()) { return; }
 
@@ -204,10 +196,9 @@ std::reference_wrapper<ast::expression const> names_from_expression::visit(
     "only top-level columns except structs and lists are supported in "
     "Parquet filter expression",
     std::invalid_argument);
-  auto const col_name            = col_name_iter->second;
-  auto const normalized_col_name = normalize_column_path(col_name, _case_sensitive_names);
+  auto const col_name = col_name_iter->second;
   // If the normalized column name is not in the skip_names, add it
-  if (_skip_names.count(normalized_col_name) == 0) { _column_names.insert(col_name); }
+  if (_skip_names.count(col_name) == 0) { _column_names.insert(col_name); }
   return expr;
 }
 
@@ -215,10 +206,9 @@ std::reference_wrapper<ast::expression const> names_from_expression::visit(
   ast::column_name_reference const& expr)
 {
   // collect column names
-  auto const col_name            = expr.get_column_name();
-  auto const normalized_col_name = normalize_column_path(col_name, _case_sensitive_names);
+  auto const col_name = expr.get_column_name();
   // If the normalized column name is not in the skip_names, add it
-  if (_skip_names.count(normalized_col_name) == 0) { _column_names.insert(col_name); }
+  if (_skip_names.count(col_name) == 0) { _column_names.insert(col_name); }
   return expr;
 }
 

--- a/cpp/src/io/parquet/expression_transform_helpers.cpp
+++ b/cpp/src/io/parquet/expression_transform_helpers.cpp
@@ -5,7 +5,7 @@
 
 #include "expression_transform_helpers.hpp"
 
-#include "reader_impl_helpers.hpp"
+#include "column_path_helpers.hpp"
 
 #include <cudf/ast/detail/expression_transformer.hpp>
 #include <cudf/ast/detail/operators.hpp>

--- a/cpp/src/io/parquet/expression_transform_helpers.hpp
+++ b/cpp/src/io/parquet/expression_transform_helpers.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "reader_impl_helpers.hpp"
+
 #include <cudf/ast/detail/expression_transformer.hpp>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/io/parquet.hpp>
@@ -202,8 +204,7 @@ class names_from_expression : public ast::detail::expression_transformer {
 
   std::unordered_map<cudf::size_type, std::string> _column_indices_to_names;
   std::unordered_set<std::string> _column_names;
-  std::unordered_set<std::string> _skip_names;
-  bool _case_sensitive_names{true};
+  column_path_set _skip_names;
 };
 
 /**
@@ -250,12 +251,11 @@ class named_to_reference_converter : public ast::detail::expression_transformer 
   std::vector<std::reference_wrapper<ast::expression const>> visit_operands(
     cudf::host_span<std::reference_wrapper<ast::expression const> const> operands);
 
-  std::unordered_map<std::string, size_type> _column_name_to_index;
+  column_path_map<size_type> _column_name_to_index;
   std::optional<std::reference_wrapper<ast::expression const>> _converted_expr;
   // Using std::list or std::deque to avoid reference invalidation
   std::list<ast::column_reference> _col_ref;
   std::list<ast::operation> _operators;
-  bool _case_sensitive_names{true};
 };
 
 /**

--- a/cpp/src/io/parquet/expression_transform_helpers.hpp
+++ b/cpp/src/io/parquet/expression_transform_helpers.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "reader_impl_helpers.hpp"
+#include "column_path_helpers.hpp"
 
 #include <cudf/ast/detail/expression_transformer.hpp>
 #include <cudf/ast/expressions.hpp>

--- a/cpp/src/io/parquet/reader_impl_helpers.cpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.cpp
@@ -5,6 +5,7 @@
 
 #include "reader_impl_helpers.hpp"
 
+#include "column_path_helpers.hpp"
 #include "compact_protocol_reader.hpp"
 #include "io/utilities/base64_utilities.hpp"
 #include "io/utilities/row_selection.hpp"
@@ -93,27 +94,6 @@ cuda::std::optional<LogicalType> converted_to_logical_type(SchemaElement const& 
 }
 
 }  // namespace
-
-std::string normalize_column_path(std::string_view col_path, bool case_sensitive_names)
-{
-  if (case_sensitive_names) { return std::string{col_path}; }
-  auto normalized_path = std::string(col_path.size(), '\0');
-  std::transform(col_path.begin(), col_path.end(), normalized_path.begin(), [](unsigned char c) {
-    return std::tolower(c);
-  });
-  return normalized_path;
-}
-
-bool are_column_paths_equal(std::string_view lhs, std::string_view rhs, bool case_sensitive)
-{
-  if (lhs.size() != rhs.size()) { return false; }
-  if (case_sensitive) { return lhs == rhs; }
-  // Optimize by normalizing and comparing char-by-char instead of whole strings
-  return std::equal(
-    lhs.begin(), lhs.end(), rhs.begin(), [](unsigned char lhs_char, unsigned char rhs_char) {
-      return std::equal_to<>{}(std::tolower(lhs_char), std::tolower(rhs_char));
-    });
-}
 
 type_id to_type_id(SchemaElement const& schema,
                    bool strings_to_categorical,

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -13,8 +13,13 @@
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/types.hpp>
 
+#include <cstddef>
+#include <functional>
+#include <string>
 #include <string_view>
 #include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace cudf::io::parquet::detail {
@@ -101,6 +106,80 @@ struct row_group_info {
 [[nodiscard]] bool are_column_paths_equal(std::string_view lhs,
                                           std::string_view rhs,
                                           bool case_sensitive);
+
+/**
+ * @brief Transparent hash for column paths that honors a case-sensitivity policy.
+ *
+ * Hashes the column path according to `case_sensitive_names`, so that two paths that compare equal
+ * under `are_column_paths_equal` also hash equally.
+ */
+struct column_path_hash {
+  using is_transparent = void;
+
+  bool case_sensitive_names{true};
+
+  std::size_t operator()(std::string_view path) const
+  {
+    return std::hash<std::string>{}(normalize_column_path(path, case_sensitive_names));
+  }
+};
+
+/**
+ * @brief Transparent equality for column paths that honors a case-sensitivity policy.
+ *
+ * Delegates to `are_column_paths_equal`, keeping the comparison consistent with `column_path_hash`.
+ */
+struct column_path_equal {
+  using is_transparent = void;
+
+  bool case_sensitive_names{true};
+
+  bool operator()(std::string_view lhs, std::string_view rhs) const
+  {
+    return are_column_paths_equal(lhs, rhs, case_sensitive_names);
+  }
+};
+
+/**
+ * @brief A set of column paths matched with a configurable case-sensitivity policy.
+ */
+using column_path_set = std::unordered_set<std::string, column_path_hash, column_path_equal>;
+
+/**
+ * @brief A map keyed by column path matched with a configurable case-sensitivity policy.
+ */
+template <typename Value>
+using column_path_map = std::unordered_map<std::string, Value, column_path_hash, column_path_equal>;
+
+/**
+ * @brief Constructs an empty `column_path_set` whose hash/equality use the given policy.
+ *
+ * @param case_sensitive_names Whether column-path matching is case-sensitive
+ * @param bucket_hint Optional initial bucket count
+ * @return An empty `column_path_set` using the requested policy
+ */
+[[nodiscard]] inline column_path_set make_column_path_set(bool case_sensitive_names,
+                                                          std::size_t bucket_hint = 0)
+{
+  return column_path_set(
+    bucket_hint, column_path_hash{case_sensitive_names}, column_path_equal{case_sensitive_names});
+}
+
+/**
+ * @brief Constructs an empty `column_path_map` whose hash/equality use the given policy.
+ *
+ * @tparam Value Mapped value type
+ * @param case_sensitive_names Whether column-path matching is case-sensitive
+ * @param bucket_hint Optional initial bucket count
+ * @return An empty `column_path_map` using the requested policy
+ */
+template <typename Value>
+[[nodiscard]] column_path_map<Value> make_column_path_map(bool case_sensitive_names,
+                                                          std::size_t bucket_hint = 0)
+{
+  return column_path_map<Value>(
+    bucket_hint, column_path_hash{case_sensitive_names}, column_path_equal{case_sensitive_names});
+}
 
 /**
  * @brief Translates Parquet datatype to cuDF type enum

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -19,7 +19,6 @@
 #include <string_view>
 #include <tuple>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace cudf::io::parquet::detail {
@@ -81,105 +80,6 @@ struct row_group_info {
    */
   [[nodiscard]] bool has_page_index() const { return column_chunks.has_value(); }
 };
-
-/**
- * @brief Returns a normalized (lowercased) column name or path when case-insensitive matching is
- * enabled
- *
- * @param col_path The column name or path to normalize
- * @param case_sensitive_names Whether to normalize the column path case-insensitively
- *
- * @return The normalized column path
- */
-[[nodiscard]] std::string normalize_column_path(std::string_view col_path,
-                                                bool case_sensitive_names);
-
-/**
- * @brief Compares two column paths with specified case sensitivity
- *
- * @param lhs The left-hand side column path
- * @param rhs The right-hand side column path
- * @param case_sensitive Whether to compare the column paths case-sensitively
- *
- * @return Boolean indicating if the column paths are equal
- */
-[[nodiscard]] bool are_column_paths_equal(std::string_view lhs,
-                                          std::string_view rhs,
-                                          bool case_sensitive);
-
-/**
- * @brief Transparent hash for column paths that honors a case-sensitivity policy.
- *
- * Hashes the column path according to `case_sensitive_names`, so that two paths that compare equal
- * under `are_column_paths_equal` also hash equally.
- */
-struct column_path_hash {
-  using is_transparent = void;
-
-  bool case_sensitive_names{true};
-
-  std::size_t operator()(std::string_view path) const
-  {
-    return std::hash<std::string>{}(normalize_column_path(path, case_sensitive_names));
-  }
-};
-
-/**
- * @brief Transparent equality for column paths that honors a case-sensitivity policy.
- *
- * Delegates to `are_column_paths_equal`, keeping the comparison consistent with `column_path_hash`.
- */
-struct column_path_equal {
-  using is_transparent = void;
-
-  bool case_sensitive_names{true};
-
-  bool operator()(std::string_view lhs, std::string_view rhs) const
-  {
-    return are_column_paths_equal(lhs, rhs, case_sensitive_names);
-  }
-};
-
-/**
- * @brief A set of column paths matched with a configurable case-sensitivity policy.
- */
-using column_path_set = std::unordered_set<std::string, column_path_hash, column_path_equal>;
-
-/**
- * @brief A map keyed by column path matched with a configurable case-sensitivity policy.
- */
-template <typename Value>
-using column_path_map = std::unordered_map<std::string, Value, column_path_hash, column_path_equal>;
-
-/**
- * @brief Constructs an empty `column_path_set` whose hash/equality use the given policy.
- *
- * @param case_sensitive_names Whether column-path matching is case-sensitive
- * @param bucket_hint Optional initial bucket count
- * @return An empty `column_path_set` using the requested policy
- */
-[[nodiscard]] inline column_path_set make_column_path_set(bool case_sensitive_names,
-                                                          std::size_t bucket_hint = 0)
-{
-  return column_path_set(
-    bucket_hint, column_path_hash{case_sensitive_names}, column_path_equal{case_sensitive_names});
-}
-
-/**
- * @brief Constructs an empty `column_path_map` whose hash/equality use the given policy.
- *
- * @tparam Value Mapped value type
- * @param case_sensitive_names Whether column-path matching is case-sensitive
- * @param bucket_hint Optional initial bucket count
- * @return An empty `column_path_map` using the requested policy
- */
-template <typename Value>
-[[nodiscard]] column_path_map<Value> make_column_path_map(bool case_sensitive_names,
-                                                          std::size_t bucket_hint = 0)
-{
-  return column_path_map<Value>(
-    bucket_hint, column_path_hash{case_sensitive_names}, column_path_equal{case_sensitive_names});
-}
 
 /**
  * @brief Translates Parquet datatype to cuDF type enum


### PR DESCRIPTION
## Description

Close #21864 

Follow-up to #21700. That PR repeated `normalize_column_path(...)` at every insertion/lookup of the column-name hash containers. As suggested, this PR encapsulates that policy in a small pair of hash/equality functors that carry the `case_sensitive_names` policy.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
