### PR TITLE
fix(ci): fix configuration for breaking change notification workflow

### DIFF
--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -11,6 +11,8 @@ on: # zizmor: ignore[dangerous-triggers]
       - labeled
       - unlabeled
 
+permissions: {}
+
 jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -1,5 +1,8 @@
 name: Trigger Breaking Change Notifications
 
+# `zizmor` always flags these triggers because they are easy to use
+# incorrectly. These usages are ok and don't execute any PR-specific
+# code (and so aren't susceptible to exploits from forked PRs)
 on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
@@ -15,7 +18,7 @@ jobs:
       contents: read
     uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
     secrets:
-      NV_SLACK_BREAKING_CHANGE_ALERT: ${{ secrets.NV_SLACK_BREAKING_CHANGE_ALERT }}
+      slack-webhook-url: ${{ secrets.NV_SLACK_BREAKING_CHANGE_NOTIFIER_APP }}
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/560

Fixes misconfigurations in the GitHub Actions workflow that generates Notifications when PRs are labeled `breaking`.

Any other changes come from making the configuration for this workflow identical across all RAPIDS repos.
