### PR TITLE
Speculative fix for scalar null mask creation

### DIFF
--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -10,7 +10,6 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/structs/utilities.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/strings/detail/strings_children.cuh>
@@ -40,22 +39,15 @@ struct scalar_as_column_view {
   template <typename T, CUDF_ENABLE_IF(is_fixed_width<T>())>
   return_type operator()(scalar const& s,
                          rmm::cuda_stream_view stream,
-                         rmm::device_async_resource_ref mr)
+                         rmm::device_async_resource_ref)
   {
     auto& h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
-    auto const is_valid      = s.is_valid(stream);
-    auto const null_count    = static_cast<size_type>(!is_valid);
-    auto null_mask           = cudf::detail::create_null_mask(
-      1, is_valid ? cudf::mask_state::ALL_VALID : cudf::mask_state::ALL_NULL, stream, mr);
-    auto const* null_mask_ptr = static_cast<bitmask_type const*>(null_mask.data());
-    auto aux_col              = std::make_unique<column>(data_type{type_id::INT8},
-                                            0,
-                                            rmm::device_buffer{},
-                                            std::move(null_mask),
-                                            null_count);
-    auto col_v = column_view(
-      s.type(), 1, h_scalar_type_view.data(), null_mask_ptr, null_count);
-    return std::pair{col_v, std::move(aux_col)};
+    auto col_v               = column_view(s.type(),
+                             1,
+                             h_scalar_type_view.data(),
+                             reinterpret_cast<bitmask_type const*>(s.validity_data()),
+                             !s.is_valid(stream));
+    return std::pair{col_v, std::unique_ptr<column>(nullptr)};
   }
   template <typename T, CUDF_ENABLE_IF(!is_fixed_width<T>())>
   return_type operator()(scalar const&, rmm::cuda_stream_view, rmm::device_async_resource_ref)
@@ -78,28 +70,15 @@ scalar_as_column_view::return_type scalar_as_column_view::operator()<cudf::strin
 
   auto chars_column_v = column_view(
     data_type{type_id::INT8}, h_scalar_type_view.size(), h_scalar_type_view.data(), nullptr, 0);
-  auto const is_valid   = s.is_valid(stream);
-  auto const null_count = static_cast<size_type>(!is_valid);
-  auto null_mask        = cudf::detail::create_null_mask(
-    1, is_valid ? cudf::mask_state::ALL_VALID : cudf::mask_state::ALL_NULL, stream, mr);
   // Construct string column_view
   auto col_v = column_view(s.type(),
                            1,
                            h_scalar_type_view.data(),
-                           static_cast<bitmask_type const*>(null_mask.data()),
-                           null_count,
+                           reinterpret_cast<bitmask_type const*>(s.validity_data()),
+                           static_cast<size_type>(!s.is_valid(stream)),
                            0,
                            {offsets_column->view()});
-  // Keep the null mask and offsets alive for the lifetime of the column_view
-  std::vector<std::unique_ptr<column>> children;
-  children.push_back(std::move(offsets_column));
-  auto aux_col = std::make_unique<column>(data_type{type_id::INT8},
-                                          0,
-                                          rmm::device_buffer{},
-                                          std::move(null_mask),
-                                          null_count,
-                                          std::move(children));
-  return std::pair{col_v, std::move(aux_col)};
+  return std::pair{col_v, std::move(offsets_column)};
 }
 
 // specializing for struct column

--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -10,6 +10,7 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/structs/utilities.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/strings/detail/strings_children.cuh>
@@ -39,15 +40,22 @@ struct scalar_as_column_view {
   template <typename T, CUDF_ENABLE_IF(is_fixed_width<T>())>
   return_type operator()(scalar const& s,
                          rmm::cuda_stream_view stream,
-                         rmm::device_async_resource_ref)
+                         rmm::device_async_resource_ref mr)
   {
     auto& h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
-    auto col_v               = column_view(s.type(),
-                             1,
-                             h_scalar_type_view.data(),
-                             reinterpret_cast<bitmask_type const*>(s.validity_data()),
-                             !s.is_valid(stream));
-    return std::pair{col_v, std::unique_ptr<column>(nullptr)};
+    auto const is_valid      = s.is_valid(stream);
+    auto const null_count    = static_cast<size_type>(!is_valid);
+    auto null_mask           = cudf::detail::create_null_mask(
+      1, is_valid ? cudf::mask_state::ALL_VALID : cudf::mask_state::ALL_NULL, stream, mr);
+    auto const* null_mask_ptr = static_cast<bitmask_type const*>(null_mask.data());
+    auto aux_col              = std::make_unique<column>(data_type{type_id::INT8},
+                                            0,
+                                            rmm::device_buffer{},
+                                            std::move(null_mask),
+                                            null_count);
+    auto col_v = column_view(
+      s.type(), 1, h_scalar_type_view.data(), null_mask_ptr, null_count);
+    return std::pair{col_v, std::move(aux_col)};
   }
   template <typename T, CUDF_ENABLE_IF(!is_fixed_width<T>())>
   return_type operator()(scalar const&, rmm::cuda_stream_view, rmm::device_async_resource_ref)
@@ -70,15 +78,28 @@ scalar_as_column_view::return_type scalar_as_column_view::operator()<cudf::strin
 
   auto chars_column_v = column_view(
     data_type{type_id::INT8}, h_scalar_type_view.size(), h_scalar_type_view.data(), nullptr, 0);
+  auto const is_valid   = s.is_valid(stream);
+  auto const null_count = static_cast<size_type>(!is_valid);
+  auto null_mask        = cudf::detail::create_null_mask(
+    1, is_valid ? cudf::mask_state::ALL_VALID : cudf::mask_state::ALL_NULL, stream, mr);
   // Construct string column_view
   auto col_v = column_view(s.type(),
                            1,
                            h_scalar_type_view.data(),
-                           reinterpret_cast<bitmask_type const*>(s.validity_data()),
-                           static_cast<size_type>(!s.is_valid(stream)),
+                           static_cast<bitmask_type const*>(null_mask.data()),
+                           null_count,
                            0,
                            {offsets_column->view()});
-  return std::pair{col_v, std::move(offsets_column)};
+  // Keep the null mask and offsets alive for the lifetime of the column_view
+  std::vector<std::unique_ptr<column>> children;
+  children.push_back(std::move(offsets_column));
+  auto aux_col = std::make_unique<column>(data_type{type_id::INT8},
+                                          0,
+                                          rmm::device_buffer{},
+                                          std::move(null_mask),
+                                          null_count,
+                                          std::move(children));
+  return std::pair{col_v, std::move(aux_col)};
 }
 
 // specializing for struct column

--- a/cpp/tests/binaryop/binop-compiled-fixed_point-test.cpp
+++ b/cpp/tests/binaryop/binop-compiled-fixed_point-test.cpp
@@ -505,7 +505,7 @@ TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullMaxColumnScalar)
   // DECIMAL scale -2: column {1.00, 5.00, 3.00}, scalar 5.00 -> greatest is 5.00
   auto const col      = fp_wrapper<RepType>{{100, 500, 300}, scale_type{-2}};
   auto const scalar   = cudf::make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
-  auto const expected = fp_wrapper<RepType>{{500, 500, 500}, scale_type{-2}};
+  auto const expected = fp_wrapper<RepType>{{500, 500, 500}, {true, true, true}, scale_type{-2}};
 
   auto const type = cudf::binary_operation_fixed_point_output_type(
     cudf::binary_operator::NULL_MAX, static_cast<cudf::column_view>(col).type(), scalar->type());
@@ -522,7 +522,7 @@ TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullMinColumnScalar)
 
   auto const col      = fp_wrapper<RepType>{{100, 500, 300}, scale_type{-2}};
   auto const scalar   = cudf::make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
-  auto const expected = fp_wrapper<RepType>{{100, 500, 300}, scale_type{-2}};
+  auto const expected = fp_wrapper<RepType>{{100, 500, 300}, {true, true, true}, scale_type{-2}};
 
   auto const type = cudf::binary_operation_fixed_point_output_type(
     cudf::binary_operator::NULL_MIN, static_cast<cudf::column_view>(col).type(), scalar->type());

--- a/cpp/tests/binaryop/binop-compiled-fixed_point-test.cpp
+++ b/cpp/tests/binaryop/binop-compiled-fixed_point-test.cpp
@@ -490,6 +490,63 @@ TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullEqualsSimple)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+// Null-aware column-vs-scalar fixed_point binary ops with N > 1 rows.
+// Exercises the compiled path where a scalar is wrapped as a 1-row column_view
+// (scalar_as_column_view in binary_ops.cu). Prior to fixing that wrapper, null-aware
+// kernels read scalar validity via bit_is_set and compute-sanitizer memcheck reports
+// a 4-byte OOB read from the scalar's 1-byte device bool allocation.
+// Repro: compute-sanitizer --tool memcheck ./FIXED_POINT_COMPILED_TEST --gtest_filter='*NullMaxColumnScalar*'
+TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullMaxColumnScalar)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  // DECIMAL scale -2: column {1.00, 5.00, 3.00}, scalar 5.00 -> greatest is 5.00
+  auto const col      = fp_wrapper<RepType>{{100, 500, 300}, scale_type{-2}};
+  auto const scalar   = cudf::make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
+  auto const expected = fp_wrapper<RepType>{{500, 500, 500}, scale_type{-2}};
+
+  auto const type = cudf::binary_operation_fixed_point_output_type(
+    cudf::binary_operator::NULL_MAX, static_cast<cudf::column_view>(col).type(), scalar->type());
+  auto const result = cudf::binary_operation(col, *scalar, cudf::binary_operator::NULL_MAX, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullMinColumnScalar)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  auto const col      = fp_wrapper<RepType>{{100, 500, 300}, scale_type{-2}};
+  auto const scalar   = cudf::make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
+  auto const expected = fp_wrapper<RepType>{{100, 500, 300}, scale_type{-2}};
+
+  auto const type = cudf::binary_operation_fixed_point_output_type(
+    cudf::binary_operator::NULL_MIN, static_cast<cudf::column_view>(col).type(), scalar->type());
+  auto const result = cudf::binary_operation(col, *scalar, cudf::binary_operator::NULL_MIN, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullEqualsColumnScalar)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  auto const col      = fp_wrapper<RepType>{{100, 500, 300}, scale_type{-2}};
+  auto const scalar   = cudf::make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
+  auto const expected = wrapper<bool>{{0, 1, 0}, {true, true, true}};
+
+  auto const result = cudf::binary_operation(
+    col, *scalar, cudf::binary_operator::NULL_EQUALS, cudf::data_type{cudf::type_id::BOOL8});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOp_Div)
 {
   using namespace numeric;


### PR DESCRIPTION
## Description

Closes #22757

This PR fixes `scalar_as_column_view` to handle cases where the input scalar is null. If the input is valid, it's directly just converted to a column view. Otherwise, an actual column with single null element is allocated and its view is returned.

UPDATE:
Temporarily reverted the scalar change in order to validate the added tests. In the new state, the tests pass, but fail if invoked with `compute-sanitizer` and `--rmm_mode=cuda`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
