### PR TITLE
fix(ci): add missing permissions to pandas-tests workflow

### DIFF
--- a/.github/workflows/pandas-tests.yaml
+++ b/.github/workflows/pandas-tests.yaml
@@ -24,8 +24,11 @@ jobs:
   pandas-tests:
       # run the Pandas unit tests
       permissions:
+        actions: read
         contents: read
         id-token: write
+        packages: read
+        pull-requests: read
       secrets: inherit # zizmor: ignore[secrets-inherit]
       uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
       with:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The pandas-tests workflow has been failing since the zizmor security hardening (#22343) because the job-level permissions were incomplete. The shared workflow custom-job.yaml requires actions: read, packages: read, and pull-requests: read, but only contents: read and id-token: write were granted.

This matches the permissions pattern used by all other jobs calling shared-workflows in build.yaml and test.yaml.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
