### PR TITLE
Remove cudf-polars CI timeouts

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -61,6 +61,7 @@ DESELECTED_TESTS_STR=$(printf -- " --deselect %s" "${DESELECTED_TESTS[@]}")
 # shellcheck disable=SC2086
 echo "Run polars tests with injected in-memory GPU engine"
 python -m pytest \
+       -vv \
        --import-mode=importlib \
        --cache-clear \
        -m "" \

--- a/ci/test_cudf_polars_polars_tests.sh
+++ b/ci/test_cudf_polars_polars_tests.sh
@@ -62,7 +62,7 @@ trap set_exitcode ERR
 set +e
 
 rapids-logger "Run polars tests"
-timeout 50m ./ci/run_cudf_polars_polars_tests.sh
+./ci/run_cudf_polars_polars_tests.sh
 
 trap ERR
 set -e

--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -42,7 +42,8 @@ timeout 30m ./ci/run_custreamz_pytests.sh \
   --cov-report=term
 
 rapids-logger "pytest cudf-polars"
-timeout 30m ./ci/run_cudf_polars_pytests.sh \
+./ci/run_cudf_polars_pytests.sh \
+  -vv \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars.xml" \
   --numprocesses=8 \
   --dist=worksteal \

--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -80,7 +80,8 @@ for version in "${VERSIONS[@]}"; do
         COVERAGE_ARGS=(--no-cov)
     fi
 
-    timeout 35m ./ci/run_cudf_polars_pytests.sh \
+    ./ci/run_cudf_polars_pytests.sh \
+        -vv \
         "${COVERAGE_ARGS[@]}" \
         --numprocesses=8 \
         --dist=worksteal \


### PR DESCRIPTION
## Description

We're investigating some persistent CI failures, many of which are made harder to debug by the timeouts in our CI scripts. For example, https://github.com/rapidsai/cudf/actions/runs/26805071862/job/79020475939#step:13:3529 has a run where the output was swallowed and the cause of the error is unclear.

To ensure we get the full pytest output, this PR removes those timeouts

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
