### PR TITLE
Backport fixes for Velox to release/26.06

### DIFF
--- a/cpp/src/binaryop/compiled/binary_ops.cu
+++ b/cpp/src/binaryop/compiled/binary_ops.cu
@@ -10,6 +10,7 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/structs/utilities.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/strings/detail/strings_children.cuh>
@@ -39,15 +40,24 @@ struct scalar_as_column_view {
   template <typename T, CUDF_ENABLE_IF(is_fixed_width<T>())>
   return_type operator()(scalar const& s,
                          rmm::cuda_stream_view stream,
-                         rmm::device_async_resource_ref)
+                         rmm::device_async_resource_ref mr)
   {
     auto& h_scalar_type_view = static_cast<cudf::scalar_type_t<T>&>(const_cast<scalar&>(s));
-    auto col_v               = column_view(s.type(),
-                             1,
-                             h_scalar_type_view.data(),
-                             reinterpret_cast<bitmask_type const*>(s.validity_data()),
-                             !s.is_valid(stream));
-    return std::pair{col_v, std::unique_ptr<column>(nullptr)};
+
+    // Valid scalar needs no null mask
+    if (s.is_valid(stream)) {
+      auto col_v = column_view(s.type(), 1, h_scalar_type_view.data(), nullptr, 0);
+      return std::pair{col_v, nullptr};
+    }
+
+    // Null scalar needs a single-element null mask (kept alive by an auxiliary column) as its
+    // validity (bool) cannot be reinterpreted as `bitmask_type` without reading out of bounds.
+    auto null_mask = cudf::detail::create_null_mask(1, cudf::mask_state::ALL_NULL, stream, mr);
+    auto const* null_mask_ptr = static_cast<bitmask_type const*>(null_mask.data());
+    auto aux_col              = std::make_unique<column>(
+      data_type{type_id::INT8}, 0, rmm::device_buffer{}, std::move(null_mask), 1);
+    auto col_v = column_view(s.type(), 1, h_scalar_type_view.data(), null_mask_ptr, 1);
+    return std::pair{col_v, std::move(aux_col)};
   }
   template <typename T, CUDF_ENABLE_IF(!is_fixed_width<T>())>
   return_type operator()(scalar const&, rmm::cuda_stream_view, rmm::device_async_resource_ref)
@@ -68,17 +78,29 @@ scalar_as_column_view::return_type scalar_as_column_view::operator()<cudf::strin
   auto offsets_column          = std::get<0>(cudf::detail::make_offsets_child_column(
     offsets_transformer_itr, offsets_transformer_itr + 1, stream, mr));
 
-  auto chars_column_v = column_view(
-    data_type{type_id::INT8}, h_scalar_type_view.size(), h_scalar_type_view.data(), nullptr, 0);
-  // Construct string column_view
-  auto col_v = column_view(s.type(),
-                           1,
-                           h_scalar_type_view.data(),
-                           reinterpret_cast<bitmask_type const*>(s.validity_data()),
-                           static_cast<size_type>(!s.is_valid(stream)),
-                           0,
-                           {offsets_column->view()});
-  return std::pair{col_v, std::move(offsets_column)};
+  // Valid scalar needs no null mask. The offsets child column is kept alive to back the returned
+  // string column_view.
+  if (s.is_valid(stream)) {
+    auto col_v = cudf::column_view(
+      s.type(), 1, h_scalar_type_view.data(), nullptr, 0, 0, {offsets_column->view()});
+    return std::pair{col_v, std::move(offsets_column)};
+  }
+
+  // Null scalar needs a single-element null mask and offsets (kepy alive by an auxiliary column) as
+  // its validity (bool) cannot be reinterpreted as `bitmask_type` without reading out of bounds.
+  auto null_mask = cudf::detail::create_null_mask(1, cudf::mask_state::ALL_NULL, stream, mr);
+  auto const* null_mask_ptr = static_cast<bitmask_type const*>(null_mask.data());
+  auto col_v                = cudf::column_view(
+    s.type(), 1, h_scalar_type_view.data(), null_mask_ptr, 1, 0, {offsets_column->view()});
+  std::vector<std::unique_ptr<column>> children;
+  children.push_back(std::move(offsets_column));
+  auto aux_col = std::make_unique<column>(data_type{type_id::INT8},
+                                          0,
+                                          rmm::device_buffer{},
+                                          std::move(null_mask),
+                                          1,
+                                          std::move(children));
+  return std::pair{col_v, std::move(aux_col)};
 }
 
 // specializing for struct column

--- a/cpp/tests/binaryop/binop-compiled-fixed_point-test.cpp
+++ b/cpp/tests/binaryop/binop-compiled-fixed_point-test.cpp
@@ -490,6 +490,44 @@ TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullEqualsSimple)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullMaxColumnScalar)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  // DECIMAL scale -2: column {1.00, 5.00, 3.00}, scalar 5.00 -> greatest is 5.00.
+  // NULL_MAX always produces a nullable output, so the expected column is nullable (all valid).
+  auto const col      = fp_wrapper<RepType>{{100, 500, 300}, scale_type{-2}};
+  auto const scalar   = cudf::make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
+  auto const expected = fp_wrapper<RepType>{{500, 500, 500}, {1, 1, 1}, scale_type{-2}};
+
+  auto const type = cudf::binary_operation_fixed_point_output_type(
+    cudf::binary_operator::NULL_MAX, static_cast<cudf::column_view>(col).type(), scalar->type());
+  auto const result = cudf::binary_operation(col, *scalar, cudf::binary_operator::NULL_MAX, type);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOpNullEqualsNullColumnScalar)
+{
+  using namespace numeric;
+  using decimalXX = TypeParam;
+  using RepType   = cudf::device_storage_type_t<decimalXX>;
+
+  auto const col = fp_wrapper<RepType>{{100, 500, 300}, {1, 0, 1}, scale_type{-2}};
+
+  // A null scalar compared with NULL_EQUALS yields true only where the column value is also null.
+  auto scalar = cudf::make_fixed_point_scalar<decimalXX>(500, scale_type{-2});
+  scalar->set_valid_async(false);
+  auto const expected = wrapper<bool>{{0, 1, 0}, {true, true, true}};
+
+  auto const result = cudf::binary_operation(
+    col, *scalar, cudf::binary_operator::NULL_EQUALS, cudf::data_type{cudf::type_id::BOOL8});
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
 TYPED_TEST(FixedPointCompiledTest, FixedPointBinaryOp_Div)
 {
   using namespace numeric;


### PR DESCRIPTION
## Description
This PR backports fixes needed in Velox to `release/26.06`. A hotfix release is not required, we only need a branch based on `release/26.06` until Velox is updated to use CMake 4.x in its CI.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
