### PR TITLE
Increase timeouts for slower cudf-polars tests

### DIFF
--- a/python/cudf_polars/tests/expressions/test_rolling.py
+++ b/python/cudf_polars/tests/expressions/test_rolling.py
@@ -358,6 +358,7 @@ def test_rank_over_with_null_values(
 @pytest.mark.parametrize("method", ["ordinal", "dense", "min", "max", "average"])
 @pytest.mark.parametrize("descending", [False, True])
 @pytest.mark.parametrize("order_by", [None, ["g2", pl.col("x2") * 2]])
+@pytest.mark.timeout(120)
 def test_rank_over_with_null_group_keys(
     engine: pl.GPUEngine,
     df: pl.LazyFrame,

--- a/python/cudf_polars/tests/streaming/test_sort.py
+++ b/python/cudf_polars/tests/streaming/test_sort.py
@@ -87,6 +87,7 @@ def large_frames():
     )
 
 
+@pytest.mark.timeout(120)
 def test_sort(df, engine):
     q = df.sort(by=["y", "z"])
     assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
## Description

https://github.com/rapidsai/cudf/actions/runs/26937471348/job/79470587366 contains a couple of failures. There are some pytest internal errors so I think we don't get the whole traceback, but at least some look related to timeouts in the tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
