### PR TITLE
Rename build/probe to right/left in mixed_join_semi

### DIFF
--- a/cpp/include/cudf/join/join.hpp
+++ b/cpp/include/cudf/join/join.hpp
@@ -43,7 +43,8 @@ enum class join_kind : int32_t {
 };
 
 /**
- * @brief Specifies whether a join implementation should apply an optional probe-side prefilter.
+ * @brief Specifies whether a join implementation should apply an optional prefilter that reduces
+ *        candidate rows before probing the hash table.
  *
  * `NO` preserves the current direct probe behavior. `YES` enables implementation-defined
  * prefiltering, such as bloom-filter-based candidate reduction before probing a hash table.

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -97,27 +97,27 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
   // TODO: The non-conditional join impls start with a dictionary matching,
   // figure out what that is and what it's needed for (and if conditional joins
   // need to do the same).
-  auto& probe                 = left_equality;
-  auto& build                 = right_equality;
-  auto probe_view             = table_device_view::create(probe, stream);
-  auto build_view             = table_device_view::create(build, stream);
+  auto& left                  = left_equality;
+  auto& right                 = right_equality;
+  auto left_view              = table_device_view::create(left, stream);
+  auto right_view             = table_device_view::create(right, stream);
   auto left_conditional_view  = table_device_view::create(left_conditional, stream);
   auto right_conditional_view = table_device_view::create(right_conditional, stream);
 
-  auto const preprocessed_build =
-    cudf::detail::row::equality::preprocessed_table::create(build, stream);
-  auto const preprocessed_probe =
-    cudf::detail::row::equality::preprocessed_table::create(probe, stream);
+  auto const preprocessed_right =
+    cudf::detail::row::equality::preprocessed_table::create(right, stream);
+  auto const preprocessed_left =
+    cudf::detail::row::equality::preprocessed_table::create(left, stream);
   auto const row_comparator =
-    cudf::detail::row::equality::two_table_comparator{preprocessed_probe, preprocessed_build};
-  auto const equality_probe = row_comparator.equal_to<false>(has_nulls, compare_nulls);
+    cudf::detail::row::equality::two_table_comparator{preprocessed_left, preprocessed_right};
+  auto const equality_left = row_comparator.equal_to<false>(has_nulls, compare_nulls);
 
   // Create hash table containing all keys found in right table
   // TODO: To add support for nested columns we will need to flatten in many
   // places. However, this probably isn't worth adding any time soon since we
   // won't be able to support AST conditions for those types anyway.
-  auto const build_nulls    = cudf::nullate::DYNAMIC{cudf::has_nulls(build)};
-  auto const row_hash_build = cudf::detail::row::hash::row_hasher{preprocessed_build};
+  auto const right_nulls    = cudf::nullate::DYNAMIC{cudf::has_nulls(right)};
+  auto const row_hash_right = cudf::detail::row::hash::row_hasher{preprocessed_right};
 
   // Since we may see multiple rows that are identical in the equality tables
   // but differ in the conditional tables, the equality comparator used for
@@ -128,22 +128,22 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
   // the columns of the conditional table that are used by the expression, but
   // that requires additional plumbing through the AST machinery and is out of
   // scope for now.
-  auto const row_comparator_build =
-    cudf::detail::row::equality::two_table_comparator{preprocessed_build, preprocessed_build};
-  auto const equality_build_equality =
-    row_comparator_build.equal_to<false>(build_nulls, compare_nulls);
-  auto const preprocessed_build_condtional =
+  auto const row_comparator_right =
+    cudf::detail::row::equality::two_table_comparator{preprocessed_right, preprocessed_right};
+  auto const equality_right_equality =
+    row_comparator_right.equal_to<false>(right_nulls, compare_nulls);
+  auto const preprocessed_right_condtional =
     cudf::detail::row::equality::preprocessed_table::create(right_conditional, stream);
-  auto const row_comparator_conditional_build = cudf::detail::row::equality::two_table_comparator{
-    preprocessed_build_condtional, preprocessed_build_condtional};
-  auto const equality_build_conditional =
-    row_comparator_conditional_build.equal_to<false>(build_nulls, compare_nulls);
+  auto const row_comparator_conditional_right = cudf::detail::row::equality::two_table_comparator{
+    preprocessed_right_condtional, preprocessed_right_condtional};
+  auto const equality_right_conditional =
+    row_comparator_conditional_right.equal_to<false>(right_nulls, compare_nulls);
 
-  hash_set_type row_set{{static_cast<std::size_t>(build.num_rows())},
+  hash_set_type row_set{{static_cast<std::size_t>(right.num_rows())},
                         cudf::detail::CUCO_DESIRED_LOAD_FACTOR,
                         cuco::empty_key{JoinNoMatch},
-                        {equality_build_equality, equality_build_conditional},
-                        {row_hash_build.device_hasher(build_nulls)},
+                        {equality_right_equality, equality_right_conditional},
+                        {row_hash_right.device_hasher(right_nulls)},
                         {},
                         {},
                         rmm::mr::polymorphic_allocator<char>{},
@@ -152,12 +152,12 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
   auto iter = cuda::counting_iterator<cudf::size_type>{0};
 
   // skip rows that are null here.
-  if ((compare_nulls == null_equality::EQUAL) or (not nullable(build))) {
+  if ((compare_nulls == null_equality::EQUAL) or (not nullable(right))) {
     row_set.insert_async(iter, iter + right_num_rows, stream.value());
   } else {
     cuda::counting_iterator<cudf::size_type> stencil(0);
     auto const [row_bitmask, _] =
-      cudf::detail::bitmask_and(build, stream, cudf::get_current_device_resource_ref());
+      cudf::detail::bitmask_and(right, stream, cudf::get_current_device_resource_ref());
     row_is_valid pred{static_cast<bitmask_type const*>(row_bitmask.data())};
 
     // insert valid rows
@@ -169,21 +169,20 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
     parser.shmem_per_thread *
     cuco::detail::int_div_ceil(config.num_threads_per_block, hash_set_type::cg_size);
 
-  auto const row_hash   = cudf::detail::row::hash::row_hasher{preprocessed_probe};
-  auto const hash_probe = row_hash.device_hasher(has_nulls);
+  auto const row_hash  = cudf::detail::row::hash::row_hasher{preprocessed_left};
+  auto const hash_left = row_hash.device_hasher(has_nulls);
 
-  hash_set_ref_type const row_set_ref =
-    row_set.ref(cuco::contains).rebind_hash_function(hash_probe);
+  hash_set_ref_type const row_set_ref = row_set.ref(cuco::contains).rebind_hash_function(hash_left);
 
-  // Vector used to indicate indices from left/probe table which are present in output
-  auto left_table_keep_mask = rmm::device_uvector<bool>(probe.num_rows(), stream);
+  // Vector used to indicate indices from the left table which are present in output
+  auto left_table_keep_mask = rmm::device_uvector<bool>(left.num_rows(), stream);
 
   launch_mixed_join_semi(has_nulls,
                          *left_conditional_view,
                          *right_conditional_view,
-                         *probe_view,
-                         *build_view,
-                         equality_probe,
+                         *left_view,
+                         *right_view,
+                         equality_left,
                          row_set_ref,
                          cudf::device_span<bool>(left_table_keep_mask),
                          parser.device_expression_data,
@@ -191,12 +190,12 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
                          shmem_size_per_block,
                          stream);
 
-  auto gather_map = std::make_unique<rmm::device_uvector<size_type>>(probe.num_rows(), stream, mr);
+  auto gather_map = std::make_unique<rmm::device_uvector<size_type>>(left.num_rows(), stream, mr);
 
   // gather_map_end will be the end of valid data in gather_map
   auto gather_map_end = cudf::detail::copy_if(
     cuda::counting_iterator<size_type>{0},
-    cuda::counting_iterator<size_type>{probe.num_rows()},
+    cuda::counting_iterator<size_type>{left.num_rows()},
     left_table_keep_mask.begin(),
     gather_map->begin(),
     [join_type] __device__(bool keep_row) {


### PR DESCRIPTION
## Description

Closes https://github.com/rapidsai/cudf/issues/22400

This PR renames all uses of `probe`/`build` with `left`/`right` for `mixed_join_semi`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
