### PR TITLE
Add blog links to appropriate cpp/examples readme files

### DIFF
--- a/cpp/examples/billion_rows/README.md
+++ b/cpp/examples/billion_rows/README.md
@@ -42,3 +42,5 @@ build/brc_pipeline input.txt 25 2
 If your machine does not come with a pre-built libcudf binary, expect the
 first build to take some time, as it would build libcudf on the host machine.
 It may be sped up by configuring the proper `PARALLEL_LEVEL` number.
+
+Blog post that uses this code: https://developer.nvidia.com/blog/processing-one-billion-rows-of-data-with-rapids-cudf-pandas-accelerator-mode/

--- a/cpp/examples/billion_rows/README.md
+++ b/cpp/examples/billion_rows/README.md
@@ -4,6 +4,8 @@ This C++ example demonstrates using libcudf APIs to read and process
 a table with 1 billion rows. The 1 billion row challenge is described here:
 https://github.com/gunnarmorling/1brc
 
+Blog post that uses this code: https://developer.nvidia.com/blog/processing-one-billion-rows-of-data-with-rapids-cudf-pandas-accelerator-mode/
+
 The examples load the 1 billion row text file using the CSV reader.
 The file contains around 400 unique city names (string type) along with
 random temperature values (float type).
@@ -42,5 +44,3 @@ build/brc_pipeline input.txt 25 2
 If your machine does not come with a pre-built libcudf binary, expect the
 first build to take some time, as it would build libcudf on the host machine.
 It may be sped up by configuring the proper `PARALLEL_LEVEL` number.
-
-Blog post that uses this code: https://developer.nvidia.com/blog/processing-one-billion-rows-of-data-with-rapids-cudf-pandas-accelerator-mode/

--- a/cpp/examples/nested_types/README.md
+++ b/cpp/examples/nested_types/README.md
@@ -1,0 +1,38 @@
+# libcudf C++ example using nested data types
+
+This C++ example demonstrates using libcudf APIs to perform operations on
+tables containing nested data types (e.g. structs and lists).
+
+The example reads a line-delimited JSON file whose records contain nested
+fields, then deduplicates the rows and annotates each unique row with the
+number of times it occurs. It showcases the libcudf nested-type row operators
+of three kinds:
+1. hashing - used to hash inputs of any type
+2. equality - used in conjunction with hashing to determine equality for nested types
+3. lexicographic - used to create a lexicographical order for nested types so as to enable sorting
+
+The example performs the following steps:
+1. `read_json` - Reads the nested-type table from a line-delimited JSON file
+2. `count_aggregate` - Uses a groupby aggregation to count duplicate rows (hashing and equality)
+3. `join_count` - Joins each row with its duplicate count (hashing and equality)
+4. `sort_keys` - Sorts the resulting table by the nested key column (lexicographic)
+5. `write_json` - Writes the deduplicated, sorted table to a line-delimited JSON file
+
+## Compile and execute
+
+```bash
+# Configure project
+cmake -S . -B build/
+# Build
+cmake --build build/ --parallel $PARALLEL_LEVEL
+# Execute using the included example.json and the default pool memory resource
+build/deduplication
+# Execute with explicit arguments: input file, output file, and memory resource ("pool" or "cuda")
+build/deduplication example.json output.json pool
+```
+
+If your machine does not come with a pre-built libcudf binary, expect the
+first build to take some time, as it would build libcudf on the host machine.
+It may be sped up by configuring the proper `PARALLEL_LEVEL` number.
+
+Blog post that uses this code: https://developer.nvidia.com/blog/streamline-etl-workflows-with-nested-data-types-in-rapids-libcudf/

--- a/cpp/examples/nested_types/README.md
+++ b/cpp/examples/nested_types/README.md
@@ -3,6 +3,8 @@
 This C++ example demonstrates using libcudf APIs to perform operations on
 tables containing nested data types (e.g. structs and lists).
 
+Blog post that uses this code: https://developer.nvidia.com/blog/streamline-etl-workflows-with-nested-data-types-in-rapids-libcudf/
+
 The example reads a line-delimited JSON file whose records contain nested
 fields, then deduplicates the rows and annotates each unique row with the
 number of times it occurs. It showcases the libcudf nested-type row operators
@@ -34,5 +36,3 @@ build/deduplication example.json output.json pool
 If your machine does not come with a pre-built libcudf binary, expect the
 first build to take some time, as it would build libcudf on the host machine.
 It may be sped up by configuring the proper `PARALLEL_LEVEL` number.
-
-Blog post that uses this code: https://developer.nvidia.com/blog/streamline-etl-workflows-with-nested-data-types-in-rapids-libcudf/

--- a/cpp/examples/parquet_io/README.md
+++ b/cpp/examples/parquet_io/README.md
@@ -3,6 +3,8 @@
 This C++ example demonstrates using libcudf APIs to read and write Parquet
 files with different encodings and compression types.
 
+Blog post that uses this code: https://developer.nvidia.com/blog/encoding-and-compression-guide-for-parquet-string-data-using-rapids/
+
 The following encoding and compression types are demonstrated:
 * Encoding types: `DEFAULT`, `DICTIONARY`, `PLAIN`, `DELTA_BINARY_PACKED`,
   `DELTA_LENGTH_BYTE_ARRAY`, `DELTA_BYTE_ARRAY`
@@ -43,5 +45,3 @@ Pass `-h` or `--help` to either executable to print full usage information.
 If your machine does not come with a pre-built libcudf binary, expect the
 first build to take some time, as it would build libcudf on the host machine.
 It may be sped up by configuring the proper `PARALLEL_LEVEL` number.
-
-Blog post that uses this code: https://developer.nvidia.com/blog/encoding-and-compression-guide-for-parquet-string-data-using-rapids/

--- a/cpp/examples/parquet_io/README.md
+++ b/cpp/examples/parquet_io/README.md
@@ -1,0 +1,47 @@
+# libcudf C++ examples for Parquet I/O
+
+This C++ example demonstrates using libcudf APIs to read and write Parquet
+files with different encodings and compression types.
+
+The following encoding and compression types are demonstrated:
+* Encoding types: `DEFAULT`, `DICTIONARY`, `PLAIN`, `DELTA_BINARY_PACKED`,
+  `DELTA_LENGTH_BYTE_ARRAY`, `DELTA_BYTE_ARRAY`
+* Compression types: `NONE`, `AUTO`, `SNAPPY`, `LZ4`, `ZSTD`
+
+There are two examples included:
+1. `parquet_io.cpp`
+   Reads an input Parquet file, writes it back out using the specified
+   encoding and compression (optionally with page statistics), reads the
+   transcoded file, and validates that the data round-trips correctly. The
+   write and read steps are timed.
+2. `parquet_io_multithreaded.cpp`
+   Reads one or more Parquet files (or directories of files) using multiple
+   threads and a configurable I/O source type (`FILEPATH`, `HOST_BUFFER`,
+   `PINNED_BUFFER`, `DEVICE_BUFFER`), optionally writing and validating the
+   output.
+
+## Compile and execute
+
+```bash
+# Configure project
+cmake -S . -B build/
+# Build
+cmake --build build/ --parallel $PARALLEL_LEVEL
+# Execute using the included example.parquet and default encoding/compression
+build/parquet_io
+# Execute with explicit arguments:
+#   <input file> <output file> <encoding type> <compression type> <write page stats: yes/no>
+build/parquet_io example.parquet output.parquet DELTA_BINARY_PACKED ZSTD
+# Execute the multithreaded example:
+#   <comma delimited list of dirs and/or files> <input multiplier> <io source type>
+#   <number of times to read> <thread count> <write to temp output files and validate: yes/no>
+build/parquet_io_multithreaded example.parquet
+```
+
+Pass `-h` or `--help` to either executable to print full usage information.
+
+If your machine does not come with a pre-built libcudf binary, expect the
+first build to take some time, as it would build libcudf on the host machine.
+It may be sped up by configuring the proper `PARALLEL_LEVEL` number.
+
+Blog post that uses this code: https://developer.nvidia.com/blog/encoding-and-compression-guide-for-parquet-string-data-using-rapids/

--- a/cpp/examples/string_transforms/README.md
+++ b/cpp/examples/string_transforms/README.md
@@ -28,3 +28,5 @@ build/output info.csv output.csv 100000
 If your machine does not come with a pre-built libcudf binary, expect the
 first build to take some time, as it would build libcudf on the host machine.
 It may be sped up by configuring the proper `PARALLEL_LEVEL` number.
+
+Blog post that uses this code: https://developer.nvidia.com/blog/efficient-transforms-in-cudf-using-jit-compilation/

--- a/cpp/examples/string_transforms/README.md
+++ b/cpp/examples/string_transforms/README.md
@@ -3,6 +3,8 @@
 This C++ example demonstrates using libcudf transform API to access and create
 strings columns.
 
+Blog post that uses this code: https://developer.nvidia.com/blog/efficient-transforms-in-cudf-using-jit-compilation/
+
 The example source code loads a csv file and produces a transformed column from the table using the values from the tables.
 
 The following examples are included:
@@ -28,5 +30,3 @@ build/output info.csv output.csv 100000
 If your machine does not come with a pre-built libcudf binary, expect the
 first build to take some time, as it would build libcudf on the host machine.
 It may be sped up by configuring the proper `PARALLEL_LEVEL` number.
-
-Blog post that uses this code: https://developer.nvidia.com/blog/efficient-transforms-in-cudf-using-jit-compilation/


### PR DESCRIPTION
## Description
Adds a couple of README.md files to the cpp/examples and includes links to the associated blogs for those examples as well as others that already have readme files.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
