### PR TITLE
Fix zero-count regex quantifier expansion

### DIFF
--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -758,10 +758,10 @@ class regex_parser {
         auto const n = item.d.count.n;  // minimum count
         auto const m = item.d.count.m;  // maximum count
         assert(n >= 0 && "invalid repeat count value n");
+        std::vector<regex_parser::Item> repeat_copy(begin, end);
         // zero-repeat edge-case: need to erase the previous items
         if (n == 0) { out.erase(begin, end); }
 
-        std::vector<regex_parser::Item> repeat_copy(begin, end);
         // special handling for quantified capture groups
         if ((n > 1) && (*begin).type == LBRA) {
           (*begin).type = LBRA_NC;  // change first one to non-capture

--- a/cpp/tests/strings/contains_tests.cpp
+++ b/cpp/tests/strings/contains_tests.cpp
@@ -466,6 +466,13 @@ TEST_F(StringsContainsTests, FixedQuantifier)
 
 TEST_F(StringsContainsTests, ZeroRangeQuantifier)
 {
+  EXPECT_NO_THROW(cudf::strings::regex_program::create("a{0}"));
+  EXPECT_NO_THROW(cudf::strings::regex_program::create("a{0,1}"));
+  EXPECT_NO_THROW(cudf::strings::regex_program::create("a{0,}"));
+  EXPECT_NO_THROW(cudf::strings::regex_program::create("(ab){0}"));
+  EXPECT_NO_THROW(cudf::strings::regex_program::create("(ab){0,1}"));
+  EXPECT_NO_THROW(cudf::strings::regex_program::create("(ab){0,}"));
+
   auto input = cudf::test::strings_column_wrapper({"a", "", "abc", "XYAZ", "ABC", "ZYXA"});
   auto sv    = cudf::strings_column_view(input);
 


### PR DESCRIPTION
## Summary

- Copy the regex item range before erasing it for zero-count counted quantifiers.
- Add regression coverage for `{0}`, `{0,1}`, and `{0,}` on both single items and capture groups.

## Details

`expand_counted_items()` previously erased the repeated range when the minimum count was zero, then constructed `repeat_copy` from the same `std::vector` iterators. `std::vector::erase` invalidates iterators in the erased range, so patterns such as `a{0}` and `a{0,1}` could rely on undefined behavior during regex program construction.

The range is now copied before the zero-count erase. That keeps the existing `{0}`, `{0,m}`, and `{0,}` behavior intact while avoiding use of invalidated iterators.

## Validation

- `pre-commit run clang-format --files cpp/src/strings/regex/regcomp.cpp cpp/tests/strings/contains_tests.cpp`
- `git diff --check`

I did not run the C++ gtests locally because this checkout does not have a `cpp/build` tree or gtest binaries.
