### PR TITLE
Fix hybrid scan reader state not fully reset for multi-threaded reuse

### DIFF
--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -814,6 +814,11 @@ void hybrid_scan_reader_impl::reset_internal_state()
   _reader_column_schema.reset();
   _expr_conv = named_to_reference_converter{};
   _mr        = cudf::get_current_device_resource_ref();
+
+  _output_chunk_produced       = false;
+  _is_filter_columns_selected  = false;
+  _is_payload_columns_selected = false;
+  _is_all_columns_selected     = false;
 }
 
 void hybrid_scan_reader_impl::initialize_column_selection_options(


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
hybrid_scan_reader_impl::reset_internal_state() was not resetting _output_chunk_produced and the three column selection flags (_is_filter_columns_selected, _is_payload_columns_selected, _is_all_columns_selected). When a reader instance is reused across multiple threads, stale state from a previous read carries over:
 - _output_chunk_produced being true causes is_first_output_chunk() to incorrectly return false
 - Column selection flags being true triggers early-return guards in select_all_columns() / select_filter_columns() / select_payload_columns(), skipping column setup entirely

  This patch adds the missing resets to reset_internal_state().

<!-- Reference any issues closed by this PR with "closes #1234". -->
closes #22851 
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
