### PR TITLE
Reenable benchmarks when rapidsmpf supports MPI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -735,9 +735,7 @@ jobs:
         SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
       build_command: |
         sccache --zero-stats;
-        configure-cudf-cpp -DBUILD_BENCHMARKS=ON;
-        configure-cudf_streaming-cpp -DBUILD_BENCHMARKS=OFF;
-        build-all -j0 --verbose 2>&1 | tee telemetry-artifacts/build.log;
+        build-all -j0 --verbose -DBUILD_BENCHMARKS=ON 2>&1 | tee telemetry-artifacts/build.log;
         sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
   unit-tests-cudf-pandas:
     needs: [wheel-build-cudf, changed-files]

--- a/cpp/libcudf_streaming/CMakeLists.txt
+++ b/cpp/libcudf_streaming/CMakeLists.txt
@@ -66,8 +66,15 @@ include(cmake/thirdparty/get_rapidsmpf.cmake)
 include(../cmake/thirdparty/get_cucollections.cmake)
 
 if(BUILD_BENCHMARKS)
-  rapids_find_package(ucxx REQUIRED)
-  rapids_find_package(MPI REQUIRED)
+  if(RAPIDSMPF_HAVE_MPI)
+    rapids_find_package(ucxx REQUIRED)
+    rapids_find_package(MPI REQUIRED)
+  else()
+    message(
+      STATUS
+        "CUDF_STREAMING: Skipping MPI-dependent benchmarks (RAPIDSMPF_HAVE_MPI=${RAPIDSMPF_HAVE_MPI})"
+    )
+  endif()
 endif()
 
 # ##################################################################################################

--- a/cpp/libcudf_streaming/CMakeLists.txt
+++ b/cpp/libcudf_streaming/CMakeLists.txt
@@ -66,8 +66,15 @@ include(cmake/thirdparty/get_rapidsmpf.cmake)
 include(../cmake/thirdparty/get_cucollections.cmake)
 
 if(BUILD_BENCHMARKS)
-  if(RAPIDSMPF_HAVE_MPI)
+  if(RAPIDSMPF_HAVE_UCXX)
     rapids_find_package(ucxx REQUIRED)
+  else()
+    message(
+      STATUS
+        "CUDF_STREAMING: Skipping UCXX-dependent benchmarks (RAPIDSMPF_HAVE_UCXX=${RAPIDSMPF_HAVE_UCXX})"
+    )
+  endif()
+  if(RAPIDSMPF_HAVE_MPI)
     rapids_find_package(MPI REQUIRED)
   else()
     message(

--- a/cpp/libcudf_streaming/benchmarks/CMakeLists.txt
+++ b/cpp/libcudf_streaming/benchmarks/CMakeLists.txt
@@ -13,26 +13,28 @@ add_library(bench_utils INTERFACE)
 target_sources(bench_utils INTERFACE utils/random_data.cu)
 target_compile_options(bench_utils INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda>)
 
-add_executable(bench_shuffle "bench_shuffle.cpp")
-set_target_properties(
-  bench_shuffle
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CUDF_STREAMING_BINARY_DIR}/benchmarks"
-             CXX_STANDARD 20
-             CXX_STANDARD_REQUIRED ON
-             CXX_EXTENSIONS ON
-             CUDA_STANDARD 20
-             CUDA_STANDARD_REQUIRED ON
-)
-target_link_libraries(
-  bench_shuffle PRIVATE cudf_streaming rapidsmpf::rapidsmpf ucxx::ucxx MPI::MPI_CXX
-                        $<TARGET_NAME_IF_EXISTS:conda_env> bench_utils
-)
-install(
-  TARGETS bench_shuffle
-  COMPONENT benchmarking
-  DESTINATION bin/benchmarks/libcudf_streaming
-  EXCLUDE_FROM_ALL
-)
+if(RAPIDSMPF_HAVE_MPI)
+  add_executable(bench_shuffle "bench_shuffle.cpp")
+  set_target_properties(
+    bench_shuffle
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CUDF_STREAMING_BINARY_DIR}/benchmarks"
+               CXX_STANDARD 20
+               CXX_STANDARD_REQUIRED ON
+               CXX_EXTENSIONS ON
+               CUDA_STANDARD 20
+               CUDA_STANDARD_REQUIRED ON
+  )
+  target_link_libraries(
+    bench_shuffle PRIVATE cudf_streaming rapidsmpf::rapidsmpf ucxx::ucxx MPI::MPI_CXX
+                          $<TARGET_NAME_IF_EXISTS:conda_env> bench_utils
+  )
+  install(
+    TARGETS bench_shuffle
+    COMPONENT benchmarking
+    DESTINATION bin/benchmarks/libcudf_streaming
+    EXCLUDE_FROM_ALL
+  )
+endif()
 
 add_executable(bench_partition "bench_partition.cpp")
 set_target_properties(
@@ -77,4 +79,6 @@ install(
   EXCLUDE_FROM_ALL
 )
 
-add_subdirectory(streaming)
+if(RAPIDSMPF_HAVE_MPI)
+  add_subdirectory(streaming)
+endif()

--- a/cpp/libcudf_streaming/benchmarks/CMakeLists.txt
+++ b/cpp/libcudf_streaming/benchmarks/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(bench_utils INTERFACE)
 target_sources(bench_utils INTERFACE utils/random_data.cu)
 target_compile_options(bench_utils INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda>)
 
-if(RAPIDSMPF_HAVE_MPI)
+if(RAPIDSMPF_HAVE_MPI AND RAPIDSMPF_HAVE_UCXX)
   add_executable(bench_shuffle "bench_shuffle.cpp")
   set_target_properties(
     bench_shuffle
@@ -79,6 +79,6 @@ install(
   EXCLUDE_FROM_ALL
 )
 
-if(RAPIDSMPF_HAVE_MPI)
+if(RAPIDSMPF_HAVE_MPI AND RAPIDSMPF_HAVE_UCXX)
   add_subdirectory(streaming)
 endif()

--- a/cpp/libcudf_streaming/benchmarks/streaming/CMakeLists.txt
+++ b/cpp/libcudf_streaming/benchmarks/streaming/CMakeLists.txt
@@ -5,7 +5,7 @@
 # cmake-format: on
 # =============================================================================
 
-if(RAPIDSMPF_HAVE_MPI)
+if(RAPIDSMPF_HAVE_MPI AND RAPIDSMPF_HAVE_UCXX)
   add_executable(bench_streaming_shuffle "bench_streaming_shuffle.cpp")
   set_target_properties(
     bench_streaming_shuffle

--- a/cpp/libcudf_streaming/benchmarks/streaming/CMakeLists.txt
+++ b/cpp/libcudf_streaming/benchmarks/streaming/CMakeLists.txt
@@ -5,24 +5,26 @@
 # cmake-format: on
 # =============================================================================
 
-add_executable(bench_streaming_shuffle "bench_streaming_shuffle.cpp")
-set_target_properties(
-  bench_streaming_shuffle
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CUDF_STREAMING_BINARY_DIR}/benchmarks"
-             CXX_STANDARD 20
-             CXX_STANDARD_REQUIRED ON
-             CUDA_STANDARD 20
-             CUDA_STANDARD_REQUIRED ON
-)
-target_link_libraries(
-  bench_streaming_shuffle PRIVATE cudf_streaming rapidsmpf::rapidsmpf ucxx::ucxx MPI::MPI_CXX
-                                  $<TARGET_NAME_IF_EXISTS:conda_env> bench_utils
-)
-install(
-  TARGETS bench_streaming_shuffle
-  COMPONENT benchmarking
-  DESTINATION bin/benchmarks/libcudf_streaming
-  EXCLUDE_FROM_ALL
-)
+if(RAPIDSMPF_HAVE_MPI)
+  add_executable(bench_streaming_shuffle "bench_streaming_shuffle.cpp")
+  set_target_properties(
+    bench_streaming_shuffle
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CUDF_STREAMING_BINARY_DIR}/benchmarks"
+               CXX_STANDARD 20
+               CXX_STANDARD_REQUIRED ON
+               CUDA_STANDARD 20
+               CUDA_STANDARD_REQUIRED ON
+  )
+  target_link_libraries(
+    bench_streaming_shuffle PRIVATE cudf_streaming rapidsmpf::rapidsmpf ucxx::ucxx MPI::MPI_CXX
+                                    $<TARGET_NAME_IF_EXISTS:conda_env> bench_utils
+  )
+  install(
+    TARGETS bench_streaming_shuffle
+    COMPONENT benchmarking
+    DESTINATION bin/benchmarks/libcudf_streaming
+    EXCLUDE_FROM_ALL
+  )
 
-add_subdirectory(ndsh)
+  add_subdirectory(ndsh)
+endif()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Control whether MPI benchmarks are built based on whether the rapidsmpf CMake interface indicates it is supported.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
