### PR TITLE
Skip test_string_agg_aliases on older SQLite versions

### DIFF
--- a/python/cudf_polars/cudf_polars/testing/inject_gpu_engine.py
+++ b/python/cudf_polars/cudf_polars/testing/inject_gpu_engine.py
@@ -291,6 +291,10 @@ EXPECTED_FAILURES: Mapping[str, str] = {
 
 
 TESTS_TO_SKIP: Mapping[str, str] = {
+    # TODO: remove once CI SQLite >= 3.44.0
+    # sqlite3.OperationalError: near "ORDER": syntax error on older versions
+    "tests/unit/sql/test_string_agg.py::test_string_agg_aliases[STRING_AGG]": "SQLite version in CI does not support ORDER BY in string aggregation",
+    "tests/unit/sql/test_string_agg.py::test_string_agg_aliases[GROUP_CONCAT]": "SQLite version in CI does not support ORDER BY in string aggregation",
     "tests/unit/operations/test_profile.py::test_profile_with_cse": "Shape assertion won't match",
     # value_counts / struct-expansion row ordering is not guaranteed, so the GPU
     # result may or may not match CPU. Skip rather than xfail to avoid a flaky


### PR DESCRIPTION
Skips `test_string_agg_aliases[STRING_AGG]` and `test_string_agg_aliases[GROUP_CONCAT]` 
in the cudf-polars-polars test suite by adding them to `TESTS_TO_SKIP` in 
`inject_gpu_engine.py`.

These tests fail with `sqlite3.OperationalError: near "ORDER": syntax error` because 
the CI environment's SQLite version predates 3.44.0, which is when support for 
`ORDER BY` inside `GROUP_CONCAT`/`STRING_AGG` aggregates was introduced. This is a 
CI environment constraint, not a bug in cuDF-polars logic.

TODO: remove the skip entries once CI upgrades to SQLite >= 3.44.0.

Closes #22850
Checklist:

 I am familiar with the Contributing Guidelines
 New or existing tests cover these changes — (N/A: this is a test skip for a CI env limitation)
 The documentation is up to date — (N/A: no API/behavior changes)
