### PR TITLE
Add additional regex gtests for contains, count, findall, and replace

### DIFF
--- a/cpp/tests/strings/contains_tests.cpp
+++ b/cpp/tests/strings/contains_tests.cpp
@@ -1130,3 +1130,129 @@ TEST_F(StringsContainsTests, CrlfDefaultLfOnlyNoExtNewline)
     cudf::test::fixed_width_column_wrapper<bool>({0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cudf::strings::contains_re(view, *prog), expected);
 }
+
+TEST_F(StringsContainsTests, AlternationNullableBranch)
+{
+  // "a(bc|de|fg|)h" has an explicit empty branch that makes 'h' directly reachable after 'a'.
+  auto input = cudf::test::strings_column_wrapper(
+    {"ah", "abch", "adeh", "afghh", "abcde", "a", "h", "", "abcdefgh", "xabchx"});
+  auto sv = cudf::strings_column_view(input);
+
+  auto prog = cudf::strings::regex_program::create("a(bc|de|fg|)h");
+  {
+    auto results = cudf::strings::contains_re(sv, *prog);
+    cudf::test::fixed_width_column_wrapper<bool> expected({1, 1, 1, 1, 0, 0, 0, 0, 1, 1});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+  {
+    auto results = cudf::strings::count_re(sv, *prog);
+    cudf::test::fixed_width_column_wrapper<int32_t> expected({1, 1, 1, 1, 0, 0, 0, 0, 1, 1});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+}
+
+TEST_F(StringsContainsTests, BoundedRepetitionGap)
+{
+  // "ab{0,4}cv" — 'b' may repeat 0–4 times; five or more b's yield no match.
+  auto input = cudf::test::strings_column_wrapper(
+    {"acv", "abcv", "abbcv", "abbbcv", "abbbbcv", "abbbbbcv", "av", "acvx", "xacvx", ""});
+  auto sv = cudf::strings_column_view(input);
+
+  auto prog    = cudf::strings::regex_program::create("ab{0,4}cv");
+  auto results = cudf::strings::contains_re(sv, *prog);
+  cudf::test::fixed_width_column_wrapper<bool> expected({1, 1, 1, 1, 1, 0, 0, 1, 1, 0});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+}
+
+TEST_F(StringsContainsTests, ExtNewlineDotAny)
+{
+  // DEFAULT mode excludes only \n from '.'.
+  // EXT_NEWLINE additionally excludes \r, U+0085 (NEL), U+2028 (LS), and U+2029 (PS).
+  auto input = cudf::test::strings_column_wrapper({"axb",
+                                                   "a\nb",
+                                                   "a\rb",
+                                                   "a\xc2\x85"
+                                                   "b",  // U+0085 NEL between 'a' and 'b'
+                                                   "a\xe2\x80\xa8"
+                                                   "b",  // U+2028 LINE SEPARATOR
+                                                   "a\xe2\x80\xa9"
+                                                   "b",  // U+2029 PARAGRAPH SEPARATOR
+                                                   "abc",
+                                                   ""});
+  auto sv    = cudf::strings_column_view(input);
+
+  // DEFAULT: only \n excluded — \r and extended newlines are matched by '.'
+  {
+    auto prog    = cudf::strings::regex_program::create("a.b");
+    auto results = cudf::strings::contains_re(sv, *prog);
+    cudf::test::fixed_width_column_wrapper<bool> expected({1, 0, 1, 1, 1, 1, 0, 0});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+  // EXT_NEWLINE: \r and all extended newlines also excluded
+  {
+    auto prog =
+      cudf::strings::regex_program::create("a.b", cudf::strings::regex_flags::EXT_NEWLINE);
+    auto results = cudf::strings::contains_re(sv, *prog);
+    cudf::test::fixed_width_column_wrapper<bool> expected({1, 0, 0, 0, 0, 0, 0, 0});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+  // A string composed entirely of extended newlines yields no '.+' match under EXT_NEWLINE
+  {
+    auto input2 = cudf::test::strings_column_wrapper(
+      {"hello",
+       "\xc2\x85\xe2\x80\xa8\xe2\x80\xa9",  // only extended newlines
+       "a\xc2\x85"
+       "b",
+       ""});
+    auto sv2  = cudf::strings_column_view(input2);
+    auto prog = cudf::strings::regex_program::create(".+", cudf::strings::regex_flags::EXT_NEWLINE);
+    auto results = cudf::strings::contains_re(sv2, *prog);
+    cudf::test::fixed_width_column_wrapper<bool> expected2({1, 0, 1, 0});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected2);
+  }
+}
+
+TEST_F(StringsContainsTests, AlternationPriorityCount)
+{
+  // Leftmost-first (first-alternative-wins): the shorter first branch is consumed, leaving
+  // subsequent characters available for the next match.
+  {
+    // "a|aa": "a" wins, so "aaaa" counts as 4 individual matches, not 2 "aa" matches.
+    auto input   = cudf::test::strings_column_wrapper({"aaaa", "aaaaaa", "aaab", "a", "b", ""});
+    auto sv      = cudf::strings_column_view(input);
+    auto prog    = cudf::strings::regex_program::create("a|aa");
+    auto results = cudf::strings::count_re(sv, *prog);
+    cudf::test::fixed_width_column_wrapper<int32_t> expected({4, 6, 3, 1, 0, 0});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+  {
+    // "foo|foobar": "foo" wins when both alternatives start at the same position.
+    auto input   = cudf::test::strings_column_wrapper({"foo", "foobar", "foofoo", "bar", ""});
+    auto sv      = cudf::strings_column_view(input);
+    auto prog    = cudf::strings::regex_program::create("foo|foobar");
+    auto results = cudf::strings::count_re(sv, *prog);
+    cudf::test::fixed_width_column_wrapper<int32_t> expected({1, 1, 2, 0, 0});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+}
+
+TEST_F(StringsContainsTests, LazyQuantifiers)
+{
+  // Lazy star/plus in non-DOTALL mode: prefer the shortest match.
+  auto input = cudf::test::strings_column_wrapper(
+    {"ab", "abc", "xdefx", "xghix", "jkl", "abc xdefx xghix jkl"});
+  auto sv = cudf::strings_column_view(input);
+
+  {
+    auto prog    = cudf::strings::regex_program::create("x.*?x");
+    auto results = cudf::strings::contains_re(sv, *prog);
+    cudf::test::fixed_width_column_wrapper<bool> expected({0, 0, 1, 1, 0, 1});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+  {
+    auto prog    = cudf::strings::regex_program::create("x.+?x");
+    auto results = cudf::strings::contains_re(sv, *prog);
+    cudf::test::fixed_width_column_wrapper<bool> expected({0, 0, 1, 1, 0, 1});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+}

--- a/cpp/tests/strings/findall_tests.cpp
+++ b/cpp/tests/strings/findall_tests.cpp
@@ -219,28 +219,6 @@ TEST_F(StringsFindallTests, OneCaptureGroup)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
 }
 
-TEST_F(StringsFindallTests, EmptyMatch)
-{
-  auto input = cudf::test::strings_column_wrapper({" ", "hello world", "é\r\ny"});
-  auto sv    = cudf::strings_column_view(input);
-  using LCW  = cudf::test::lists_column_wrapper<cudf::string_view>;
-
-  auto expected = LCW({LCW{}, LCW{}, LCW{}});
-  auto prog     = cudf::strings::regex_program::create("^$", cudf::strings::regex_flags::MULTILINE);
-  auto results  = cudf::strings::findall(sv, *prog);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
-
-  expected = LCW({LCW{}, LCW{"", "", "", ""}, LCW{"", "", "", ""}});
-  prog     = cudf::strings::regex_program::create("\\b");
-  results  = cudf::strings::findall(sv, *prog);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
-
-  expected = LCW({LCW{}, LCW{"", "", "", ""}, LCW{"", "", "", ""}});
-  prog     = cudf::strings::regex_program::create("(\\b)");
-  results  = cudf::strings::findall(sv, *prog);
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
-}
-
 TEST_F(StringsFindallTests, Errors)
 {
   auto input   = cudf::test::strings_column_wrapper({"1 One", "2 Two", "3 Three 4 Four", ""});
@@ -248,4 +226,20 @@ TEST_F(StringsFindallTests, Errors)
   auto pattern = std::string("(\\d+)-(\\w+)");
   auto prog    = cudf::strings::regex_program::create(pattern);
   EXPECT_THROW(cudf::strings::findall(sv, *prog), cudf::logic_error);
+}
+
+TEST_F(StringsFindallTests, AlternationPriorityFirstWins)
+{
+  // Leftmost-first (first-alternative-wins): "foo" is found instead of "foobar" when both
+  // alternatives start at the same position.
+  auto input =
+    cudf::test::strings_column_wrapper({"foo", "foobar", "foobarbaz", "bar", "xfoobar", ""});
+  auto sv   = cudf::strings_column_view(input);
+  auto prog = cudf::strings::regex_program::create(
+    "foo|foobar", cudf::strings::regex_flags::DEFAULT, cudf::strings::capture_groups::NON_CAPTURE);
+  auto results = cudf::strings::findall(sv, *prog);
+
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+  LCW expected({LCW{"foo"}, LCW{"foo"}, LCW{"foo"}, LCW{}, LCW{"foo"}, LCW{}});
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
 }

--- a/cpp/tests/strings/findall_tests.cpp
+++ b/cpp/tests/strings/findall_tests.cpp
@@ -219,15 +219,6 @@ TEST_F(StringsFindallTests, OneCaptureGroup)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
 }
 
-TEST_F(StringsFindallTests, Errors)
-{
-  auto input   = cudf::test::strings_column_wrapper({"1 One", "2 Two", "3 Three 4 Four", ""});
-  auto sv      = cudf::strings_column_view(input);
-  auto pattern = std::string("(\\d+)-(\\w+)");
-  auto prog    = cudf::strings::regex_program::create(pattern);
-  EXPECT_THROW(cudf::strings::findall(sv, *prog), cudf::logic_error);
-}
-
 TEST_F(StringsFindallTests, AlternationPriorityFirstWins)
 {
   // Leftmost-first (first-alternative-wins): "foo" is found instead of "foobar" when both
@@ -242,4 +233,35 @@ TEST_F(StringsFindallTests, AlternationPriorityFirstWins)
   using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
   LCW expected({LCW{"foo"}, LCW{"foo"}, LCW{"foo"}, LCW{}, LCW{"foo"}, LCW{}});
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
+}
+
+TEST_F(StringsFindallTests, EmptyMatch)
+{
+  auto input = cudf::test::strings_column_wrapper({" ", "hello world", "é\r\ny"});
+  auto sv    = cudf::strings_column_view(input);
+  using LCW  = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  auto expected = LCW({LCW{}, LCW{}, LCW{}});
+  auto prog     = cudf::strings::regex_program::create("^$", cudf::strings::regex_flags::MULTILINE);
+  auto results  = cudf::strings::findall(sv, *prog);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
+
+  expected = LCW({LCW{}, LCW{"", "", "", ""}, LCW{"", "", "", ""}});
+  prog     = cudf::strings::regex_program::create("\\b");
+  results  = cudf::strings::findall(sv, *prog);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
+
+  expected = LCW({LCW{}, LCW{"", "", "", ""}, LCW{"", "", "", ""}});
+  prog     = cudf::strings::regex_program::create("(\\b)");
+  results  = cudf::strings::findall(sv, *prog);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
+}
+
+TEST_F(StringsFindallTests, Errors)
+{
+  auto input   = cudf::test::strings_column_wrapper({"1 One", "2 Two", "3 Three 4 Four", ""});
+  auto sv      = cudf::strings_column_view(input);
+  auto pattern = std::string("(\\d+)-(\\w+)");
+  auto prog    = cudf::strings::regex_program::create(pattern);
+  EXPECT_THROW(cudf::strings::findall(sv, *prog), cudf::logic_error);
 }

--- a/cpp/tests/strings/replace_regex_tests.cpp
+++ b/cpp/tests/strings/replace_regex_tests.cpp
@@ -535,3 +535,30 @@ TEST_F(StringsReplaceRegexTest, CrlfEdgeCasesExtNewline)
                                    str_col(&edge_case::exp_abc_backref));
   }
 }
+
+TEST_F(StringsReplaceRegexTest, AlternationPriorityFirstWins)
+{
+  // Leftmost-first (first-alternative-wins): when a shorter first alternative is a prefix of a
+  // longer second, the shorter match is consumed and the remainder is left for the next search.
+  auto repl = cudf::string_scalar("X");
+
+  {
+    // "foo" wins over "foobar": "foobar" becomes "Xbar".
+    auto input =
+      cudf::test::strings_column_wrapper({"foo", "foobar", "foobarbaz", "bar", "xfoobar", ""});
+    auto sv      = cudf::strings_column_view(input);
+    auto prog    = cudf::strings::regex_program::create("foo|foobar");
+    auto results = cudf::strings::replace_re(sv, *prog, repl);
+    cudf::test::strings_column_wrapper expected({"X", "Xbar", "Xbarbaz", "bar", "xXbar", ""});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+  {
+    // "cat" wins over "catch": "catch" becomes "Xch".
+    auto input   = cudf::test::strings_column_wrapper({"cat", "catch", "catfish", "dog", ""});
+    auto sv      = cudf::strings_column_view(input);
+    auto prog    = cudf::strings::regex_program::create("cat|catch");
+    auto results = cudf::strings::replace_re(sv, *prog, repl);
+    cudf::test::strings_column_wrapper expected({"X", "Xch", "Xfish", "dog", ""});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+}


### PR DESCRIPTION
## Description
Adds some additional gtests for regex patterns to help validate optimizations in follow on PRs.

This is part of splitting out some of the work for #21936

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
