### PR TITLE
Use google cloud read-only Maven Central mirror

### DIFF
--- a/ci/test_java.sh
+++ b/ci/test_java.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -45,7 +45,7 @@ export LIBCUDF_LARGE_STRINGS_ENABLED=0
 
 rapids-logger "Run Java tests"
 pushd java
-timeout 30m mvn test -B -DCUDF_JNI_ENABLE_PROFILING=OFF
+timeout 30m mvn test -B -s ci/test_java_settings.xml -DCUDF_JNI_ENABLE_PROFILING=OFF
 popd
 
 rapids-logger "Test script exiting with value: $EXITCODE"

--- a/java/ci/test_java_settings.xml
+++ b/java/ci/test_java_settings.xml
@@ -1,0 +1,10 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>gcs-maven-central</id>
+      <name>GCS mirror of Maven Central</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
## Description
Creates a settings.xml file for the java-tests mvn build to use Google Cloud's read-only Maven Central mirror to help prevent 429 errors in the java-tests GHA runner.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
