### PR TITLE
ci: reduce timeout for cudf_streaming C++ tests to 5m

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -34,7 +34,7 @@ fi
 
 if (( SUITEERROR == 0 )); then
     rapids-logger "Run libcudf_streaming gtests"
-    timeout 30m ./ci/run_cudf_streaming_ctests.sh -j20
+    timeout 5m ./ci/run_cudf_streaming_ctests.sh -j20
     SUITEERROR=$?
 fi
 


### PR DESCRIPTION
## Description

Reduce the `timeout` for `cudf_streaming` C++ tests from 30m to 5m in `ci/test_cpp.sh`.

The cudf_streaming tests are lightweight and complete quickly. The 30m timeout was kept during the initial PR (#22747) out of caution after reviewer feedback (https://github.com/rapidsai/cudf/pull/22747#discussion_r3344137304, https://github.com/rapidsai/cudf/pull/22747#discussion_r3350958574), but 5m provides ample headroom while catching hangs much sooner.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.