### PR TITLE
[MLIR] MaskedType: core type, constructor, accessors

### DIFF
--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -35,13 +35,15 @@ def _pack_masked_result(builder, target_type, result_value, result_valid):
 
 
 class MaskedTypeModel(PrimitiveModel):
-    def __init__(self, dmm, fe_type):
-        value_mlir = dmm.lookup(fe_type.value_type).get_value_type()
-        valid_mlir = dmm.lookup(types.boolean).get_value_type()
-        be_type = llvm.StructType.new_identified(
-            fe_type.name, [value_mlir, valid_mlir]
+    def __init__(self, data_model_manager, masked_type):
+        value_mlir = data_model_manager.lookup(
+            masked_type.value_type
+        ).get_value_type()
+        valid_mlir = data_model_manager.lookup(types.boolean).get_value_type()
+        struct_type = llvm.StructType.new_identified(
+            masked_type.name, [value_mlir, valid_mlir]
         )
-        super().__init__(dmm, fe_type, be_type)
+        super().__init__(data_model_manager, masked_type, struct_type)
 
 
 def _lower_masked_constructor(builder, target, args, kwargs):

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -10,16 +10,15 @@ Scope of this PR (intentionally minimal):
   two-field LLVM struct ``{value_ty, i1}``;
 * lowering of the ``Masked(value, valid)`` constructor;
 * lowering of ``.value`` and ``.valid`` accessors via a generic
-  getattr;
-* lowering of ``pack_return`` for ``MaskedType`` inputs (identity)
-  and for plain numeric/boolean scalar inputs (wrap with valid=True).
+  getattr.
 
 Out of scope (deferred to subsequent PRs in the stack):
 
+* ``pack_return`` (the scalar-vs-Masked return bridge for UDFs);
 * binary / unary / comparison op lowerings;
 * casts between ``MaskedType`` value types;
 * scalar -> ``Masked`` implicit casts (used by ``return literal``
-  patterns); ``pack_return`` covers the explicit case at this layer.
+  patterns).
 
 Importing this module registers lowerings with ``numba_cuda_mlir``.
 """
@@ -28,12 +27,12 @@ from __future__ import annotations
 
 from numba_cuda_mlir import types
 from numba_cuda_mlir._mlir import ir as mlir_ir
-from numba_cuda_mlir._mlir.dialects import arith, llvm
+from numba_cuda_mlir._mlir.dialects import llvm
 from numba_cuda_mlir.extending import lowering_registry
 from numba_cuda_mlir.lowering_utilities import convert
 from numba_cuda_mlir.models import PrimitiveModel, register_model
 
-from cudf.core.udf.api import Masked, pack_return
+from cudf.core.udf.api import Masked
 from cudf.core.udf.mlir_backend.masked_typing import MaskedType
 
 
@@ -124,46 +123,6 @@ def _register():
             builder.get_numba_type(target.name)
         )
         builder.store_var(target, convert(field_value, target_mlir_ty))
-
-    # ``pack_return(masked)`` -> identity. This gets called by user UDFs
-    # whose return value is already a ``Masked``.
-    def _lower_pack_return_masked(builder, target, args, kwargs):
-        builder.store_var(target, builder.load_var(args[0]))
-
-    lower(pack_return, MaskedType)(_lower_pack_return_masked)
-
-    # ``pack_return(scalar)`` -> ``Masked(scalar, True)``. Allows UDFs
-    # that ``return some_int`` to type-unify with a Masked return shape.
-    def _lower_pack_return_scalar(builder, target, args, kwargs):
-        target_type = builder.get_numba_type(target.name)
-        value_mlir_ty = builder.get_mlir_type(target_type.value_type)
-        scalar_val = convert(builder.load_var(args[0]), value_mlir_ty)
-        valid_one = arith.constant(
-            result=builder.get_mlir_type(types.boolean), value=1
-        )
-        struct_val = _pack_masked_result(
-            builder, target_type, scalar_val, valid_one
-        )
-        builder.store_var(target, struct_val)
-
-    # Register one entry per concrete numeric scalar shape so the
-    # dispatcher finds an exact match rather than falling through to
-    # ``types.Number`` (which would shadow Boolean).
-    for scalar_ty in (
-        types.Integer,
-        types.int8,
-        types.int16,
-        types.int32,
-        types.int64,
-        types.uint8,
-        types.uint16,
-        types.uint32,
-        types.uint64,
-        types.float32,
-        types.float64,
-        types.boolean,
-    ):
-        lower(pack_return, scalar_ty)(_lower_pack_return_scalar)
 
 
 _register()

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -44,9 +44,6 @@ def _register():
     lower = lowering_registry.lower
     lower_getattr_generic = lowering_registry.lower_getattr_generic
 
-    # Data model: a MaskedType is an LLVM struct {value_ty, i1}. Each
-    # parameterization (Masked(int64), Masked(float64), ...) gets its
-    # own identified struct so MLIR can keep them distinct.
     @register_model(MaskedType)
     class MaskedTypeModel(PrimitiveModel):
         def __init__(self, dmm, fe_type):
@@ -57,7 +54,6 @@ def _register():
             )
             super().__init__(dmm, fe_type, be_type)
 
-    # ``Masked(value, valid)`` -> packed struct.
     def _lower_masked_constructor(builder, target, args, kwargs):
         target_type = builder.get_numba_type(target.name)
         val_var, valid_var = args
@@ -75,11 +71,10 @@ def _register():
         builder.store_var(target, struct_val)
 
     lower(Masked, types.Any, types.boolean)(_lower_masked_constructor)
-    # Row-apply may pass a literal True/False for ``valid``, typed as
+    # Row apply may pass a literal True/False for ``valid``, typed as
     # ``Literal[bool]``; accept that shape too.
     lower(Masked, types.Any, types.Literal)(_lower_masked_constructor)
 
-    # Generic getattr for ``.value`` and ``.valid``.
     @lower_getattr_generic(MaskedType)
     def _lower_masked_getattr(context, builder, target, value, attr):
         struct_value = builder.load_var(value)

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -45,6 +45,11 @@ class MaskedTypeModel(PrimitiveModel):
 
 
 def _lower_masked_constructor(builder, target, args, kwargs):
+    if kwargs:
+        raise TypeError(
+            "Masked(value, valid) does not accept keyword arguments; "
+            f"got {kwargs!r}"
+        )
     target_type = builder.get_numba_type(target.name)
     val_var, valid_var = args
 

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -113,7 +113,6 @@ def _register() -> None:
     the registry to be ready.
     """
     lower = lowering_registry.lower
-    lower_getattr_generic = lowering_registry.lower_getattr_generic
 
     register_model(MaskedType)(MaskedTypeModel)
 
@@ -122,7 +121,7 @@ def _register() -> None:
     # ``Literal[bool]``; accept that shape too.
     lower(Masked, types.Any, types.Literal)(_lower_masked_constructor)
 
-    lower_getattr_generic(MaskedType)(_lower_masked_getattr)
+    lowering_registry.lower_getattr_generic(MaskedType)(_lower_masked_getattr)
 
 
 _register()

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -34,67 +34,72 @@ def _pack_masked_result(builder, target_type, result_value, result_valid):
     return with_valid
 
 
+class MaskedTypeModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        value_mlir = dmm.lookup(fe_type.value_type).get_value_type()
+        valid_mlir = dmm.lookup(types.boolean).get_value_type()
+        be_type = llvm.StructType.new_identified(
+            fe_type.name, [value_mlir, valid_mlir]
+        )
+        super().__init__(dmm, fe_type, be_type)
+
+
+def _lower_masked_constructor(builder, target, args, kwargs):
+    target_type = builder.get_numba_type(target.name)
+    val_var, valid_var = args
+
+    # Coerce the raw value to the target's declared MLIR value type
+    # (handles e.g. Literal[bool](True) flowing in for ``valid``).
+    value_mlir_ty = builder.get_mlir_type(target_type.value_type)
+    valid_mlir_ty = builder.get_mlir_type(types.boolean)
+    value_mlir = convert(builder.load_var(val_var), value_mlir_ty)
+    valid_mlir = convert(builder.load_var(valid_var), valid_mlir_ty)
+
+    struct_val = _pack_masked_result(
+        builder, target_type, value_mlir, valid_mlir
+    )
+    builder.store_var(target, struct_val)
+
+
+def _lower_masked_getattr(context, builder, target, value, attr):
+    struct_value = builder.load_var(value)
+    if attr == "value":
+        field_index = 0
+    elif attr == "valid":
+        field_index = 1
+    else:
+        raise AttributeError(f"MaskedType has no attribute {attr!r}")
+    struct_ty = llvm.StructType(struct_value.type)
+    field_mlir_ty = struct_ty.body[field_index]
+    field_value = llvm.extractvalue(
+        res=field_mlir_ty,
+        container=struct_value,
+        position=mlir_ir.DenseI64ArrayAttr.get([field_index]),
+    )
+    target_mlir_ty = builder.get_mlir_type(
+        builder.get_numba_type(target.name)
+    )
+    builder.store_var(target, convert(field_value, target_mlir_ty))
+
+
 def _register():
     """Register the data model and lowerings with ``numba_cuda_mlir``.
 
-    Called once at module import; deferred from module top-level so
-    helper definitions above remain available for tests/imports without
-    needing the registry to be ready.
+    Called once at module import; deferred from module top-level so the
+    definitions above remain available for tests/imports without needing
+    the registry to be ready.
     """
     lower = lowering_registry.lower
     lower_getattr_generic = lowering_registry.lower_getattr_generic
 
-    @register_model(MaskedType)
-    class MaskedTypeModel(PrimitiveModel):
-        def __init__(self, dmm, fe_type):
-            value_mlir = dmm.lookup(fe_type.value_type).get_value_type()
-            valid_mlir = dmm.lookup(types.boolean).get_value_type()
-            be_type = llvm.StructType.new_identified(
-                fe_type.name, [value_mlir, valid_mlir]
-            )
-            super().__init__(dmm, fe_type, be_type)
-
-    def _lower_masked_constructor(builder, target, args, kwargs):
-        target_type = builder.get_numba_type(target.name)
-        val_var, valid_var = args
-
-        # Coerce the raw value to the target's declared MLIR value type
-        # (handles e.g. Literal[bool](True) flowing in for ``valid``).
-        value_mlir_ty = builder.get_mlir_type(target_type.value_type)
-        valid_mlir_ty = builder.get_mlir_type(types.boolean)
-        value_mlir = convert(builder.load_var(val_var), value_mlir_ty)
-        valid_mlir = convert(builder.load_var(valid_var), valid_mlir_ty)
-
-        struct_val = _pack_masked_result(
-            builder, target_type, value_mlir, valid_mlir
-        )
-        builder.store_var(target, struct_val)
+    register_model(MaskedType)(MaskedTypeModel)
 
     lower(Masked, types.Any, types.boolean)(_lower_masked_constructor)
     # Row apply may pass a literal True/False for ``valid``, typed as
     # ``Literal[bool]``; accept that shape too.
     lower(Masked, types.Any, types.Literal)(_lower_masked_constructor)
 
-    @lower_getattr_generic(MaskedType)
-    def _lower_masked_getattr(context, builder, target, value, attr):
-        struct_value = builder.load_var(value)
-        if attr == "value":
-            field_index = 0
-        elif attr == "valid":
-            field_index = 1
-        else:
-            raise AttributeError(f"MaskedType has no attribute {attr!r}")
-        struct_ty = llvm.StructType(struct_value.type)
-        field_mlir_ty = struct_ty.body[field_index]
-        field_value = llvm.extractvalue(
-            res=field_mlir_ty,
-            container=struct_value,
-            position=mlir_ir.DenseI64ArrayAttr.get([field_index]),
-        )
-        target_mlir_ty = builder.get_mlir_type(
-            builder.get_numba_type(target.name)
-        )
-        builder.store_var(target, convert(field_value, target_mlir_ty))
+    lower_getattr_generic(MaskedType)(_lower_masked_getattr)
 
 
 _register()

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLIR (numba_cuda_mlir) lowering for ``MaskedType`` -- mirrors the typing
+surface introduced in :mod:`cudf.core.udf.mlir_backend.masked_typing`.
+
+Scope of this PR (intentionally minimal):
+
+* a ``PrimitiveModel`` data model registering ``MaskedType`` as a
+  two-field LLVM struct ``{value_ty, i1}``;
+* lowering of the ``Masked(value, valid)`` constructor;
+* lowering of ``.value`` and ``.valid`` accessors via a generic
+  getattr;
+* lowering of ``pack_return`` for ``MaskedType`` inputs (identity)
+  and for plain numeric/boolean scalar inputs (wrap with valid=True).
+
+Out of scope (deferred to subsequent PRs in the stack):
+
+* binary / unary / comparison op lowerings;
+* casts between ``MaskedType`` value types;
+* scalar -> ``Masked`` implicit casts (used by ``return literal``
+  patterns); ``pack_return`` covers the explicit case at this layer.
+
+Importing this module registers lowerings with ``numba_cuda_mlir``.
+"""
+
+from __future__ import annotations
+
+from numba_cuda_mlir import types
+from numba_cuda_mlir._mlir import ir as mlir_ir
+from numba_cuda_mlir._mlir.dialects import arith, llvm
+from numba_cuda_mlir.extending import lowering_registry
+from numba_cuda_mlir.lowering_utilities import convert
+from numba_cuda_mlir.models import PrimitiveModel, register_model
+
+from cudf.core.udf.api import Masked, pack_return
+from cudf.core.udf.mlir_backend.masked_typing import MaskedType
+
+
+def _pack_masked_result(builder, target_type, result_value, result_valid):
+    """Build a ``MaskedType`` struct value from raw ``value`` and ``valid``.
+
+    Used by the constructor lowering and by ``pack_return`` for plain
+    scalars.
+    """
+    struct_ty = builder.get_mlir_type(target_type)
+    undef = llvm.UndefOp(struct_ty)
+    with_value = llvm.insertvalue(
+        container=undef,
+        value=result_value,
+        position=mlir_ir.DenseI64ArrayAttr.get([0]),
+    )
+    with_valid = llvm.insertvalue(
+        container=with_value,
+        value=result_valid,
+        position=mlir_ir.DenseI64ArrayAttr.get([1]),
+    )
+    return with_valid
+
+
+def _register():
+    """Register the data model and lowerings with ``numba_cuda_mlir``.
+
+    Called once at module import; deferred from module top-level so
+    helper definitions above remain available for tests/imports without
+    needing the registry to be ready.
+    """
+    lower = lowering_registry.lower
+    lower_getattr_generic = lowering_registry.lower_getattr_generic
+
+    # Data model: a MaskedType is an LLVM struct {value_ty, i1}. Each
+    # parameterization (Masked(int64), Masked(float64), ...) gets its
+    # own identified struct so MLIR can keep them distinct.
+    @register_model(MaskedType)
+    class MaskedTypeModel(PrimitiveModel):
+        def __init__(self, dmm, fe_type):
+            value_mlir = dmm.lookup(fe_type.value_type).get_value_type()
+            valid_mlir = dmm.lookup(types.boolean).get_value_type()
+            be_type = llvm.StructType.new_identified(
+                fe_type.name, [value_mlir, valid_mlir]
+            )
+            super().__init__(dmm, fe_type, be_type)
+
+    # ``Masked(value, valid)`` -> packed struct.
+    def _lower_masked_constructor(builder, target, args, kwargs):
+        target_type = builder.get_numba_type(target.name)
+        val_var, valid_var = args
+
+        # Coerce the raw value to the target's declared MLIR value type
+        # (handles e.g. Literal[bool](True) flowing in for ``valid``).
+        value_mlir_ty = builder.get_mlir_type(target_type.value_type)
+        valid_mlir_ty = builder.get_mlir_type(types.boolean)
+        value_mlir = convert(builder.load_var(val_var), value_mlir_ty)
+        valid_mlir = convert(builder.load_var(valid_var), valid_mlir_ty)
+
+        struct_val = _pack_masked_result(
+            builder, target_type, value_mlir, valid_mlir
+        )
+        builder.store_var(target, struct_val)
+
+    lower(Masked, types.Any, types.boolean)(_lower_masked_constructor)
+    # Row-apply may pass a literal True/False for ``valid``, typed as
+    # ``Literal[bool]``; accept that shape too.
+    lower(Masked, types.Any, types.Literal)(_lower_masked_constructor)
+
+    # Generic getattr for ``.value`` and ``.valid``.
+    @lower_getattr_generic(MaskedType)
+    def _lower_masked_getattr(context, builder, target, value, attr):
+        struct_value = builder.load_var(value)
+        if attr == "value":
+            field_index = 0
+        elif attr == "valid":
+            field_index = 1
+        else:
+            raise AttributeError(f"MaskedType has no attribute {attr!r}")
+        struct_ty = llvm.StructType(struct_value.type)
+        field_mlir_ty = struct_ty.body[field_index]
+        field_value = llvm.extractvalue(
+            res=field_mlir_ty,
+            container=struct_value,
+            position=mlir_ir.DenseI64ArrayAttr.get([field_index]),
+        )
+        target_mlir_ty = builder.get_mlir_type(
+            builder.get_numba_type(target.name)
+        )
+        builder.store_var(target, convert(field_value, target_mlir_ty))
+
+    # ``pack_return(masked)`` -> identity. This gets called by user UDFs
+    # whose return value is already a ``Masked``.
+    def _lower_pack_return_masked(builder, target, args, kwargs):
+        builder.store_var(target, builder.load_var(args[0]))
+
+    lower(pack_return, MaskedType)(_lower_pack_return_masked)
+
+    # ``pack_return(scalar)`` -> ``Masked(scalar, True)``. Allows UDFs
+    # that ``return some_int`` to type-unify with a Masked return shape.
+    def _lower_pack_return_scalar(builder, target, args, kwargs):
+        target_type = builder.get_numba_type(target.name)
+        value_mlir_ty = builder.get_mlir_type(target_type.value_type)
+        scalar_val = convert(builder.load_var(args[0]), value_mlir_ty)
+        valid_one = arith.constant(
+            result=builder.get_mlir_type(types.boolean), value=1
+        )
+        struct_val = _pack_masked_result(
+            builder, target_type, scalar_val, valid_one
+        )
+        builder.store_var(target, struct_val)
+
+    # Register one entry per concrete numeric scalar shape so the
+    # dispatcher finds an exact match rather than falling through to
+    # ``types.Number`` (which would shadow Boolean).
+    for scalar_ty in (
+        types.Integer,
+        types.int8,
+        types.int16,
+        types.int32,
+        types.int64,
+        types.uint8,
+        types.uint16,
+        types.uint32,
+        types.uint64,
+        types.float32,
+        types.float64,
+        types.boolean,
+    ):
+        lower(pack_return, scalar_ty)(_lower_pack_return_scalar)
+
+
+_register()

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from numba_cuda_mlir import types
 from numba_cuda_mlir._mlir import ir as mlir_ir
 from numba_cuda_mlir._mlir.dialects import llvm
@@ -12,8 +14,20 @@ from numba_cuda_mlir.models import PrimitiveModel, register_model
 from cudf.core.udf.api import Masked
 from cudf.core.udf.mlir_backend.masked_typing import MaskedType
 
+if TYPE_CHECKING:
+    from numba_cuda_mlir.mlir_lowering import MLIRLower
+    from numba_cuda_mlir.numba_cuda.core.ir import Var
+    from numba_cuda_mlir.numba_cuda.datamodel.manager import (
+        DataModelManager,
+    )
 
-def _pack_masked(builder, target_type, value, valid):
+
+def _pack_masked(
+    builder: MLIRLower,
+    target_type: MaskedType,
+    value: mlir_ir.Value,
+    valid: mlir_ir.Value,
+) -> mlir_ir.Value:
     """Build a ``MaskedType`` struct value from a ``value`` and a ``valid`` bit.
 
     Used by the constructor lowering and by ``pack_return`` for plain
@@ -35,7 +49,9 @@ def _pack_masked(builder, target_type, value, valid):
 
 
 class MaskedTypeModel(PrimitiveModel):
-    def __init__(self, data_model_manager, masked_type):
+    def __init__(
+        self, data_model_manager: DataModelManager, masked_type: MaskedType
+    ) -> None:
         value_mlir = data_model_manager.lookup(
             masked_type.value_type
         ).get_value_type()
@@ -46,7 +62,9 @@ class MaskedTypeModel(PrimitiveModel):
         super().__init__(data_model_manager, masked_type, struct_type)
 
 
-def _lower_masked_constructor(builder, target, args, kwargs):
+def _lower_masked_constructor(
+    builder: MLIRLower, target: Var, args: list[Var], kwargs: list
+) -> None:
     if kwargs:
         raise TypeError(
             "Masked(value, valid) does not accept keyword arguments; "
@@ -62,13 +80,13 @@ def _lower_masked_constructor(builder, target, args, kwargs):
     value_mlir = convert(builder.load_var(val_var), value_mlir_ty)
     valid_mlir = convert(builder.load_var(valid_var), valid_mlir_ty)
 
-    struct_val = _pack_masked(
-        builder, target_type, value_mlir, valid_mlir
-    )
+    struct_val = _pack_masked(builder, target_type, value_mlir, valid_mlir)
     builder.store_var(target, struct_val)
 
 
-def _lower_masked_getattr(context, builder, target, value, attr):
+def _lower_masked_getattr(
+    context, builder: MLIRLower, target: Var, value: Var, attr: str
+) -> None:
     struct_value = builder.load_var(value)
     if attr == "value":
         field_index = 0
@@ -83,13 +101,11 @@ def _lower_masked_getattr(context, builder, target, value, attr):
         container=struct_value,
         position=mlir_ir.DenseI64ArrayAttr.get([field_index]),
     )
-    target_mlir_ty = builder.get_mlir_type(
-        builder.get_numba_type(target.name)
-    )
+    target_mlir_ty = builder.get_mlir_type(builder.get_numba_type(target.name))
     builder.store_var(target, convert(field_value, target_mlir_ty))
 
 
-def _register():
+def _register() -> None:
     """Register the data model and lowerings with ``numba_cuda_mlir``.
 
     Called once at module import; deferred from module top-level so the

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -13,8 +13,8 @@ from cudf.core.udf.api import Masked
 from cudf.core.udf.mlir_backend.masked_typing import MaskedType
 
 
-def _pack_masked_result(builder, target_type, result_value, result_valid):
-    """Build a ``MaskedType`` struct value from raw ``value`` and ``valid``.
+def _pack_masked(builder, target_type, value, valid):
+    """Build a ``MaskedType`` struct value from a ``value`` and a ``valid`` bit.
 
     Used by the constructor lowering and by ``pack_return`` for plain
     scalars.
@@ -23,12 +23,12 @@ def _pack_masked_result(builder, target_type, result_value, result_valid):
     undef = llvm.UndefOp(struct_ty)
     with_value = llvm.insertvalue(
         container=undef,
-        value=result_value,
+        value=value,
         position=mlir_ir.DenseI64ArrayAttr.get([0]),
     )
     with_valid = llvm.insertvalue(
         container=with_value,
-        value=result_valid,
+        value=valid,
         position=mlir_ir.DenseI64ArrayAttr.get([1]),
     )
     return with_valid
@@ -62,7 +62,7 @@ def _lower_masked_constructor(builder, target, args, kwargs):
     value_mlir = convert(builder.load_var(val_var), value_mlir_ty)
     valid_mlir = convert(builder.load_var(valid_var), valid_mlir_ty)
 
-    struct_val = _pack_masked_result(
+    struct_val = _pack_masked(
         builder, target_type, value_mlir, valid_mlir
     )
     builder.store_var(target, struct_val)

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_lowering.py
@@ -1,28 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
-"""
-MLIR (numba_cuda_mlir) lowering for ``MaskedType`` -- mirrors the typing
-surface introduced in :mod:`cudf.core.udf.mlir_backend.masked_typing`.
-
-Scope of this PR (intentionally minimal):
-
-* a ``PrimitiveModel`` data model registering ``MaskedType`` as a
-  two-field LLVM struct ``{value_ty, i1}``;
-* lowering of the ``Masked(value, valid)`` constructor;
-* lowering of ``.value`` and ``.valid`` accessors via a generic
-  getattr.
-
-Out of scope (deferred to subsequent PRs in the stack):
-
-* ``pack_return`` (the scalar-vs-Masked return bridge for UDFs);
-* binary / unary / comparison op lowerings;
-* casts between ``MaskedType`` value types;
-* scalar -> ``Masked`` implicit casts (used by ``return literal``
-  patterns).
-
-Importing this module registers lowerings with ``numba_cuda_mlir``.
-"""
-
 from __future__ import annotations
 
 from numba_cuda_mlir import types

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
@@ -59,16 +59,16 @@ class MaskedConstructor(ConcreteTemplate):
     ]
 
 
-# ``m.value`` -> inner value type; ``m.valid`` -> boolean.
+# ``m.value`` -> inner value type; ``m.valid`` -> boolean. ``AttributeTemplate``
+# dispatches ``resolve_<attr>`` methods automatically.
 class MaskedTypeAttrs(AttributeTemplate):
     key = MaskedType
 
-    def generic_resolve(self, typ, attr):
-        if attr == "value":
-            return typ.value_type
-        if attr == "valid":
-            return types.boolean
-        return None
+    def resolve_value(self, typ):
+        return typ.value_type
+
+    def resolve_valid(self, typ):
+        return types.boolean
 
 
 def _register():

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
@@ -50,32 +50,33 @@ class MaskedType(types.Type):
         return hash(repr(self))
 
 
+# ``Masked(value, valid)`` constructor: produces a ``Masked(value_ty)``.
+class MaskedConstructor(ConcreteTemplate):
+    key = Masked
+    cases = [
+        nb_signature(MaskedType(t), t, types.boolean)
+        for t in _supported_value_type_instances
+    ]
+
+
+# ``m.value`` -> inner value type; ``m.valid`` -> boolean.
+class MaskedTypeAttrs(AttributeTemplate):
+    key = MaskedType
+
+    def generic_resolve(self, typ, attr):
+        if attr == "value":
+            return typ.value_type
+        if attr == "valid":
+            return types.boolean
+        return None
+
+
 def _register():
     """Register typing for ``Masked`` and ``MaskedType`` attributes with
     ``numba_cuda_mlir``. Called once at module import.
     """
-
-    # ``Masked(value, valid)`` constructor: produces a ``Masked(value_ty)``.
-    class MaskedConstructor(ConcreteTemplate):
-        key = Masked
-        cases = [
-            nb_signature(MaskedType(t), t, types.boolean)
-            for t in _supported_value_type_instances
-        ]
-
     typing_registry.register_global(Masked, types.Function(MaskedConstructor))
-
-    # ``m.value`` -> inner value type; ``m.valid`` -> boolean.
-    @typing_registry.register_attr
-    class MaskedTypeAttrs(AttributeTemplate):
-        key = MaskedType
-
-        def generic_resolve(self, typ, attr):
-            if attr == "value":
-                return typ.value_type
-            if attr == "valid":
-                return types.boolean
-            return None
+    typing_registry.register_attr(MaskedTypeAttrs)
 
 
 _register()

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
@@ -11,12 +11,11 @@ Scope of this PR (intentionally minimal):
   ``float32``, ``float64``, ``boolean``) -- string / datetime / timedelta
   cases are layered in later PRs;
 * the ``Masked(value, valid)`` constructor;
-* the ``.value`` and ``.valid`` attributes;
-* the ``pack_return`` template that bridges plain scalars and
-  ``MaskedType``.
+* the ``.value`` and ``.valid`` attributes.
 
 Out of scope (deferred to subsequent PRs in the stack):
 
+* ``pack_return`` (the scalar-vs-Masked return bridge for UDFs);
 * ``NAType`` and ``Masked + NA`` semantics;
 * binary / unary / comparison / bitwise op typing;
 * string- and datetime-flavored value types;
@@ -32,13 +31,12 @@ from numba_cuda_mlir.extending import typing_registry
 from numba_cuda_mlir.numba_cuda import types as nb_types
 from numba_cuda_mlir.numba_cuda.types.misc import unliteral
 from numba_cuda_mlir.numba_cuda.typing.templates import (
-    AbstractTemplate,
     AttributeTemplate,
     ConcreteTemplate,
 )
 from numba_cuda_mlir.typing import signature as nb_signature
 
-from cudf.core.udf.api import Masked, pack_return
+from cudf.core.udf.api import Masked
 
 # Numba type classes that may serve as the inner value of a ``MaskedType``
 # at this layer. Subsequent PRs extend this tuple as new value types
@@ -87,8 +85,8 @@ class MaskedType(types.Type):
 
 
 def _register():
-    """Register typing for ``Masked``, ``pack_return``, and ``MaskedType``
-    attributes with ``numba_cuda_mlir``. Called once at module import.
+    """Register typing for ``Masked`` and ``MaskedType`` attributes with
+    ``numba_cuda_mlir``. Called once at module import.
     """
 
     # ``Masked(value, valid)`` constructor: produces a ``Masked(value_ty)``.
@@ -111,21 +109,6 @@ def _register():
                 return typ.value_type
             if attr == "valid":
                 return types.boolean
-            return None
-
-    # ``pack_return(x)``:
-    #   - if x is already a Masked, returns x's type (identity)
-    #   - if x is a plain numeric scalar, returns Masked(x's type)
-    @typing_registry.register_global(pack_return)
-    class PackReturnTemplate(AbstractTemplate):
-        def generic(self, args, kws):
-            if len(args) != 1 or kws:
-                return None
-            (arg,) = args
-            if isinstance(arg, MaskedType):
-                return nb_signature(arg, arg)
-            if isinstance(arg, _SUPPORTED_MASKED_VALUE_TYPE_CLASSES):
-                return nb_signature(MaskedType(arg), arg)
             return None
 
 

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLIR (numba_cuda_mlir) typing for ``MaskedType`` -- the foundational
+"value + validity bit" wrapper used by every UDF input/return value.
+
+Scope of this PR (intentionally minimal):
+
+* the ``MaskedType`` class itself, parameterized by a value type;
+* numeric value types only (``int8..int64``, ``uint8..uint64``,
+  ``float32``, ``float64``, ``boolean``) -- string / datetime / timedelta
+  cases are layered in later PRs;
+* the ``Masked(value, valid)`` constructor;
+* the ``.value`` and ``.valid`` attributes;
+* the ``pack_return`` template that bridges plain scalars and
+  ``MaskedType``.
+
+Out of scope (deferred to subsequent PRs in the stack):
+
+* ``NAType`` and ``Masked + NA`` semantics;
+* binary / unary / comparison / bitwise op typing;
+* string- and datetime-flavored value types;
+* casts between Masked values of different inner types.
+
+Importing this module registers typing with ``numba_cuda_mlir``.
+"""
+
+from __future__ import annotations
+
+from numba_cuda_mlir import types
+from numba_cuda_mlir.extending import typing_registry
+from numba_cuda_mlir.numba_cuda import types as nb_types
+from numba_cuda_mlir.numba_cuda.types.misc import unliteral
+from numba_cuda_mlir.numba_cuda.typing.templates import (
+    AbstractTemplate,
+    AttributeTemplate,
+    ConcreteTemplate,
+)
+from numba_cuda_mlir.typing import signature as nb_signature
+
+from cudf.core.udf.api import Masked, pack_return
+
+# Numba type classes that may serve as the inner value of a ``MaskedType``
+# at this layer. Subsequent PRs extend this tuple as new value types
+# (string, datetime, timedelta) come online.
+_SUPPORTED_MASKED_VALUE_TYPE_CLASSES = (
+    types.Number,
+    types.Boolean,
+)
+
+# Concrete instances used for the ``Masked`` constructor's ConcreteTemplate
+# cases. ``ConcreteTemplate.cases`` requires fully-qualified instances rather
+# than type classes. ``integer_domain`` / ``real_domain`` are exposed on the
+# vendored ``numba_cuda`` types module (not on ``numba_cuda_mlir.types``).
+_supported_value_type_instances = (
+    nb_types.integer_domain | nb_types.real_domain | {nb_types.boolean}
+)
+
+
+class MaskedType(types.Type):
+    """A Numba type for ``Masked(value_type, valid: bool)`` values.
+
+    Parameterized by ``value_type`` so that ``MaskedType(int64)`` and
+    ``MaskedType(float64)`` are distinct types that cache and dispatch
+    independently.
+
+    Unsupported inner types are wrapped in ``types.Poison`` so the
+    typing pass can still construct a ``MaskedType`` (e.g. while
+    inferring the type of an unsupported column) and surface a
+    descriptive error later when the user actually performs an
+    operation.
+    """
+
+    def __init__(self, value):
+        if isinstance(value, types.Literal):
+            value = unliteral(value)
+        if isinstance(value, _SUPPORTED_MASKED_VALUE_TYPE_CLASSES):
+            self.value_type = value
+        else:
+            self.value_type = types.Poison(value)
+        super().__init__(name=f"Masked({self.value_type})")
+
+    def __hash__(self):
+        # Two MaskedType instances compare equal (and hash equal) iff their
+        # parameter ``value_type`` matches, so numba can cache them by repr.
+        return hash(repr(self))
+
+
+def _register():
+    """Register typing for ``Masked``, ``pack_return``, and ``MaskedType``
+    attributes with ``numba_cuda_mlir``. Called once at module import.
+    """
+
+    # ``Masked(value, valid)`` constructor: produces a ``Masked(value_ty)``.
+    class MaskedConstructor(ConcreteTemplate):
+        key = Masked
+        cases = [
+            nb_signature(MaskedType(t), t, types.boolean)
+            for t in _supported_value_type_instances
+        ]
+
+    typing_registry.register_global(Masked, types.Function(MaskedConstructor))
+
+    # ``m.value`` -> inner value type; ``m.valid`` -> boolean.
+    @typing_registry.register_attr
+    class MaskedTypeAttrs(AttributeTemplate):
+        key = MaskedType
+
+        def generic_resolve(self, typ, attr):
+            if attr == "value":
+                return typ.value_type
+            if attr == "valid":
+                return types.boolean
+            return None
+
+    # ``pack_return(x)``:
+    #   - if x is already a Masked, returns x's type (identity)
+    #   - if x is a plain numeric scalar, returns Masked(x's type)
+    @typing_registry.register_global(pack_return)
+    class PackReturnTemplate(AbstractTemplate):
+        def generic(self, args, kws):
+            if len(args) != 1 or kws:
+                return None
+            (arg,) = args
+            if isinstance(arg, MaskedType):
+                return nb_signature(arg, arg)
+            if isinstance(arg, _SUPPORTED_MASKED_VALUE_TYPE_CLASSES):
+                return nb_signature(MaskedType(arg), arg)
+            return None
+
+
+_register()

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
@@ -14,35 +14,25 @@ from numba_cuda_mlir.typing import signature as nb_signature
 
 from cudf.core.udf.api import Masked
 
-# Numba type classes that may serve as the inner value of a ``MaskedType``
-# at this layer. Subsequent PRs extend this tuple as new value types
-# (string, datetime, timedelta) come online.
 _SUPPORTED_MASKED_VALUE_TYPE_CLASSES = (
     types.Number,
     types.Boolean,
 )
 
-# Concrete instances used for the ``Masked`` constructor's ConcreteTemplate
-# cases. ``ConcreteTemplate.cases`` requires fully-qualified instances rather
-# than type classes. ``integer_domain`` / ``real_domain`` are exposed on the
-# vendored ``numba_cuda`` types module (not on ``numba_cuda_mlir.types``).
+
 _supported_value_type_instances = (
     nb_types.integer_domain | nb_types.real_domain | {nb_types.boolean}
 )
 
 
 class MaskedType(types.Type):
-    """A Numba type for ``Masked(value_type, valid: bool)`` values.
+    """Logical struct type used for propagation of nulls. Semantically carries
+    the column value and corresponding validity bit from the columns bitmask.
+    Operations over this type such as arithmetic are implemented to be sensitive
+    to the nullity of the output value.
 
-    Parameterized by ``value_type`` so that ``MaskedType(int64)`` and
-    ``MaskedType(float64)`` are distinct types that cache and dispatch
-    independently.
-
-    Unsupported inner types are wrapped in ``types.Poison`` so the
-    typing pass can still construct a ``MaskedType`` (e.g. while
-    inferring the type of an unsupported column) and surface a
-    descriptive error later when the user actually performs an
-    operation.
+    Instances are parameterized by value type mapping to the type of the source
+    column.
     """
 
     def __init__(self, value):

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
@@ -1,29 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
-"""
-MLIR (numba_cuda_mlir) typing for ``MaskedType`` -- the foundational
-"value + validity bit" wrapper used by every UDF input/return value.
-
-Scope of this PR (intentionally minimal):
-
-* the ``MaskedType`` class itself, parameterized by a value type;
-* numeric value types only (``int8..int64``, ``uint8..uint64``,
-  ``float32``, ``float64``, ``boolean``) -- string / datetime / timedelta
-  cases are layered in later PRs;
-* the ``Masked(value, valid)`` constructor;
-* the ``.value`` and ``.valid`` attributes.
-
-Out of scope (deferred to subsequent PRs in the stack):
-
-* ``pack_return`` (the scalar-vs-Masked return bridge for UDFs);
-* ``NAType`` and ``Masked + NA`` semantics;
-* binary / unary / comparison / bitwise op typing;
-* string- and datetime-flavored value types;
-* casts between Masked values of different inner types.
-
-Importing this module registers typing with ``numba_cuda_mlir``.
-"""
-
 from __future__ import annotations
 
 from numba_cuda_mlir import types

--- a/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
+++ b/python/cudf/cudf/core/udf/mlir_backend/masked_typing.py
@@ -35,7 +35,7 @@ class MaskedType(types.Type):
     column.
     """
 
-    def __init__(self, value):
+    def __init__(self, value: types.Type) -> None:
         if isinstance(value, types.Literal):
             value = unliteral(value)
         if isinstance(value, _SUPPORTED_MASKED_VALUE_TYPE_CLASSES):
@@ -44,7 +44,7 @@ class MaskedType(types.Type):
             self.value_type = types.Poison(value)
         super().__init__(name=f"Masked({self.value_type})")
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # Two MaskedType instances compare equal (and hash equal) iff their
         # parameter ``value_type`` matches, so numba can cache them by repr.
         return hash(repr(self))
@@ -64,14 +64,14 @@ class MaskedConstructor(ConcreteTemplate):
 class MaskedTypeAttrs(AttributeTemplate):
     key = MaskedType
 
-    def resolve_value(self, typ):
+    def resolve_value(self, typ: MaskedType) -> types.Type:
         return typ.value_type
 
-    def resolve_valid(self, typ):
+    def resolve_valid(self, typ: MaskedType) -> types.Type:
         return types.boolean
 
 
-def _register():
+def _register() -> None:
     """Register typing for ``Masked`` and ``MaskedType`` attributes with
     ``numba_cuda_mlir``. Called once at module import.
     """

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/conftest.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/conftest.py
@@ -1,11 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Test-collection shims for the MLIR backend suite.
-
-Runs at conftest import time (before the test modules import
-``numba_cuda_mlir``) so the workarounds below are in place by the time
-collection imports the backend.
-"""
+"""Test-collection shims for the MLIR backend suite."""
 
 from __future__ import annotations
 
@@ -13,20 +8,18 @@ import warnings
 
 import numpy as np
 
-# numba-cuda-mlir 0.4.0 has a few numpy < 2.0 compatibility issues
-# TODO: remove with a suitable numba-cuda-mlir release
+collect_ignore_glob: list[str] = []
+
+# numba-cuda-mlir 0.4.0 cannot be imported under numpy < 2.0: it accesses the
+# removed ``np.bool`` alias at import time (raises AttributeError) and gates its
+# ``bool`` type export on numpy >= 2.0. Suppressing warnings can't help -- the
+# AttributeError is unconditional -- so skip the MLIR backend tests on numpy < 2
+# instead of erroring at collection.
+# TODO: remove once a numba-cuda-mlir release > 0.4.0 supports numpy < 2.0.
 if np.lib.NumpyVersion(np.__version__) < "2.0.0":
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        try:
-            from numba_cuda_mlir.numba_cuda import types as _ncm_types
-
-            if not hasattr(_ncm_types, "bool"):
-                _ncm_types.bool = _ncm_types.bool_
-                if "bool" not in _ncm_types.__all__:
-                    _ncm_types.__all__.append("bool")
-
-            import numba_cuda_mlir.cuda
-            import numba_cuda_mlir.types  # noqa: F401
-        except ImportError:
-            pass
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            import numba_cuda_mlir.cuda  # noqa: F401
+    except Exception:
+        collect_ignore_glob = ["test_masked_*.py"]

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/conftest.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/conftest.py
@@ -3,21 +3,30 @@
 """Test-collection shims for the MLIR backend suite.
 
 Runs at conftest import time (before the test modules import
-``numba_cuda_mlir``) so the workaround below is in place by the time
+``numba_cuda_mlir``) so the workarounds below are in place by the time
 collection imports the backend.
 """
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 
+# numba-cuda-mlir 0.4.0 has a few numpy < 2.0 compatibility issues
+# TODO: remove with a suitable numba-cuda-mlir release
 if np.lib.NumpyVersion(np.__version__) < "2.0.0":
-    try:
-        from numba_cuda_mlir.numba_cuda import types as _ncm_types
-    except ImportError:
-        pass
-    else:
-        if not hasattr(_ncm_types, "bool"):
-            _ncm_types.bool = _ncm_types.bool_
-            if "bool" not in _ncm_types.__all__:
-                _ncm_types.__all__.append("bool")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try:
+            from numba_cuda_mlir.numba_cuda import types as _ncm_types
+
+            if not hasattr(_ncm_types, "bool"):
+                _ncm_types.bool = _ncm_types.bool_
+                if "bool" not in _ncm_types.__all__:
+                    _ncm_types.__all__.append("bool")
+
+            import numba_cuda_mlir.cuda
+            import numba_cuda_mlir.types  # noqa: F401
+        except ImportError:
+            pass

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/conftest.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Test-collection shims for the MLIR backend suite.
 
@@ -6,6 +6,7 @@ Runs at conftest import time (before the test modules import
 ``numba_cuda_mlir``) so the workaround below is in place by the time
 collection imports the backend.
 """
+
 from __future__ import annotations
 
 import numpy as np

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/conftest.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/conftest.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+"""Test-collection shims for the MLIR backend suite.
+
+Runs at conftest import time (before the test modules import
+``numba_cuda_mlir``) so the workaround below is in place by the time
+collection imports the backend.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+if np.lib.NumpyVersion(np.__version__) < "2.0.0":
+    try:
+        from numba_cuda_mlir.numba_cuda import types as _ncm_types
+    except ImportError:
+        pass
+    else:
+        if not hasattr(_ncm_types, "bool"):
+            _ncm_types.bool = _ncm_types.bool_
+            if "bool" not in _ncm_types.__all__:
+                _ncm_types.__all__.append("bool")

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -38,8 +38,6 @@ from cudf.core.udf.api import Masked
 from cudf.core.udf.utils import DEPRECATED_SM_REGEX
 from cudf.utils._numba import _CUDFNumbaConfig
 
-# --- helpers ---------------------------------------------------------------
-
 
 def _jit(sig):
     """Compile a small kernel suppressing the deprecated-SM warning."""
@@ -78,9 +76,6 @@ _DTYPE_SAMPLES = [
     (types.float64, np.float64, np.float64(-1.25)),
     (types.boolean, np.bool_, np.bool_(True)),
 ]
-
-
-# --- constructor + accessors -----------------------------------------------
 
 
 @pytest.mark.parametrize("nb_ty,np_dt,sample", _DTYPE_SAMPLES)

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -68,8 +68,9 @@ def test_masked_constructor_and_accessors_literal_validity(
     out_value = cp.zeros(1, dtype=np_dt)
     out_valid = cp.zeros(1, dtype=np.bool_)
     _launch(k, out_value, out_valid, in_v)
-    assert out_value.get()[0] == sample
     assert bool(out_valid.get()[0]) is valid
+    if valid:
+        assert out_value.get()[0] == sample
 
 
 @pytest.mark.parametrize("valid", [True, False])
@@ -92,5 +93,6 @@ def test_masked_constructor_and_accessors_runtime_validity(valid):
     out_value = cp.zeros(1, dtype=np.int64)
     out_valid = cp.zeros(1, dtype=np.bool_)
     _launch(k, out_value, out_valid, in_v, in_valid)
-    assert int(out_value.get()[0]) == 42
     assert bool(out_valid.get()[0]) is valid
+    if valid:
+        assert int(out_value.get()[0]) == 42

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -18,23 +18,24 @@ import cudf.core.udf.mlir_backend.masked_lowering
 import cudf.core.udf.mlir_backend.masked_typing  # noqa: F401
 from cudf.core.udf.api import Masked
 from cudf.core.udf.utils import DEPRECATED_SM_REGEX
-from cudf.utils._numba import _CUDFNumbaConfig
 
+from .utils import MLIRNumbaCudaConfig
+
+# The low-occupancy performance warning is suppressed via ``MLIRNumbaCudaConfig``
+# in ``_launch``; the filters here cover advisory warnings that aren't config
+# controlled (otherwise promoted to errors by ``filterwarnings = error``).
 pytestmark = [
     pytest.mark.filterwarnings(f"ignore:{DEPRECATED_SM_REGEX}:UserWarning"),
     pytest.mark.filterwarnings(
         "ignore:Linking LTOIR with optimization_level:"
         "numba_cuda_mlir.numba_cuda.core.errors.NumbaWarning"
     ),
-    pytest.mark.filterwarnings(
-        "ignore::numba_cuda_mlir.numba_cuda.core.errors.NumbaPerformanceWarning"
-    ),
 ]
 
 
 def _launch(kernel, *args):
     """Launch ``kernel[1, 1](*args)`` (a 1x1 grid, by design)."""
-    with _CUDFNumbaConfig():
+    with MLIRNumbaCudaConfig():
         kernel[1, 1](*args)
     cuda.synchronize()
 

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -15,6 +15,10 @@ from numba_cuda_mlir import (
     cuda,
     types,
 )
+from numba_cuda_mlir.numba_cuda.core.errors import (
+    NumbaPerformanceWarning,
+    NumbaWarning,
+)
 
 import cudf.core.udf.mlir_backend.masked_lowering
 import cudf.core.udf.mlir_backend.masked_typing  # noqa: F401
@@ -34,14 +38,34 @@ def _jit(sig):
                 category=UserWarning,
                 module=r"^numba\.cuda(\.|$)",
             )
+            # Advisory warning raised while linking LTOIR at opt>0; harmless
+            # for these tests and otherwise promoted to an error.
+            warnings.filterwarnings(
+                "ignore",
+                message="Linking LTOIR with optimization_level",
+                category=NumbaWarning,
+            )
             return cuda.jit(sig)(fn)
 
     return deco
 
 
 def _launch(kernel, *args):
-    """Launch ``kernel[1, 1](*args)`` with the low-occupancy warning suppressed."""
-    with _CUDFNumbaConfig():
+    """Launch ``kernel[1, 1](*args)``.
+
+    These unit kernels run on a 1x1 grid by design, so suppress the
+    low-occupancy performance warning (which numba_cuda_mlir raises on its
+    own config, independent of ``_CUDFNumbaConfig``) and the advisory LTO
+    linking warning. Both are otherwise promoted to errors by the project's
+    ``filterwarnings = error``.
+    """
+    with _CUDFNumbaConfig(), warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=NumbaPerformanceWarning)
+        warnings.filterwarnings(
+            "ignore",
+            message="Linking LTOIR with optimization_level",
+            category=NumbaWarning,
+        )
         kernel[1, 1](*args)
     cuda.synchronize()
 

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -21,9 +21,7 @@ from cudf.core.udf.utils import DEPRECATED_SM_REGEX
 
 from .utils import MLIRNumbaCudaConfig
 
-# The low-occupancy performance warning is suppressed via ``MLIRNumbaCudaConfig``
-# in ``_launch``; the filters here cover advisory warnings that aren't config
-# controlled (otherwise promoted to errors by ``filterwarnings = error``).
+
 pytestmark = [
     pytest.mark.filterwarnings(f"ignore:{DEPRECATED_SM_REGEX}:UserWarning"),
     pytest.mark.filterwarnings(
@@ -34,7 +32,7 @@ pytestmark = [
 
 
 def _launch(kernel, *args):
-    """Launch ``kernel[1, 1](*args)`` (a 1x1 grid, by design)."""
+    # Launch over a 1x1 grid
     with MLIRNumbaCudaConfig():
         kernel[1, 1](*args)
     cuda.synchronize()
@@ -55,13 +53,14 @@ _DTYPE_SAMPLES = [
 ]
 
 
+@pytest.mark.parametrize("valid", [True, False])
 @pytest.mark.parametrize("nb_ty,np_dt,sample", _DTYPE_SAMPLES)
-def test_masked_constructor_and_accessors_valid_true(nb_ty, np_dt, sample):
-    """``Masked(v, True).value == v`` and ``.valid == True``, for every supported dtype."""
-
+def test_masked_constructor_and_accessors_literal_validity(
+    nb_ty, np_dt, sample, valid
+):
     @cuda.jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
     def k(out_value, out_valid, v):
-        m = Masked(v[0], True)
+        m = Masked(v[0], valid)
         out_value[0] = m.value
         out_valid[0] = m.valid
 
@@ -70,30 +69,11 @@ def test_masked_constructor_and_accessors_valid_true(nb_ty, np_dt, sample):
     out_valid = cp.zeros(1, dtype=np.bool_)
     _launch(k, out_value, out_valid, in_v)
     assert out_value.get()[0] == sample
-    assert bool(out_valid.get()[0]) is True
+    assert bool(out_valid.get()[0]) is valid
 
 
-@pytest.mark.parametrize("nb_ty,np_dt,sample", _DTYPE_SAMPLES)
-def test_masked_constructor_and_accessors_valid_false(nb_ty, np_dt, sample):
-    """``Masked(v, False).valid == False`` (and ``.value`` is preserved)."""
-
-    @cuda.jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
-    def k(out_value, out_valid, v):
-        m = Masked(v[0], False)
-        out_value[0] = m.value
-        out_valid[0] = m.valid
-
-    in_v = cp.array([sample], dtype=np_dt)
-    out_value = cp.zeros(1, dtype=np_dt)
-    out_valid = cp.zeros(1, dtype=np.bool_)
-    _launch(k, out_value, out_valid, in_v)
-    assert out_value.get()[0] == sample
-    assert bool(out_valid.get()[0]) is False
-
-
-def test_masked_constructor_with_runtime_valid_flag():
-    """The validity flag can be a runtime value, not only a Python literal."""
-
+@pytest.mark.parametrize("valid", [True, False])
+def test_masked_constructor_and_accessors_runtime_validity(valid):
     @cuda.jit(
         types.void(
             types.int64[::1],
@@ -102,15 +82,15 @@ def test_masked_constructor_with_runtime_valid_flag():
             types.boolean[::1],
         )
     )
-    def k(out_value, out_valid, v, valid):
-        m = Masked(v[0], valid[0])
+    def k(out_value, out_valid, v, valid_in):
+        m = Masked(v[0], valid_in[0])
         out_value[0] = m.value
         out_valid[0] = m.valid
 
     in_v = cp.array([42], dtype=np.int64)
-    in_valid = cp.array([False], dtype=np.bool_)
+    in_valid = cp.array([valid], dtype=np.bool_)
     out_value = cp.zeros(1, dtype=np.int64)
     out_valid = cp.zeros(1, dtype=np.bool_)
     _launch(k, out_value, out_valid, in_v, in_valid)
     assert int(out_value.get()[0]) == 42
-    assert bool(out_valid.get()[0]) is False
+    assert bool(out_valid.get()[0]) is valid

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -1,19 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
-"""Kernel-level tests for the MLIR backend MaskedType *lowering* (PR 2 MVP).
-
-Each test JIT-compiles a small ``cuda.jit`` kernel that constructs a
-``Masked`` value, accesses its ``.value`` and ``.valid`` fields, and
-writes the results to host arrays for comparison. Together they cover:
-
-* the data model registration (struct ``{value_ty, i1}``);
-* ``Masked(value, valid)`` constructor lowering;
-* the generic ``.value`` / ``.valid`` getattr lowering.
-
-Out of scope (later PRs): ``pack_return``, NA, masked binary/unary/
-comparison ops, masked-to-masked unification, datetime / timedelta /
-string value types.
-"""
 
 from __future__ import annotations
 
@@ -31,8 +17,6 @@ from numba_cuda_mlir import (
 )
 
 import cudf.core.udf.mlir_backend.masked_lowering
-
-# Importing these registers typing/lowering on numba_cuda_mlir's registries.
 import cudf.core.udf.mlir_backend.masked_typing  # noqa: F401
 from cudf.core.udf.api import Masked
 from cudf.core.udf.utils import DEPRECATED_SM_REGEX
@@ -62,8 +46,6 @@ def _launch(kernel, *args):
     cuda.synchronize()
 
 
-# Combinations of (numba type, numpy dtype, sample value) used to
-# parametrize the multi-dtype tests below.
 _DTYPE_SAMPLES = [
     (types.int8, np.int8, np.int8(7)),
     (types.int16, np.int16, np.int16(-300)),

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import cupy as cp
 import numpy as np
 import pytest
@@ -15,10 +13,6 @@ from numba_cuda_mlir import (
     cuda,
     types,
 )
-from numba_cuda_mlir.numba_cuda.core.errors import (
-    NumbaPerformanceWarning,
-    NumbaWarning,
-)
 
 import cudf.core.udf.mlir_backend.masked_lowering
 import cudf.core.udf.mlir_backend.masked_typing  # noqa: F401
@@ -26,46 +20,30 @@ from cudf.core.udf.api import Masked
 from cudf.core.udf.utils import DEPRECATED_SM_REGEX
 from cudf.utils._numba import _CUDFNumbaConfig
 
+pytestmark = [
+    pytest.mark.filterwarnings(f"ignore:{DEPRECATED_SM_REGEX}:UserWarning"),
+    pytest.mark.filterwarnings(
+        "ignore:Linking LTOIR with optimization_level:"
+        "numba_cuda_mlir.numba_cuda.core.errors.NumbaWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore::numba_cuda_mlir.numba_cuda.core.errors.NumbaPerformanceWarning"
+    ),
+]
+
 
 def _jit(sig):
-    """Compile a small kernel suppressing the deprecated-SM warning."""
+    """Compile a small kernel for the given signature."""
 
     def deco(fn):
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=DEPRECATED_SM_REGEX,
-                category=UserWarning,
-                module=r"^numba\.cuda(\.|$)",
-            )
-            # Advisory warning raised while linking LTOIR at opt>0; harmless
-            # for these tests and otherwise promoted to an error.
-            warnings.filterwarnings(
-                "ignore",
-                message="Linking LTOIR with optimization_level",
-                category=NumbaWarning,
-            )
-            return cuda.jit(sig)(fn)
+        return cuda.jit(sig)(fn)
 
     return deco
 
 
 def _launch(kernel, *args):
-    """Launch ``kernel[1, 1](*args)``.
-
-    These unit kernels run on a 1x1 grid by design, so suppress the
-    low-occupancy performance warning (which numba_cuda_mlir raises on its
-    own config, independent of ``_CUDFNumbaConfig``) and the advisory LTO
-    linking warning. Both are otherwise promoted to errors by the project's
-    ``filterwarnings = error``.
-    """
-    with _CUDFNumbaConfig(), warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=NumbaPerformanceWarning)
-        warnings.filterwarnings(
-            "ignore",
-            message="Linking LTOIR with optimization_level",
-            category=NumbaWarning,
-        )
+    """Launch ``kernel[1, 1](*args)`` (a 1x1 grid, by design)."""
+    with _CUDFNumbaConfig():
         kernel[1, 1](*args)
     cuda.synchronize()
 
@@ -76,6 +54,7 @@ _DTYPE_SAMPLES = [
     (types.int32, np.int32, np.int32(123_456)),
     (types.int64, np.int64, np.int64(-9_999_999)),
     (types.uint8, np.uint8, np.uint8(255)),
+    (types.uint16, np.uint16, np.uint16(60_000)),
     (types.uint32, np.uint32, np.uint32(4_000_000_000)),
     (types.uint64, np.uint64, np.uint64(9_223_372_036_854_775_808)),
     (types.float32, np.float32, np.float32(3.5)),

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -8,12 +8,11 @@ writes the results to host arrays for comparison. Together they cover:
 
 * the data model registration (struct ``{value_ty, i1}``);
 * ``Masked(value, valid)`` constructor lowering;
-* the generic ``.value`` / ``.valid`` getattr lowering;
-* ``pack_return`` for both ``MaskedType`` (identity) and plain scalar
-  inputs (wrap with ``valid=True``).
+* the generic ``.value`` / ``.valid`` getattr lowering.
 
-Out of scope (later PRs): NA, masked binary/unary/comparison ops,
-masked-to-masked unification, datetime / timedelta / string value types.
+Out of scope (later PRs): ``pack_return``, NA, masked binary/unary/
+comparison ops, masked-to-masked unification, datetime / timedelta /
+string value types.
 """
 
 from __future__ import annotations
@@ -35,7 +34,7 @@ import cudf.core.udf.mlir_backend.masked_lowering
 
 # Importing these registers typing/lowering on numba_cuda_mlir's registries.
 import cudf.core.udf.mlir_backend.masked_typing  # noqa: F401
-from cudf.core.udf.api import Masked, pack_return
+from cudf.core.udf.api import Masked
 from cudf.core.udf.utils import DEPRECATED_SM_REGEX
 from cudf.utils._numba import _CUDFNumbaConfig
 
@@ -142,60 +141,4 @@ def test_masked_constructor_with_runtime_valid_flag():
     out_valid = cp.zeros(1, dtype=np.bool_)
     _launch(k, out_value, out_valid, in_v, in_valid)
     assert int(out_value.get()[0]) == 42
-    assert bool(out_valid.get()[0]) is False
-
-
-# --- pack_return -----------------------------------------------------------
-
-
-@pytest.mark.parametrize("nb_ty,np_dt,sample", _DTYPE_SAMPLES)
-def test_pack_return_of_scalar(nb_ty, np_dt, sample):
-    """``pack_return(x: scalar)`` -> ``Masked(x, True)``, for every supported dtype."""
-
-    @cuda.jit(device=True)
-    def fn(x):
-        return pack_return(x)
-
-    @_jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
-    def k(out_value, out_valid, v):
-        m = fn(v[0])
-        out_value[0] = m.value
-        out_valid[0] = m.valid
-
-    in_v = cp.array([sample], dtype=np_dt)
-    out_value = cp.zeros(1, dtype=np_dt)
-    out_valid = cp.zeros(1, dtype=np.bool_)
-    _launch(k, out_value, out_valid, in_v)
-    assert out_value.get()[0] == sample
-    assert bool(out_valid.get()[0]) is True
-
-
-def test_pack_return_of_masked_is_identity():
-    """``pack_return(m: Masked)`` -> ``m`` (round-trips both fields)."""
-
-    @cuda.jit(device=True)
-    def fn(m):
-        return pack_return(m)
-
-    @_jit(
-        types.void(
-            types.int64[::1],
-            types.boolean[::1],
-            types.int64[::1],
-            types.boolean[::1],
-        )
-    )
-    def k(out_value, out_valid, v, valid):
-        m_in = Masked(v[0], valid[0])
-        m_out = fn(m_in)
-        out_value[0] = m_out.value
-        out_valid[0] = m_out.valid
-
-    in_v = cp.array([777], dtype=np.int64)
-    in_valid = cp.array([False], dtype=np.bool_)
-    out_value = cp.zeros(1, dtype=np.int64)
-    out_valid = cp.zeros(1, dtype=np.bool_)
-    _launch(k, out_value, out_valid, in_v, in_valid)
-    # Identity: both fields survive untouched.
-    assert int(out_value.get()[0]) == 777
     assert bool(out_valid.get()[0]) is False

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+"""Kernel-level tests for the MLIR backend MaskedType *lowering* (PR 2 MVP).
+
+Each test JIT-compiles a small ``cuda.jit`` kernel that constructs a
+``Masked`` value, accesses its ``.value`` and ``.valid`` fields, and
+writes the results to host arrays for comparison. Together they cover:
+
+* the data model registration (struct ``{value_ty, i1}``);
+* ``Masked(value, valid)`` constructor lowering;
+* the generic ``.value`` / ``.valid`` getattr lowering;
+* ``pack_return`` for both ``MaskedType`` (identity) and plain scalar
+  inputs (wrap with ``valid=True``).
+
+Out of scope (later PRs): NA, masked binary/unary/comparison ops,
+masked-to-masked unification, datetime / timedelta / string value types.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import cupy as cp
+import numpy as np
+import pytest
+
+pytest.importorskip("numba_cuda_mlir")
+
+from numba_cuda_mlir import (
+    cuda,
+    types,
+)
+
+import cudf.core.udf.mlir_backend.masked_lowering
+
+# Importing these registers typing/lowering on numba_cuda_mlir's registries.
+import cudf.core.udf.mlir_backend.masked_typing  # noqa: F401
+from cudf.core.udf.api import Masked, pack_return
+from cudf.core.udf.utils import DEPRECATED_SM_REGEX
+from cudf.utils._numba import _CUDFNumbaConfig
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _jit(sig):
+    """Compile a small kernel suppressing the deprecated-SM warning."""
+
+    def deco(fn):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=DEPRECATED_SM_REGEX,
+                category=UserWarning,
+                module=r"^numba\.cuda(\.|$)",
+            )
+            return cuda.jit(sig)(fn)
+
+    return deco
+
+
+def _launch(kernel, *args):
+    """Launch ``kernel[1, 1](*args)`` with the low-occupancy warning suppressed."""
+    with _CUDFNumbaConfig():
+        kernel[1, 1](*args)
+    cuda.synchronize()
+
+
+# Combinations of (numba type, numpy dtype, sample value) used to
+# parametrize the multi-dtype tests below.
+_DTYPE_SAMPLES = [
+    (types.int8, np.int8, np.int8(7)),
+    (types.int16, np.int16, np.int16(-300)),
+    (types.int32, np.int32, np.int32(123_456)),
+    (types.int64, np.int64, np.int64(-9_999_999)),
+    (types.uint8, np.uint8, np.uint8(255)),
+    (types.uint32, np.uint32, np.uint32(4_000_000_000)),
+    (types.uint64, np.uint64, np.uint64(9_223_372_036_854_775_808)),
+    (types.float32, np.float32, np.float32(3.5)),
+    (types.float64, np.float64, np.float64(-1.25)),
+    (types.boolean, np.bool_, np.bool_(True)),
+]
+
+
+# --- constructor + accessors -----------------------------------------------
+
+
+@pytest.mark.parametrize("nb_ty,np_dt,sample", _DTYPE_SAMPLES)
+def test_masked_constructor_and_accessors_valid_true(nb_ty, np_dt, sample):
+    """``Masked(v, True).value == v`` and ``.valid == True``, for every supported dtype."""
+
+    @_jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
+    def k(out_value, out_valid, v):
+        m = Masked(v[0], True)
+        out_value[0] = m.value
+        out_valid[0] = m.valid
+
+    in_v = cp.array([sample], dtype=np_dt)
+    out_value = cp.zeros(1, dtype=np_dt)
+    out_valid = cp.zeros(1, dtype=np.bool_)
+    _launch(k, out_value, out_valid, in_v)
+    assert out_value.get()[0] == sample
+    assert bool(out_valid.get()[0]) is True
+
+
+@pytest.mark.parametrize("nb_ty,np_dt,sample", _DTYPE_SAMPLES)
+def test_masked_constructor_and_accessors_valid_false(nb_ty, np_dt, sample):
+    """``Masked(v, False).valid == False`` (and ``.value`` is preserved)."""
+
+    @_jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
+    def k(out_value, out_valid, v):
+        m = Masked(v[0], False)
+        out_value[0] = m.value
+        out_valid[0] = m.valid
+
+    in_v = cp.array([sample], dtype=np_dt)
+    out_value = cp.zeros(1, dtype=np_dt)
+    out_valid = cp.zeros(1, dtype=np.bool_)
+    _launch(k, out_value, out_valid, in_v)
+    assert out_value.get()[0] == sample
+    assert bool(out_valid.get()[0]) is False
+
+
+def test_masked_constructor_with_runtime_valid_flag():
+    """The validity flag can be a runtime value, not only a Python literal."""
+
+    @_jit(
+        types.void(
+            types.int64[::1],
+            types.boolean[::1],
+            types.int64[::1],
+            types.boolean[::1],
+        )
+    )
+    def k(out_value, out_valid, v, valid):
+        m = Masked(v[0], valid[0])
+        out_value[0] = m.value
+        out_valid[0] = m.valid
+
+    in_v = cp.array([42], dtype=np.int64)
+    in_valid = cp.array([False], dtype=np.bool_)
+    out_value = cp.zeros(1, dtype=np.int64)
+    out_valid = cp.zeros(1, dtype=np.bool_)
+    _launch(k, out_value, out_valid, in_v, in_valid)
+    assert int(out_value.get()[0]) == 42
+    assert bool(out_valid.get()[0]) is False
+
+
+# --- pack_return -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("nb_ty,np_dt,sample", _DTYPE_SAMPLES)
+def test_pack_return_of_scalar(nb_ty, np_dt, sample):
+    """``pack_return(x: scalar)`` -> ``Masked(x, True)``, for every supported dtype."""
+
+    @cuda.jit(device=True)
+    def fn(x):
+        return pack_return(x)
+
+    @_jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
+    def k(out_value, out_valid, v):
+        m = fn(v[0])
+        out_value[0] = m.value
+        out_valid[0] = m.valid
+
+    in_v = cp.array([sample], dtype=np_dt)
+    out_value = cp.zeros(1, dtype=np_dt)
+    out_valid = cp.zeros(1, dtype=np.bool_)
+    _launch(k, out_value, out_valid, in_v)
+    assert out_value.get()[0] == sample
+    assert bool(out_valid.get()[0]) is True
+
+
+def test_pack_return_of_masked_is_identity():
+    """``pack_return(m: Masked)`` -> ``m`` (round-trips both fields)."""
+
+    @cuda.jit(device=True)
+    def fn(m):
+        return pack_return(m)
+
+    @_jit(
+        types.void(
+            types.int64[::1],
+            types.boolean[::1],
+            types.int64[::1],
+            types.boolean[::1],
+        )
+    )
+    def k(out_value, out_valid, v, valid):
+        m_in = Masked(v[0], valid[0])
+        m_out = fn(m_in)
+        out_value[0] = m_out.value
+        out_valid[0] = m_out.valid
+
+    in_v = cp.array([777], dtype=np.int64)
+    in_valid = cp.array([False], dtype=np.bool_)
+    out_value = cp.zeros(1, dtype=np.int64)
+    out_valid = cp.zeros(1, dtype=np.bool_)
+    _launch(k, out_value, out_valid, in_v, in_valid)
+    # Identity: both fields survive untouched.
+    assert int(out_value.get()[0]) == 777
+    assert bool(out_valid.get()[0]) is False

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ from cudf.core.udf.api import Masked
 from cudf.core.udf.utils import DEPRECATED_SM_REGEX
 
 from .utils import MLIRNumbaCudaConfig
-
 
 pytestmark = [
     pytest.mark.filterwarnings(f"ignore:{DEPRECATED_SM_REGEX}:UserWarning"),

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_lowering.py
@@ -32,15 +32,6 @@ pytestmark = [
 ]
 
 
-def _jit(sig):
-    """Compile a small kernel for the given signature."""
-
-    def deco(fn):
-        return cuda.jit(sig)(fn)
-
-    return deco
-
-
 def _launch(kernel, *args):
     """Launch ``kernel[1, 1](*args)`` (a 1x1 grid, by design)."""
     with _CUDFNumbaConfig():
@@ -67,7 +58,7 @@ _DTYPE_SAMPLES = [
 def test_masked_constructor_and_accessors_valid_true(nb_ty, np_dt, sample):
     """``Masked(v, True).value == v`` and ``.valid == True``, for every supported dtype."""
 
-    @_jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
+    @cuda.jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
     def k(out_value, out_valid, v):
         m = Masked(v[0], True)
         out_value[0] = m.value
@@ -85,7 +76,7 @@ def test_masked_constructor_and_accessors_valid_true(nb_ty, np_dt, sample):
 def test_masked_constructor_and_accessors_valid_false(nb_ty, np_dt, sample):
     """``Masked(v, False).valid == False`` (and ``.value`` is preserved)."""
 
-    @_jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
+    @cuda.jit(types.void(nb_ty[::1], types.boolean[::1], nb_ty[::1]))
     def k(out_value, out_valid, v):
         m = Masked(v[0], False)
         out_value[0] = m.value
@@ -102,7 +93,7 @@ def test_masked_constructor_and_accessors_valid_false(nb_ty, np_dt, sample):
 def test_masked_constructor_with_runtime_valid_flag():
     """The validity flag can be a runtime value, not only a Python literal."""
 
-    @_jit(
+    @cuda.jit(
         types.void(
             types.int64[::1],
             types.boolean[::1],

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
@@ -1,19 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the MLIR backend MaskedType *typing* surface (PR 2 MVP).
-
-These cover the Python-level surface registered by
-``cudf.core.udf.mlir_backend.masked_typing``: type identity / hashing,
-the ``_supported_value_type_instances`` set, and that the ``Masked``
-constructor / ``.value`` / ``.valid`` / ``pack_return`` typing templates
-exist and have the expected key. Kernel-level tests live in
-``test_masked_lowering.py``.
-
-Out of scope (deferred to subsequent PRs): NAType, ``Masked + NA``,
-binary/unary ops, datetime / timedelta value types, string value types,
-masked-to-masked unification.
-"""
-
 from __future__ import annotations
 
 import pytest

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
@@ -58,33 +58,3 @@ def test_masked_type_unsupported_value_becomes_poison():
     assert isinstance(masked.value_type, types.Poison)
 
 
-def test_supported_value_type_classes_are_numeric_and_boolean_only():
-    """At this PR layer, value types are restricted to numeric + boolean."""
-    assert _SUPPORTED_MASKED_VALUE_TYPE_CLASSES == (
-        types.Number,
-        types.Boolean,
-    )
-
-
-def test_supported_value_type_instances_includes_typical_numerics():
-    """Spot-check that the instance set covers common scalar types."""
-    expected = {
-        types.int8,
-        types.int16,
-        types.int32,
-        types.int64,
-        types.uint8,
-        types.uint16,
-        types.uint32,
-        types.uint64,
-        types.float32,
-        types.float64,
-        types.boolean,
-    }
-    missing = expected - _supported_value_type_instances
-    assert not missing, f"missing instance entries: {missing}"
-
-
-def test_supported_value_type_instances_excludes_strings():
-    """String-typed values aren't supported at this layer."""
-    assert types.unicode_type not in _supported_value_type_instances

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
@@ -28,8 +28,6 @@ from cudf.core.udf.mlir_backend.masked_typing import (
     _supported_value_type_instances,
 )
 
-# --- type identity / hashing ------------------------------------------------
-
 
 def test_masked_type_repr():
     assert repr(MaskedType(types.int64)) == "Masked(int64)"
@@ -72,9 +70,6 @@ def test_masked_type_unsupported_value_becomes_poison():
     """
     masked = MaskedType(types.unicode_type)
     assert isinstance(masked.value_type, types.Poison)
-
-
-# --- supported value type set ----------------------------------------------
 
 
 def test_supported_value_type_classes_are_numeric_and_boolean_only():

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MLIR backend MaskedType *typing* surface (PR 2 MVP).
+
+These cover the Python-level surface registered by
+``cudf.core.udf.mlir_backend.masked_typing``: type identity / hashing,
+the ``_supported_value_type_instances`` set, and that the ``Masked``
+constructor / ``.value`` / ``.valid`` / ``pack_return`` typing templates
+exist and have the expected key. Kernel-level tests live in
+``test_masked_lowering.py``.
+
+Out of scope (deferred to subsequent PRs): NAType, ``Masked + NA``,
+binary/unary ops, datetime / timedelta value types, string value types,
+masked-to-masked unification.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("numba_cuda_mlir")
+
+from numba_cuda_mlir import types
+
+from cudf.core.udf.mlir_backend.masked_typing import (
+    _SUPPORTED_MASKED_VALUE_TYPE_CLASSES,
+    MaskedType,
+    _supported_value_type_instances,
+)
+
+# --- type identity / hashing ------------------------------------------------
+
+
+def test_masked_type_repr():
+    assert repr(MaskedType(types.int64)) == "Masked(int64)"
+    assert repr(MaskedType(types.float64)) == "Masked(float64)"
+    assert repr(MaskedType(types.boolean)) == "Masked(bool)"
+
+
+def test_masked_type_equality_by_value_type():
+    """Two MaskedType instances are equal iff their value_type is equal."""
+    a = MaskedType(types.int64)
+    b = MaskedType(types.int64)
+    c = MaskedType(types.float64)
+    # Numba ``Type`` equality is structural: same name -> equal.
+    assert a == b
+    assert a != c
+
+
+def test_masked_type_hash_keys_by_value_type():
+    """Numba caches typed signatures by hash; matching params must hash equal."""
+    assert hash(MaskedType(types.int64)) == hash(MaskedType(types.int64))
+    assert hash(MaskedType(types.int64)) != hash(MaskedType(types.float64))
+
+
+def test_masked_type_unliterals_value():
+    """A literal value type is unliteralled before being stored."""
+    lit = types.IntegerLiteral(7)
+    masked = MaskedType(lit)
+    # The stored value_type is the underlying int64 (or whatever the
+    # literal unwraps to), not the literal itself.
+    assert not isinstance(masked.value_type, types.Literal)
+
+
+def test_masked_type_unsupported_value_becomes_poison():
+    """Unsupported value types are wrapped in Poison (not raised here).
+
+    The typing pass may try to construct ``MaskedType`` for unsupported
+    column dtypes; we want that to succeed at construction so a
+    descriptive error can surface later when the user actually performs
+    an op on the value. The poison sentinel is the carrier.
+    """
+    masked = MaskedType(types.unicode_type)
+    assert isinstance(masked.value_type, types.Poison)
+
+
+# --- supported value type set ----------------------------------------------
+
+
+def test_supported_value_type_classes_are_numeric_and_boolean_only():
+    """At this PR layer, value types are restricted to numeric + boolean."""
+    assert _SUPPORTED_MASKED_VALUE_TYPE_CLASSES == (
+        types.Number,
+        types.Boolean,
+    )
+
+
+def test_supported_value_type_instances_includes_typical_numerics():
+    """Spot-check that the instance set covers common scalar types."""
+    expected = {
+        types.int8,
+        types.int16,
+        types.int32,
+        types.int64,
+        types.uint8,
+        types.uint16,
+        types.uint32,
+        types.uint64,
+        types.float32,
+        types.float64,
+        types.boolean,
+    }
+    missing = expected - _supported_value_type_instances
+    assert not missing, f"missing instance entries: {missing}"
+
+
+def test_supported_value_type_instances_excludes_strings():
+    """String-typed values aren't supported at this layer."""
+    assert types.unicode_type not in _supported_value_type_instances

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/test_masked_typing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -9,9 +9,7 @@ pytest.importorskip("numba_cuda_mlir")
 from numba_cuda_mlir import types
 
 from cudf.core.udf.mlir_backend.masked_typing import (
-    _SUPPORTED_MASKED_VALUE_TYPE_CLASSES,
     MaskedType,
-    _supported_value_type_instances,
 )
 
 
@@ -56,5 +54,3 @@ def test_masked_type_unsupported_value_becomes_poison():
     """
     masked = MaskedType(types.unicode_type)
     assert isinstance(masked.value_type, types.Poison)
-
-

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/utils.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/python/cudf/cudf/tests/private_objects/mlir_backend/utils.py
+++ b/python/cudf/cudf/tests/private_objects/mlir_backend/utils.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from numba_cuda_mlir.numba_cuda.core import config
+
+
+class MLIRNumbaCudaConfig:
+    def __enter__(self) -> None:
+        self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
+        config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        config.CUDA_LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings


### PR DESCRIPTION
Add a basic MLIR based `MaskedType` and the ability to express the creation of one inside a `numba-cuda-mlir` kernel. 

Part of the MLIR UDF backend stack. Depends on #22766 (plumbing). Adds the MaskedType extension type: parameterized value type, the Masked(value, valid) constructor, the .value / .valid accessors, and the LLVM struct data model. Numeric/boolean value types only. Stacked on: #22766. Tests under tests/private_objects/mlir_backend/.