### PR TITLE
Reduce concurrency of cudf-polars tests

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -66,7 +66,7 @@ python -m pytest \
        --cache-clear \
        -m "" \
        -p cudf_polars.testing.inject_gpu_engine \
-       -n 8 \
+       -n 4 \
        --dist=worksteal \
        --tb=native \
        --timeout=240 \
@@ -87,7 +87,7 @@ CUDF_POLARS__EXECUTOR__FALLBACK_MODE=silent \
        -m "" \
        -p cudf_polars.testing.inject_gpu_engine \
        -W ignore::ResourceWarning \
-       -n 8 \
+       -n 4 \
        --dist=worksteal \
        --tb=native \
        --timeout=240 \

--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -45,7 +45,7 @@ rapids-logger "pytest cudf-polars"
 ./ci/run_cudf_polars_pytests.sh \
   -vv \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars.xml" \
-  --numprocesses=8 \
+  --numprocesses=4 \
   --dist=worksteal \
   --cov-config=./pyproject.toml \
   --cov=cudf_polars \

--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -87,7 +87,7 @@ for version in "${VERSIONS[@]}"; do
     ./ci/run_cudf_polars_pytests.sh \
         -vv \
         "${COVERAGE_ARGS[@]}" \
-        --numprocesses=8 \
+        --numprocesses=4 \
         --dist=worksteal \
         --durations 10 --durations-min 10 \
         -ra \


### PR DESCRIPTION
## Description

This reduces the number of test processes used in the cudf-polars tests (both our tests and upstream polars').

We've seen test failures from GPU out of memory errors (e.g. https://github.com/rapidsai/cudf/actions/runs/27532434416/job/81373595693). Reducing the concurrency should help reduce the peak memory usage on the GPU across all the test processes.
