### PR TITLE
[BUG] Fix conditional linking of RTCX embed dependencies & Allow null fragment names

### DIFF
--- a/cpp/librtcx/embed.cmake
+++ b/cpp/librtcx/embed.cmake
@@ -5,6 +5,10 @@
 # cmake-format: on
 # =============================================================================
 
+if(NOT TARGET zstd)
+  message(FATAL_ERROR "embed(): zstd target is required when COMPRESSION is not none.")
+endif()
+
 # This function initializes a target for JIT embedding. It must be called before any calls to
 # embed_includes() or embed_blob() for the target. It creates a dedicated INTERFACE library target
 # that is used to track registered files and dependencies via target properties. The TARGET argument
@@ -268,16 +272,9 @@ function(embed TARGET)
 
   set(RUNNER "${TARGET}__jit_embed_run")
   add_executable(${RUNNER} EXCLUDE_FROM_ALL "${EMBED_SCRIPT}")
-  target_link_libraries(${RUNNER} PRIVATE ${CMAKE_DL_LIBS})
-  if(NOT ARG_COMPRESSION STREQUAL "none")
-    if(NOT TARGET zstd)
-      message(FATAL_ERROR "embed(): zstd target is required when COMPRESSION is not none.")
-    endif()
-    target_include_directories(${RUNNER} PRIVATE ${ZSTD_INCLUDE_DIR})
-    target_link_libraries(${RUNNER} PRIVATE zstd)
-  endif()
+  target_link_libraries(${RUNNER} PRIVATE ${CMAKE_DL_LIBS} zstd)   
+  target_include_directories(${RUNNER} PRIVATE ${CMAKE_CURRENT_FUNCTION_LIST_DIR} ${ZSTD_INCLUDE_DIR})
   set_target_properties(${RUNNER} PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED YES)
-  target_include_directories(${RUNNER} PRIVATE ${CMAKE_CURRENT_FUNCTION_LIST_DIR})
 
   add_custom_command(
     OUTPUT ${OUTPUT_DIR}/${TARGET}.hpp ${OUTPUT_DIR}/${TARGET}.s ${OUTPUT_DIR}/${TARGET}.bin

--- a/cpp/librtcx/embed.cmake
+++ b/cpp/librtcx/embed.cmake
@@ -6,7 +6,7 @@
 # =============================================================================
 
 if(NOT TARGET zstd)
-  message(FATAL_ERROR "embed(): zstd target is required when COMPRESSION is not none.")
+  message(FATAL_ERROR "embed(): zstd target is required for LIBRTCX embedding.")
 endif()
 
 # This function initializes a target for JIT embedding. It must be called before any calls to
@@ -273,7 +273,9 @@ function(embed TARGET)
   set(RUNNER "${TARGET}__jit_embed_run")
   add_executable(${RUNNER} EXCLUDE_FROM_ALL "${EMBED_SCRIPT}")
   target_link_libraries(${RUNNER} PRIVATE ${CMAKE_DL_LIBS} zstd)
-  target_include_directories(${RUNNER} PRIVATE ${CMAKE_CURRENT_FUNCTION_LIST_DIR} ${ZSTD_INCLUDE_DIR})
+  target_include_directories(
+    ${RUNNER} PRIVATE ${CMAKE_CURRENT_FUNCTION_LIST_DIR} ${ZSTD_INCLUDE_DIR}
+  )
   set_target_properties(${RUNNER} PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED YES)
 
   add_custom_command(

--- a/cpp/librtcx/embed.cmake
+++ b/cpp/librtcx/embed.cmake
@@ -272,7 +272,7 @@ function(embed TARGET)
 
   set(RUNNER "${TARGET}__jit_embed_run")
   add_executable(${RUNNER} EXCLUDE_FROM_ALL "${EMBED_SCRIPT}")
-  target_link_libraries(${RUNNER} PRIVATE ${CMAKE_DL_LIBS} zstd)   
+  target_link_libraries(${RUNNER} PRIVATE ${CMAKE_DL_LIBS} zstd)
   target_include_directories(${RUNNER} PRIVATE ${CMAKE_CURRENT_FUNCTION_LIST_DIR} ${ZSTD_INCLUDE_DIR})
   set_target_properties(${RUNNER} PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED YES)
 

--- a/cpp/librtcx/rtcx.cpp
+++ b/cpp/librtcx/rtcx.cpp
@@ -619,7 +619,8 @@ void log_nvJitLink_result(link_params const& params,
   }
 
   for (auto& frag : params.memory_fragments) {
-    fragments_str = std::format("{}\t{}\n", fragments_str, frag.name);
+    fragments_str =
+      std::format("{}\t{}\n", fragments_str, frag.name == nullptr ? "<unnamed>" : frag.name);
   }
 
   std::string link_options_str;


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Fixes conditional compilation bug introduced in https://github.com/rapidsai/cudf/pull/22856.
The `Zstd` functions are always referenced regardless of the specified compression.
The dependency is always available regardless of the compression type, and it should be linked into the embed runner executable.
It also makes a fix to allow `nullptr` in fragment names.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
