### PR TITLE
Fix project link in Maven

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,7 +17,7 @@
         This project provides java bindings for cudf, to be able to process large amounts of data on a GPU.
         This is still a work in progress so some APIs may change until the 1.0 release.
     </description>
-    <url>http://ai.rapids</url>
+    <url>https://rapids.ai/</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
Fix project link in Maven.

The link is extracted by tools and visible e.g. on https://central.sonatype.com/artifact/ai.rapids/cudf

---

Supersedes #22659 (brought up to date with main). Original work by @findepi — thank you!