### PR TITLE
Adapt to rapidsmpf changes

### DIFF
--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/concatenate.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/concatenate.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "concatenate.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/concatenate.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/concatenate.cpp
@@ -31,7 +31,7 @@ streaming::Actor concatenate(std::shared_ptr<streaming::Context> ctx,
   CudaEvent event;
   std::vector<streaming::Message> messages;
   ctx->logger()->print("Concatenate");
-  auto concat_stream = ctx->br()->stream_pool().get_stream();
+  auto concat_stream = ctx->br()->stream_pool()->get_stream();
   while (!ch_out->is_shutdown()) {
     co_await ctx->executor()->schedule();
     auto msg = co_await ch_in->receive();

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/join.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/join.cpp
@@ -58,7 +58,7 @@ coro::task<streaming::Message> broadcast(std::shared_ptr<streaming::Context> ctx
   if (comm->nranks() == 1) {
     std::vector<cudf_streaming::streaming::TableChunk> chunks;
     std::vector<cudf::table_view> views;
-    auto gather_stream = ctx->br()->stream_pool().get_stream();
+    auto gather_stream = ctx->br()->stream_pool()->get_stream();
     while (true) {
       auto msg = co_await ch_in->receive();
       if (msg.empty()) { break; }
@@ -103,7 +103,7 @@ coro::task<streaming::Message> broadcast(std::shared_ptr<streaming::Context> ctx
                            std::make_unique<cudf_streaming::streaming::TableChunk>(
                              std::make_unique<PackedData>(std::move(result[0]))));
     } else {
-      auto stream = ctx->br()->stream_pool().get_stream();
+      auto stream = ctx->br()->stream_pool()->get_stream();
       co_return to_message(
         0,
         std::make_unique<cudf_streaming::streaming::TableChunk>(
@@ -502,7 +502,7 @@ streaming::Actor shuffle(std::shared_ptr<streaming::Context> ctx,
   co_await shuffler.insert_finished();
   for (auto pid : shuffler.local_partitions()) {
     auto packed_data = shuffler.extract(pid);
-    auto stream      = ctx->br()->stream_pool().get_stream();
+    auto stream      = ctx->br()->stream_pool()->get_stream();
     co_await ch_out->send(to_message(
       pid,
       std::make_unique<cudf_streaming::streaming::TableChunk>(

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/join.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/join.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "join.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q01.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q01.cpp
@@ -63,7 +63,7 @@ rapidsmpf::streaming::Actor read_lineitem(std::shared_ptr<rapidsmpf::streaming::
                      "l_tax"             // 5
                    })
                    .build();
-  auto stream = ctx->br()->stream_pool().get_stream();
+  auto stream = ctx->br()->stream_pool()->get_stream();
   // l_shipdate <= DATE '1998-09-02'
   constexpr auto date = cuda::std::chrono::year_month_day(
     cuda::std::chrono::year(1998), cuda::std::chrono::month(9), cuda::std::chrono::day(2));

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q01.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q01.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "concatenate.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q03.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q03.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "concatenate.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q03.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q03.cpp
@@ -67,7 +67,7 @@ rapidsmpf::streaming::Actor read_customer(std::shared_ptr<rapidsmpf::streaming::
                    .column_names({"c_custkey"})  // 0
                    .build();
   auto filter_expr = [&]() -> std::unique_ptr<cudf_streaming::streaming::Filter> {
-    auto stream = ctx->br()->stream_pool().get_stream();
+    auto stream = ctx->br()->stream_pool()->get_stream();
     auto owner  = new std::vector<std::any>;
     owner->push_back(std::make_shared<cudf::string_scalar>("BUILDING", true, stream));
     owner->push_back(std::make_shared<cudf::ast::literal>(
@@ -104,7 +104,7 @@ rapidsmpf::streaming::Actor read_lineitem(std::shared_ptr<rapidsmpf::streaming::
                      "l_discount",       // 2
                    })
                    .build();
-  auto stream = ctx->br()->stream_pool().get_stream();
+  auto stream = ctx->br()->stream_pool()->get_stream();
   // l_shipdate > DATE '1995-03-15'
   constexpr auto date = cuda::std::chrono::year_month_day(
     cuda::std::chrono::year(1995), cuda::std::chrono::month(3), cuda::std::chrono::day(15));
@@ -134,7 +134,7 @@ rapidsmpf::streaming::Actor read_orders(std::shared_ptr<rapidsmpf::streaming::Co
                      "o_custkey"        // 3
                    })
                    .build();
-  auto stream = ctx->br()->stream_pool().get_stream();
+  auto stream = ctx->br()->stream_pool()->get_stream();
   // o_orderdate < DATE '1995-03-15'
   constexpr auto date = cuda::std::chrono::year_month_day(
     cuda::std::chrono::year(1995), cuda::std::chrono::month(3), cuda::std::chrono::day(15));

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q04.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q04.cpp
@@ -1,6 +1,5 @@
 /**
-
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q04.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q04.cpp
@@ -110,7 +110,7 @@ rapidsmpf::streaming::Actor read_orders(std::shared_ptr<rapidsmpf::streaming::Co
                    })
                    .build();
 
-  auto stream = ctx->br()->stream_pool().get_stream();
+  auto stream = ctx->br()->stream_pool()->get_stream();
   // 1993-07-01 <= o_orderdate < 1993-10-01
   constexpr auto start_date = cuda::std::chrono::year_month_day(
     cuda::std::chrono::year(1993), cuda::std::chrono::month(7), cuda::std::chrono::day(1));

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q21.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q21.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "concatenate.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q21.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q21.cpp
@@ -86,7 +86,7 @@ rapidsmpf::streaming::Actor read_nation(std::shared_ptr<rapidsmpf::streaming::Co
                    .build();
   // filter: "n_name" == "SAUDI ARABIA"
   auto filter_expr = [&]() -> std::unique_ptr<cudf_streaming::streaming::Filter> {
-    auto stream         = ctx->br()->stream_pool().get_stream();
+    auto stream         = ctx->br()->stream_pool()->get_stream();
     auto owner          = new std::vector<std::any>;
     constexpr auto name = "SAUDI ARABIA";
     owner->push_back(std::make_shared<cudf::string_scalar>(
@@ -122,7 +122,7 @@ rapidsmpf::streaming::Actor read_orders(std::shared_ptr<rapidsmpf::streaming::Co
                    .build();
   // filter: "o_orderstatus" == "F"
   auto filter_expr = [&]() -> std::unique_ptr<cudf_streaming::streaming::Filter> {
-    auto stream           = ctx->br()->stream_pool().get_stream();
+    auto stream           = ctx->br()->stream_pool()->get_stream();
     auto owner            = new std::vector<std::any>;
     constexpr auto status = "F";
     owner->push_back(std::make_shared<cudf::string_scalar>(

--- a/cpp/libcudf_streaming/src/streaming/bloom_filter.cpp
+++ b/cpp/libcudf_streaming/src/streaming/bloom_filter.cpp
@@ -32,7 +32,7 @@ rapidsmpf::streaming::Actor BloomFilter::build(
   co_await ch_out->shutdown_metadata();
   auto const& br     = ctx_->br();
   auto mr            = br->device_mr();
-  auto filter_stream = br->stream_pool().get_stream();
+  auto filter_stream = br->stream_pool()->get_stream();
   rapidsmpf::CudaEvent event;
   auto storage =
     cudf_streaming::integrations::BloomFilter::storage(num_filter_blocks_, filter_stream, mr);

--- a/cpp/libcudf_streaming/src/streaming/bloom_filter.cpp
+++ b/cpp/libcudf_streaming/src/streaming/bloom_filter.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf/stream_compaction.hpp>

--- a/cpp/libcudf_streaming/src/streaming/parquet.cpp
+++ b/cpp/libcudf_streaming/src/streaming/parquet.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf/ast/expressions.hpp>

--- a/cpp/libcudf_streaming/src/streaming/parquet.cpp
+++ b/cpp/libcudf_streaming/src/streaming/parquet.cpp
@@ -257,7 +257,7 @@ rapidsmpf::streaming::Actor produce_chunks(
     chunk_options.set_skip_rows(chunk.skip_rows);
     chunk_options.set_num_rows(chunk.num_rows);
     chunk_options.set_source(chunk.source);
-    auto stream = ctx->br()->stream_pool().get_stream();
+    auto stream = ctx->br()->stream_pool()->get_stream();
     auto ticket = co_await ch_out->acquire();
     if (!ticket.has_value()) {
       // Semaphore (and hence output channel) shutdown
@@ -321,8 +321,8 @@ rapidsmpf::streaming::Actor read_parquet(std::shared_ptr<rapidsmpf::streaming::C
     // deps in the tasks
     rapidsmpf::cuda_stream_join(
       std::ranges::transform_view(
-        std::ranges::iota_view(std::size_t{0}, ctx->br()->stream_pool().get_pool_size()),
-        [&](auto i) { return ctx->br()->stream_pool().get_stream(i); }),
+        std::ranges::iota_view(std::size_t{0}, ctx->br()->stream_pool()->get_pool_size()),
+        [&](auto i) { return ctx->br()->stream_pool()->get_stream(i); }),
       std::ranges::single_view(filter->stream));
   }
   // TODO: Handle case where multiple ranks are reading from a single file.
@@ -381,7 +381,7 @@ rapidsmpf::streaming::Actor read_parquet(std::shared_ptr<rapidsmpf::streaming::C
       empty_opts.set_skip_rows(0);
       empty_opts.set_num_rows(0);
       co_await ctx->executor()->schedule(ch_out->send(
-        read_parquet_chunk(ctx, ctx->br()->stream_pool().get_stream(), std::move(empty_opts), 0)));
+        read_parquet_chunk(ctx, ctx->br()->stream_pool()->get_stream(), std::move(empty_opts), 0)));
     }
   } else {
     std::vector<rapidsmpf::streaming::Actor> read_tasks;
@@ -401,8 +401,8 @@ rapidsmpf::streaming::Actor read_parquet(std::shared_ptr<rapidsmpf::streaming::C
     rapidsmpf::cuda_stream_join(
       std::ranges::single_view(filter->stream),
       std::ranges::transform_view(
-        std::ranges::iota_view(std::size_t{0}, ctx->br()->stream_pool().get_pool_size()),
-        [&](auto i) { return ctx->br()->stream_pool().get_stream(i); }));
+        std::ranges::iota_view(std::size_t{0}, ctx->br()->stream_pool()->get_pool_size()),
+        [&](auto i) { return ctx->br()->stream_pool()->get_stream(i); }));
   }
 }
 }  // namespace cudf_streaming::streaming::actor

--- a/cpp/libcudf_streaming/src/streaming/partition.cpp
+++ b/cpp/libcudf_streaming/src/streaming/partition.cpp
@@ -75,7 +75,7 @@ rapidsmpf::streaming::Actor unpack_and_concat(std::shared_ptr<rapidsmpf::streami
       data               = std::move(partition_vec.data);
     }
     // Get a stream for the concatenated table chunk.
-    auto stream = ctx->br()->stream_pool().get_stream();
+    auto stream = ctx->br()->stream_pool()->get_stream();
 
     std::unique_ptr<cudf::table> ret = cudf_streaming::integrations::unpack_and_concat(
       rapidsmpf::unspill_partitions(

--- a/cpp/libcudf_streaming/src/streaming/partition.cpp
+++ b/cpp/libcudf_streaming/src/streaming/partition.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf/partitioning.hpp>
 

--- a/cpp/libcudf_streaming/tests/streaming/test_read_parquet.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_read_parquet.cpp
@@ -170,7 +170,7 @@ TEST_P(StreamingReadParquetParams, ReadParquet)
   if (num_rows.has_value()) { options.set_num_rows(num_rows.value()); }
   auto filter_expr = [&]() -> std::unique_ptr<Filter> {
     if (!use_filter) { return nullptr; }
-    auto stream = ctx->br()->stream_pool().get_stream();
+    auto stream = ctx->br()->stream_pool()->get_stream();
     auto owner  = new std::vector<std::any>;
     owner->push_back(std::make_shared<cudf::numeric_scalar<std::int32_t>>(15, true, stream));
     owner->push_back(std::make_shared<cudf::ast::literal>(

--- a/cpp/libcudf_streaming/tests/streaming/test_read_parquet.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_read_parquet.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "base_streaming_fixture.hpp"

--- a/cpp/libcudf_streaming/tests/test_shuffler.cpp
+++ b/cpp/libcudf_streaming/tests/test_shuffler.cpp
@@ -407,7 +407,7 @@ TEST(Shuffler, concurrent_wait)
             static_cast<std::int32_t>(total_num_partitions),
             hash_fn,
             seed,
-            br->stream_pool().get_stream(),
+            br->stream_pool()->get_stream(),
             br.get(),
             rapidsmpf::AllowOverbooking::YES));
         }));

--- a/cpp/libcudf_streaming/tests/test_shuffler.cpp
+++ b/cpp/libcudf_streaming/tests/test_shuffler.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "environment.hpp"

--- a/python/cudf/cudf/pandas/_wrappers/numpy.py
+++ b/python/cudf/cudf/pandas/_wrappers/numpy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -328,9 +328,7 @@ if version.parse(numpy.__version__) >= version.parse("2.0"):
     # NumPy 2 introduced `_core` and gives warnings for access to `core`.
     from numpy._core.multiarray import flagsobj as _numpy_flagsobj
 else:
-    from numpy.core.multiarray import (  # type: ignore[no-redef]
-        flagsobj as _numpy_flagsobj,
-    )
+    from numpy.core.multiarray import flagsobj as _numpy_flagsobj
 
 # Mapping flags between slow and fast types
 _ndarray_flags = make_intermediate_proxy_type(

--- a/python/cudf_polars/cudf_polars/engine/core.py
+++ b/python/cudf_polars/cudf_polars/engine/core.py
@@ -453,7 +453,7 @@ def execute_ir_on_rank(
         Collected channel metadata.
     """
     ir_context = IRExecutionContext(
-        py_executor, get_cuda_stream=ctx.get_stream_from_pool, query_id=query_id
+        py_executor, get_cuda_stream=ctx.br().stream_pool.get_stream, query_id=query_id
     )
     metadata_collector: list[ChannelMetadata] = []
 

--- a/python/cudf_polars/cudf_polars/engine/spmd.py
+++ b/python/cudf_polars/cudf_polars/engine/spmd.py
@@ -157,7 +157,7 @@ def allgather_polars_dataframe(
     """
     comm = engine.comm
     ctx = engine.context
-    stream = ctx.get_stream_from_pool()
+    stream = ctx.br().stream_pool.get_stream()
     col_names = local_df.columns
     dtypes = [DataType(dtype) for dtype in local_df.dtypes]
 

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Shuffle logic for the RapidsMPF streaming runtime."""
 

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/shuffle.py
@@ -129,7 +129,7 @@ class ShuffleManager:
                 ``chunk``.
             """
             with stream_ordered_after(
-                self._manager.context.get_stream_from_pool,
+                self._manager.context.br().stream_pool.get_stream,
                 upstreams=(chunk.stream, partition_map.stream),
             ) as stream:
                 partition_map_col = partition_map.table_view().columns()[0]

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
@@ -481,7 +481,7 @@ def make_rapidsmpf_read_parquet_node(
 
     # Build ParquetReaderOptions
     try:
-        stream = context.get_stream_from_pool()
+        stream = context.br().stream_pool.get_stream()
         parquet_reader_options = (
             plc.io.parquet.ParquetReaderOptions.builder(plc.io.SourceInfo(ir.paths))
             .decimal_width(plc.TypeId.DECIMAL128)

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/repartition.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/repartition.py
@@ -143,7 +143,7 @@ async def concatenate_node(
             if tracer is not None and output_duplicated:
                 tracer.set_duplicated()
 
-            stream = context.get_stream_from_pool()
+            stream = context.br().stream_pool.get_stream()
             seq_num = 0
             allgather = AllGatherManager(context, comm, collective_id)
             with allgather.inserting() as inserter:

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/repartition.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/repartition.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Re-chunking logic for the RapidsMPF streaming runtime."""
 

--- a/python/cudf_polars/tests/streaming/test_allgather.py
+++ b/python/cudf_polars/tests/streaming/test_allgather.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for RapidsMPF AllGather functionality."""
@@ -22,7 +22,7 @@ async def _test_allgather(engine) -> None:
     """Very simple test that AllGatherManager can concatenate tables."""
     context = engine.context
     comm = engine.comm
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
 
     # Create simple test tables with different sizes
     tables = [

--- a/python/cudf_polars/tests/streaming/test_metadata.py
+++ b/python/cudf_polars/tests/streaming/test_metadata.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for RapidsMPF metadata functionality."""
@@ -490,7 +490,7 @@ def test_remap_partitioning_reorder_columns_projection(streaming_engine) -> None
 
 
 def _make_order_scheme(context, *, key_indices=(0,), values=(100, 200), strict=False):
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     df = DataFrame.from_polars(
         pl.DataFrame({f"k{i}": list(values) for i in key_indices}), stream
     )
@@ -678,7 +678,7 @@ def test_is_already_sorted(spmd_engine, scheme_key_count, strict, expected) -> N
     )
 
     ctx = spmd_engine.context
-    stream = ctx.get_stream_from_pool()
+    stream = ctx.br().stream_pool.get_stream()
     keys = [OrderKey(i, asc, before) for i in range(scheme_key_count)]
     boundary_chunk = TableChunk.from_pylibcudf_table(
         DataFrame.from_polars(

--- a/python/cudf_polars/tests/streaming/test_shuffler.py
+++ b/python/cudf_polars/tests/streaming/test_shuffler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -156,7 +156,7 @@ def test_local_repartitioner_hash(spmd_engine, local_count) -> None:
     results: list[tuple[int, pl.DataFrame]] = []
 
     async def _run() -> None:
-        stream = context.get_stream_from_pool()
+        stream = context.br().stream_pool.get_stream()
         cudf_df = DataFrame.from_polars(pl_df, stream)
         with reserve_op_id() as op_id:
             shuffle = ShuffleManager(
@@ -222,7 +222,7 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
     results: list[tuple[int, pl.DataFrame]] = []
 
     async def _run() -> None:
-        stream = context.get_stream_from_pool()
+        stream = context.br().stream_pool.get_stream()
         payload_df = DataFrame.from_polars(pl_payload, stream)
         rank_part_df = DataFrame.from_polars(pl_rank_part, stream)
 

--- a/python/cudf_polars/tests/streaming/test_spilling.py
+++ b/python/cudf_polars/tests/streaming/test_spilling.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for RapidsMPF spilling functionality."""
@@ -88,7 +88,7 @@ def test_make_spill_function(
     message_ids: dict[int, list[int]] = {}
 
     # Populate buffers with messages
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     for buffer_idx, (sm, count) in enumerate(
         zip(buffers, messages_per_buffer, strict=False)
     ):

--- a/python/cudf_polars/tests/streaming/test_tracing.py
+++ b/python/cudf_polars/tests/streaming/test_tracing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Integration tests for structlog tracing with rapidsmpf."""
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 @pytest.fixture
 def chunk(spmd_engine: SPMDEngine) -> TableChunk:
     context = spmd_engine.context
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     df = DataFrame.from_polars(pl.DataFrame({"x": [1, 2, 3]}), stream)
     return TableChunk.from_pylibcudf_table(
         df.table, stream, exclusive_view=True, br=context.br()

--- a/python/cudf_streaming/cudf_streaming/tests/test_bloom_filter.py
+++ b/python/cudf_streaming/cudf_streaming/tests/test_bloom_filter.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -129,7 +129,7 @@ def test_bloom_filter_roundtrip(context: Context, comm: Communicator) -> None:
     if comm.nranks != 1:
         pytest.skip("Only support single-rank runs")
 
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     values = np.arange(10, dtype=np.int32)
     build_table = make_table(values, stream=stream, br=context.br())
     probe_table = make_table(values, stream=stream, br=context.br())
@@ -150,7 +150,7 @@ def test_bloom_filter_empty_build_filters_all(
     if comm.nranks != 1:
         pytest.skip("Only support single-rank runs")
 
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     build_table = make_table(
         np.array([], dtype=np.int32), stream=stream, br=context.br()
     )

--- a/python/cudf_streaming/cudf_streaming/tests/test_channel_metadata.py
+++ b/python/cudf_streaming/cudf_streaming/tests/test_channel_metadata.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 def _make_boundaries(context: Context, table: plc.Table) -> TableChunk:
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     return TableChunk.from_pylibcudf_table(
         table,
         stream,

--- a/python/cudf_streaming/cudf_streaming/tests/test_read_parquet.py
+++ b/python/cudf_streaming/cudf_streaming/tests/test_read_parquet.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -75,7 +75,7 @@ def make_producer(
     use_filter: bool,
 ) -> CppActor:
     if use_filter:
-        fstream = context.get_stream_from_pool()
+        fstream = context.br().stream_pool.get_stream()
         return read_parquet(
             context,
             comm,
@@ -104,7 +104,7 @@ def get_expected(
     if num_rows != "all":
         options.set_num_rows(num_rows)
     if use_filter:
-        fstream = ctx.get_stream_from_pool()
+        fstream = ctx.br().stream_pool.get_stream()
         filter = make_filter(fstream)
         fstream.synchronize()
         options.set_filter(filter)

--- a/python/cudf_streaming/cudf_streaming/tests/test_streaming_allgather.py
+++ b/python/cudf_streaming/cudf_streaming/tests/test_streaming_allgather.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -40,7 +40,7 @@ def test_allgather_actor(context: Context, comm: Communicator) -> None:
 
     num_rows = 1000
     op_id = 0
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     input_tables = [
         plc.Table(
             [
@@ -101,7 +101,7 @@ async def generate_inputs(
     num_chunks: int,
 ) -> None:
     for i in range(num_chunks):
-        stream = context.get_stream_from_pool()
+        stream = context.br().stream_pool.get_stream()
         table = plc.Table(
             [
                 plc.Column.from_array(
@@ -145,7 +145,7 @@ async def allgather_and_concat(
     if not use_context_manager:
         gather.insert_finished()
     gathered = await gather.extract_all(context, ordered=True)
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     table = unpack_and_concat(gathered, stream, context.br())
     to_send = TableChunk.from_pylibcudf_table(
         table, stream, exclusive_view=True, br=context.br()

--- a/python/cudf_streaming/cudf_streaming/tests/test_streaming_shuffler.py
+++ b/python/cudf_streaming/cudf_streaming/tests/test_streaming_shuffler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -135,7 +135,7 @@ async def generate_inputs(
     context: Context, ch: Channel[TableChunk], num_rows: int, num_chunks: int
 ) -> None:
     for i in range(num_chunks):
-        stream = context.get_stream_from_pool()
+        stream = context.br().stream_pool.get_stream()
         table = plc.Table(
             [
                 plc.Column.from_array(
@@ -185,7 +185,7 @@ async def do_shuffle(
     await shuffle.insert_finished(context)
     for pid in shuffle.local_partitions():
         data = shuffle.extract(pid)
-        stream = context.get_stream_from_pool()
+        stream = context.br().stream_pool.get_stream()
         unpacked = TableChunk.from_pylibcudf_table(
             unpack_and_concat(data, stream, context.br()),
             stream,

--- a/python/cudf_streaming/cudf_streaming/tests/test_streaming_sparse_alltoall.py
+++ b/python/cudf_streaming/cudf_streaming/tests/test_streaming_sparse_alltoall.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 def make_packed_data(context: Context, values: np.ndarray) -> PackedData:
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     table = plc.Table([plc.Column.from_array(values, stream=stream)])
     return packed_data_from_cudf_packed_columns(
         plc.contiguous_split.pack(table, stream=stream),
@@ -34,7 +34,7 @@ def make_packed_data(context: Context, values: np.ndarray) -> PackedData:
 
 
 def unpack_table(context: Context, packed_data: PackedData) -> plc.Table:
-    stream = context.get_stream_from_pool()
+    stream = context.br().stream_pool.get_stream()
     return unpack_and_concat([packed_data], stream, context.br())
 
 
@@ -75,7 +75,7 @@ def test_sparse_alltoall_non_participating_ranks(
     if comm.rank == 1:
         results = exchange.extract(0)
         assert len(results) == 2
-        stream = context.get_stream_from_pool()
+        stream = context.br().stream_pool.get_stream()
         assert_eq(
             unpack_table(context, results[0]),
             plc.Table(


### PR DESCRIPTION
## Description
Now the buffer resource advertises the stream pool, we no longer get streams from the Context.

Depends on rapidsai/rapidsmpf#1105

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
