### PR TITLE
Fix deprecation warning in transform_polynomials_concurrent benchmarks

### DIFF
--- a/cpp/benchmarks/transform/polynomials_concurrent.cpp
+++ b/cpp/benchmarks/transform/polynomials_concurrent.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -44,11 +44,12 @@ static void BM_transform_polynomials_concurrent(nvbench::state& state)
     std::back_inserter(constants),
     [&](int) { return create_random_column(cudf::type_to_id<key_type>(), row_count{1}, profile); });
 
-  std::vector<cudf::column_view> inputs{column->view()};
+  std::vector<cudf::transform_input> inputs{cudf::transform_input{*column}};
   std::transform(
-    constants.begin(), constants.end(), std::back_inserter(inputs), [](auto const& col) {
-      return col->view();
-    });
+    constants.begin(),
+    constants.end(),
+    std::back_inserter(inputs),
+    [](auto const& col) -> cudf::transform_input { return cudf::scalar_column_view(*col); });
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto root_stream = launch.get_stream().get_stream();
@@ -84,14 +85,15 @@ static void BM_transform_polynomials_concurrent(nvbench::state& state)
                         ";"
                         "}";
 
-      cudf::transform(inputs,
-                      udf,
-                      cudf::data_type{cudf::type_to_id<key_type>()},
-                      false,
-                      std::nullopt,
-                      cudf::null_aware::NO,
-                      cudf::output_nullability::PRESERVE,
-                      stream);
+      cudf::transform_extended(inputs,
+                               udf,
+                               cudf::data_type{cudf::type_to_id<key_type>()},
+                               cudf::udf_source_type::CUDA,
+                               std::nullopt,
+                               cudf::null_aware::NO,
+                               std::nullopt,
+                               cudf::output_nullability::PRESERVE,
+                               stream);
       nvtxRangePop();
     };
 


### PR DESCRIPTION
## Description
Fixes deprecation warning in the benchmarks/transform/polynomials_concurrent.cpp compilation:

```
/cudf/cpp/benchmarks/transform/polynomials_concurrent.cpp:87:22: warning: 'std::unique_ptr<cudf::column> cudf::transform(const std::vector<column_view>&, const std::string&, data_type, bool, std::optional<void*>, null_aware, output_nullability, rmm::cuda_stream_view, rmm::device_async_resource_ref)' is deprecated: Use transform_extended instead [-Wdeprecated-declarations]
   87 |       cudf::transform(inputs,
      |       ~~~~~~~~~~~~~~~^~~~~~~~
   88 |                       udf,
      |                       ~~~~
   89 |                       cudf::data_type{cudf::type_to_id<key_type>()},
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   90 |                       false,
      |                       ~~~~~~
   91 |                       std::nullopt,
      |                       ~~~~~~~~~~~~~
   92 |                       cudf::null_aware::NO,
      |                       ~~~~~~~~~~~~~~~~~~~~~
   93 |                       cudf::output_nullability::PRESERVE,
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   94 |                       stream);
      |                       ~~~~~~~
In file included from /cudf/cpp/benchmarks/transform/polynomials_concurrent.cpp:12:
/cudf/cpp/include/cudf/transform.hpp:59:74: note: declared here
   59 | [[deprecated("Use transform_extended instead")]] std::unique_ptr<column> transform(
      |                                                                          ^~~~~~~~~

```


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
