### PR TITLE
[MINOR] Fix style check error in `numpy.py` wrapper

### DIFF
--- a/python/cudf/cudf/pandas/_wrappers/numpy.py
+++ b/python/cudf/cudf/pandas/_wrappers/numpy.py
@@ -328,7 +328,9 @@ if version.parse(numpy.__version__) >= version.parse("2.0"):
     # NumPy 2 introduced `_core` and gives warnings for access to `core`.
     from numpy._core.multiarray import flagsobj as _numpy_flagsobj
 else:
-    from numpy.core.multiarray import flagsobj as _numpy_flagsobj
+    from numpy.core.multiarray import (  # type: ignore[no-redef]
+        flagsobj as _numpy_flagsobj,
+    )
 
 # Mapping flags between slow and fast types
 _ndarray_flags = make_intermediate_proxy_type(


### PR DESCRIPTION
## Description

Fixes the following style check error
```
defs  [annotation-unchecked]
python/cudf/cudf/pandas/_wrappers/numpy.py:331: error: Unused "type: ignore" comment  [unused-ignore]
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
