### PR TITLE
Add string slice options for length-based bounds

### DIFF
--- a/cpp/include/cudf/strings/slice.hpp
+++ b/cpp/include/cudf/strings/slice.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -16,6 +16,57 @@ namespace strings {
  * @{
  * @file
  */
+
+/**
+ * @brief Indicates whether the start position is interpreted as a zero-based or one-based index.
+ */
+enum class start_indexing_policy {
+  ZERO_BASED,  ///< The first character position is 0
+  ONE_BASED    ///< The first character position is 1; start value 0 maps to the first character
+};
+
+/**
+ * @brief Indicates how a negative start position is interpreted.
+ */
+enum class negative_start_policy {
+  CLAMP_TO_ZERO,   ///< Negative start positions are clamped to the first character
+  RELATIVE_TO_END  ///< Negative start positions are relative to the end of the string
+};
+
+/**
+ * @brief Indicates how the second slicing parameter is interpreted.
+ */
+enum class slice_bounds_policy {
+  START_AND_STOP,   ///< The second parameter is the exclusive stop position
+  START_AND_LENGTH  ///< The second parameter is the number of characters to include
+};
+
+/**
+ * @brief Indicates how negative length values are interpreted.
+ */
+enum class negative_length_policy {
+  PRESERVE,      ///< Negative lengths are preserved when computing the stop position
+  CLAMP_TO_ZERO  ///< Negative lengths are clamped to zero
+};
+
+/**
+ * @brief Indicates how a missing length is interpreted when using START_AND_LENGTH bounds.
+ */
+enum class missing_length_policy {
+  TO_END,   ///< A missing length slices through the end of each string
+  MAX_SIZE  ///< A missing length is treated as the maximum supported size_type value
+};
+
+/**
+ * @brief Options controlling how slice bounds are interpreted.
+ */
+struct slice_strings_options {
+  start_indexing_policy start_indexing{start_indexing_policy::ZERO_BASED};
+  negative_start_policy negative_start{negative_start_policy::CLAMP_TO_ZERO};
+  slice_bounds_policy bounds{slice_bounds_policy::START_AND_STOP};
+  negative_length_policy negative_length{negative_length_policy::PRESERVE};
+  missing_length_policy missing_length{missing_length_policy::TO_END};
+};
 
 /**
  * @brief Returns a new strings column that contains substrings of the
@@ -53,6 +104,32 @@ std::unique_ptr<column> slice_strings(
   numeric_scalar<size_type> const& step  = numeric_scalar<size_type>(1),
   rmm::cuda_stream_view stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Returns a new strings column that contains substrings of the
+ * strings in the provided column.
+ *
+ * The character positions are interpreted according to the provided options.
+ * The default options preserve the zero-based `[start, stop)` interpretation.
+ *
+ * @param input Strings column for this operation
+ * @param start First character position to begin the substring
+ * @param stop Last character position (exclusive) or length, depending on `options`
+ * @param step Distance between input characters retrieved. Must be 1 unless `options` is the
+ * default zero-based `[start, stop)` behavior.
+ * @param options Options controlling how slice bounds are interpreted
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return New strings column with sliced strings
+ */
+std::unique_ptr<column> slice_strings(
+  strings_column_view const& input,
+  numeric_scalar<size_type> const& start,
+  numeric_scalar<size_type> const& stop,
+  numeric_scalar<size_type> const& step,
+  slice_strings_options const& options,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Returns a new strings column that contains substrings of the
@@ -96,6 +173,33 @@ std::unique_ptr<column> slice_strings(
   strings_column_view const& input,
   column_view const& starts,
   column_view const& stops,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Returns a new strings column that contains substrings of the
+ * strings in the provided column using unique bounds for each string.
+ *
+ * The character positions are interpreted according to the provided options.
+ * The default options preserve the zero-based `[start, stop)` interpretation.
+ *
+ * @throw cudf::logic_error if starts or stops is a different size than the strings column.
+ * @throw cudf::logic_error if starts and stops are not same integer type.
+ * @throw cudf::logic_error if starts or stops contains nulls.
+ *
+ * @param input Strings column for this operation
+ * @param starts First character positions to begin the substring
+ * @param stops Last character position (exclusive) or length, depending on `options`
+ * @param options Options controlling how slice bounds are interpreted
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return New strings column with sliced strings
+ */
+std::unique_ptr<column> slice_strings(
+  strings_column_view const& input,
+  column_view const& starts,
+  column_view const& stops,
+  slice_strings_options const& options,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 

--- a/cpp/src/strings/slice.cu
+++ b/cpp/src/strings/slice.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -39,6 +39,71 @@ namespace {
 
 constexpr size_type AVG_CHAR_BYTES_THRESHOLD = 128;
 
+bool is_default_slice_options(slice_strings_options const& options)
+{
+  return options.start_indexing == start_indexing_policy::ZERO_BASED &&
+         options.negative_start == negative_start_policy::CLAMP_TO_ZERO &&
+         options.bounds == slice_bounds_policy::START_AND_STOP &&
+         options.negative_length == negative_length_policy::PRESERVE &&
+         options.missing_length == missing_length_policy::TO_END;
+}
+
+__device__ int64_t saturating_add(int64_t lhs, int64_t rhs)
+{
+  if (rhs > 0 && lhs > cuda::std::numeric_limits<int64_t>::max() - rhs) {
+    return cuda::std::numeric_limits<int64_t>::max();
+  }
+  if (rhs < 0 && lhs < cuda::std::numeric_limits<int64_t>::min() - rhs) {
+    return cuda::std::numeric_limits<int64_t>::min();
+  }
+  return lhs + rhs;
+}
+
+__device__ int64_t clamp_position(int64_t value, int64_t length)
+{
+  return cuda::std::min(cuda::std::max(value, int64_t{0}), length);
+}
+
+__device__ int64_t pre_length_start_position(size_type length,
+                                             int64_t raw_start,
+                                             slice_strings_options const& options)
+{
+  if (raw_start < 0 && options.negative_start == negative_start_policy::RELATIVE_TO_END) {
+    return saturating_add(static_cast<int64_t>(length), raw_start);
+  }
+  if (raw_start < 0 && options.negative_start == negative_start_policy::CLAMP_TO_ZERO) { return 0; }
+  if (raw_start > 0 && options.start_indexing == start_indexing_policy::ONE_BASED) {
+    return raw_start - 1;
+  }
+  return raw_start;
+}
+
+__device__ int64_t stop_position(size_type length,
+                                 int64_t pre_length_start,
+                                 int64_t raw_stop_or_length,
+                                 bool has_stop_or_length,
+                                 slice_strings_options const& options)
+{
+  if (options.bounds == slice_bounds_policy::START_AND_LENGTH) {
+    if (!has_stop_or_length) {
+      return options.missing_length == missing_length_policy::MAX_SIZE
+               ? clamp_position(
+                   saturating_add(pre_length_start, cuda::std::numeric_limits<size_type>::max()),
+                   length)
+               : static_cast<int64_t>(length);
+    }
+    auto substring_length = raw_stop_or_length;
+    if (substring_length < 0 && options.negative_length == negative_length_policy::CLAMP_TO_ZERO) {
+      substring_length = 0;
+    }
+    return clamp_position(saturating_add(pre_length_start, substring_length), length);
+  }
+
+  if (!has_stop_or_length) { return static_cast<int64_t>(length); }
+  return raw_stop_or_length < 0 ? static_cast<int64_t>(length)
+                                : clamp_position(raw_stop_or_length, length);
+}
+
 /**
  * @brief Function logic for compute_substrings_from_fn API
  *
@@ -67,6 +132,45 @@ struct substring_from_fn {
 
   substring_from_fn(column_device_view const& d_column, IndexIterator starts, IndexIterator stops)
     : d_column(d_column), starts(starts), stops(stops)
+  {
+  }
+};
+
+template <typename IndexIterator>
+struct substring_with_options_from_fn {
+  column_device_view const d_column;
+  IndexIterator const starts;
+  IndexIterator const stops_or_lengths;
+  bool const has_stop_or_length;
+  slice_strings_options const options;
+
+  __device__ string_index_pair operator()(size_type idx) const
+  {
+    if (d_column.is_null(idx)) { return string_index_pair{nullptr, 0}; }
+    auto const d_str     = d_column.template element<string_view>(idx);
+    auto const length    = d_str.length();
+    auto const raw_start = static_cast<int64_t>(starts[idx]);
+    auto const pre_start = pre_length_start_position(length, raw_start, options);
+    auto const start     = clamp_position(pre_start, length);
+    auto const raw_stop  = has_stop_or_length ? static_cast<int64_t>(stops_or_lengths[idx]) : 0;
+    auto const stop      = stop_position(length, pre_start, raw_stop, has_stop_or_length, options);
+    auto const sub_str   = start < stop ? d_str.substr(static_cast<size_type>(start),
+                                                     static_cast<size_type>(stop - start))
+                                        : string_view{};
+    return sub_str.empty() ? string_index_pair{"", 0}
+                           : string_index_pair{sub_str.data(), sub_str.size_bytes()};
+  }
+
+  substring_with_options_from_fn(column_device_view const& d_column,
+                                 IndexIterator starts,
+                                 IndexIterator stops_or_lengths,
+                                 bool has_stop_or_length,
+                                 slice_strings_options const& options)
+    : d_column(d_column),
+      starts(starts),
+      stops_or_lengths(stops_or_lengths),
+      has_stop_or_length(has_stop_or_length),
+      options(options)
   {
   }
 };
@@ -265,6 +369,29 @@ std::unique_ptr<column> compute_substrings_from_fn(strings_column_view const& in
   return make_strings_column(results.begin(), results.end(), stream, mr);
 }
 
+template <typename IndexIterator>
+std::unique_ptr<column> compute_substrings_with_options_from_fn(
+  strings_column_view const& input,
+  IndexIterator starts,
+  IndexIterator stops_or_lengths,
+  bool has_stop_or_length,
+  slice_strings_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto results = rmm::device_uvector<string_index_pair>(input.size(), stream);
+
+  auto const d_column = column_device_view::create(input.parent(), stream);
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    cuda::counting_iterator<size_type>{0},
+                    cuda::counting_iterator<size_type>{input.size()},
+                    results.begin(),
+                    substring_with_options_from_fn{
+                      *d_column, starts, stops_or_lengths, has_stop_or_length, options});
+
+  return make_strings_column(results.begin(), results.end(), stream, mr);
+}
+
 }  // namespace
 
 //
@@ -316,6 +443,38 @@ std::unique_ptr<column> slice_strings(strings_column_view const& input,
 }
 
 std::unique_ptr<column> slice_strings(strings_column_view const& input,
+                                      numeric_scalar<size_type> const& start,
+                                      numeric_scalar<size_type> const& stop,
+                                      numeric_scalar<size_type> const& step,
+                                      slice_strings_options const& options,
+                                      rmm::cuda_stream_view stream,
+                                      rmm::device_async_resource_ref mr)
+{
+  if (is_default_slice_options(options)) {
+    return slice_strings(input, start, stop, step, stream, mr);
+  }
+
+  if (input.size() == input.null_count()) {
+    return std::make_unique<column>(input.parent(), stream, mr);
+  }
+
+  auto const step_valid = step.is_valid(stream);
+  auto const step_value = step_valid ? step.value(stream) : 1;
+  if (step_valid) { CUDF_EXPECTS(step_value == 1, "Step parameter must be 1 with slice options"); }
+
+  auto const start_value = start.is_valid(stream) ? start.value(stream) : 0;
+  auto const stop_valid  = stop.is_valid(stream);
+  auto const stop_value  = stop_valid ? stop.value(stream) : 0;
+  return compute_substrings_with_options_from_fn(input,
+                                                 cuda::constant_iterator<size_type>(start_value),
+                                                 cuda::constant_iterator<size_type>(stop_value),
+                                                 stop_valid,
+                                                 options,
+                                                 stream,
+                                                 mr);
+}
+
+std::unique_ptr<column> slice_strings(strings_column_view const& input,
                                       column_view const& starts_column,
                                       column_view const& stops_column,
                                       rmm::cuda_stream_view stream,
@@ -337,6 +496,34 @@ std::unique_ptr<column> slice_strings(strings_column_view const& input,
   return compute_substrings_from_fn(input, starts_iter, stops_iter, stream, mr);
 }
 
+std::unique_ptr<column> slice_strings(strings_column_view const& input,
+                                      column_view const& starts_column,
+                                      column_view const& stops_column,
+                                      slice_strings_options const& options,
+                                      rmm::cuda_stream_view stream,
+                                      rmm::device_async_resource_ref mr)
+{
+  if (is_default_slice_options(options)) {
+    return slice_strings(input, starts_column, stops_column, stream, mr);
+  }
+
+  if (input.size() == input.null_count()) {
+    return std::make_unique<column>(input.parent(), stream, mr);
+  }
+
+  CUDF_EXPECTS(starts_column.size() == input.size(),
+               "Parameter starts must have the same number of rows as strings.");
+  CUDF_EXPECTS(stops_column.size() == input.size(),
+               "Parameter stops must have the same number of rows as strings.");
+  CUDF_EXPECTS(starts_column.null_count() == 0, "Parameter starts must not contain nulls.");
+  CUDF_EXPECTS(stops_column.null_count() == 0, "Parameter stops must not contain nulls.");
+
+  auto starts_iter = cudf::detail::indexalator_factory::make_input_iterator(starts_column);
+  auto stops_iter  = cudf::detail::indexalator_factory::make_input_iterator(stops_column);
+  return compute_substrings_with_options_from_fn(
+    input, starts_iter, stops_iter, true, options, stream, mr);
+}
+
 }  // namespace detail
 
 // external API
@@ -353,6 +540,18 @@ std::unique_ptr<column> slice_strings(strings_column_view const& input,
 }
 
 std::unique_ptr<column> slice_strings(strings_column_view const& input,
+                                      numeric_scalar<size_type> const& start,
+                                      numeric_scalar<size_type> const& stop,
+                                      numeric_scalar<size_type> const& step,
+                                      slice_strings_options const& options,
+                                      rmm::cuda_stream_view stream,
+                                      rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::slice_strings(input, start, stop, step, options, stream, mr);
+}
+
+std::unique_ptr<column> slice_strings(strings_column_view const& input,
                                       column_view const& starts_column,
                                       column_view const& stops_column,
                                       rmm::cuda_stream_view stream,
@@ -360,6 +559,17 @@ std::unique_ptr<column> slice_strings(strings_column_view const& input,
 {
   CUDF_FUNC_RANGE();
   return detail::slice_strings(input, starts_column, stops_column, stream, mr);
+}
+
+std::unique_ptr<column> slice_strings(strings_column_view const& input,
+                                      column_view const& starts_column,
+                                      column_view const& stops_column,
+                                      slice_strings_options const& options,
+                                      rmm::cuda_stream_view stream,
+                                      rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::slice_strings(input, starts_column, stops_column, options, stream, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/slice.cu
+++ b/cpp/src/strings/slice.cu
@@ -503,6 +503,9 @@ std::unique_ptr<column> slice_strings(strings_column_view const& input,
                                       rmm::cuda_stream_view stream,
                                       rmm::device_async_resource_ref mr)
 {
+  CUDF_EXPECTS(cudf::have_same_types(starts_column, stops_column),
+               "Parameters starts and stops must be the same integer type.");
+
   if (is_default_slice_options(options)) {
     return slice_strings(input, starts_column, stops_column, stream, mr);
   }

--- a/cpp/tests/strings/slice_tests.cpp
+++ b/cpp/tests/strings/slice_tests.cpp
@@ -491,6 +491,10 @@ TEST_F(StringsSliceTest, Error)
                cudf::logic_error);
   EXPECT_THROW(cudf::strings::slice_strings(strings_view, indexes_bad, indexes_bad, options),
                cudf::logic_error);
+  auto indexes_32 = cudf::test::fixed_width_column_wrapper<int32_t>({1});
+  auto indexes_64 = cudf::test::fixed_width_column_wrapper<int64_t>({1});
+  EXPECT_THROW(cudf::strings::slice_strings(strings_view, indexes_32, indexes_64, options),
+               cudf::logic_error);
 }
 
 TEST_F(StringsSliceTest, ZeroSizeStringsColumn)

--- a/cpp/tests/strings/slice_tests.cpp
+++ b/cpp/tests/strings/slice_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/sequence.h>
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -187,6 +188,177 @@ TEST_F(StringsSliceTest, NegativePositions)
   }
 }
 
+TEST_F(StringsSliceTest, StartAndLengthOptions)
+{
+  std::vector<char const*> h_strings{"example",
+                                     "example",
+                                     "example",
+                                     "example",
+                                     "example",
+                                     "example",
+                                     "example",
+                                     "da数据ta",
+                                     nullptr,
+                                     ""};
+  cudf::test::strings_column_wrapper strings(
+    h_strings.begin(),
+    h_strings.end(),
+    thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
+  auto strings_column = cudf::strings_column_view(strings);
+  auto starts =
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>({0, 1, 2, -2, -7, -8, -9, 2, 1, 1});
+  auto lengths =
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>({2, -1, 2, 2, 7, 2, 9, 4, 2, 2});
+
+  cudf::strings::slice_strings_options options;
+  options.start_indexing  = cudf::strings::start_indexing_policy::ONE_BASED;
+  options.negative_start  = cudf::strings::negative_start_policy::RELATIVE_TO_END;
+  options.bounds          = cudf::strings::slice_bounds_policy::START_AND_LENGTH;
+  options.negative_length = cudf::strings::negative_length_policy::CLAMP_TO_ZERO;
+
+  auto results = cudf::strings::slice_strings(strings_column, starts, lengths, options);
+
+  std::vector<char const*> h_expected{
+    "ex", "", "xa", "le", "example", "e", "example", "a数据t", nullptr, ""};
+  cudf::test::strings_column_wrapper expected(
+    h_expected.begin(),
+    h_expected.end(),
+    thrust::make_transform_iterator(h_expected.begin(), [](auto str) { return str != nullptr; }));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+}
+
+TEST_F(StringsSliceTest, StartAndMissingLengthOptions)
+{
+  cudf::test::strings_column_wrapper strings{"example"};
+  auto strings_column = cudf::strings_column_view(strings);
+
+  cudf::strings::slice_strings_options options;
+  options.start_indexing  = cudf::strings::start_indexing_policy::ONE_BASED;
+  options.negative_start  = cudf::strings::negative_start_policy::RELATIVE_TO_END;
+  options.bounds          = cudf::strings::slice_bounds_policy::START_AND_LENGTH;
+  options.missing_length  = cudf::strings::missing_length_policy::MAX_SIZE;
+  options.negative_length = cudf::strings::negative_length_policy::CLAMP_TO_ZERO;
+
+  cudf::numeric_scalar<cudf::size_type> start(std::numeric_limits<cudf::size_type>::min());
+  cudf::numeric_scalar<cudf::size_type> missing_length(0, false);
+  auto results = cudf::strings::slice_strings(
+    strings_column, start, missing_length, cudf::numeric_scalar<cudf::size_type>(1), options);
+
+  cudf::test::strings_column_wrapper expected{"exampl"};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+}
+
+TEST_F(StringsSliceTest, NegativeStartClampWithLengthOptions)
+{
+  cudf::test::strings_column_wrapper strings{"abcdef"};
+  auto strings_column = cudf::strings_column_view(strings);
+  auto starts         = cudf::test::fixed_width_column_wrapper<cudf::size_type>({-2});
+  auto lengths        = cudf::test::fixed_width_column_wrapper<cudf::size_type>({3});
+
+  cudf::strings::slice_strings_options options;
+  options.bounds = cudf::strings::slice_bounds_policy::START_AND_LENGTH;
+
+  auto results = cudf::strings::slice_strings(strings_column, starts, lengths, options);
+
+  cudf::test::strings_column_wrapper expected{"abc"};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+}
+
+TEST_F(StringsSliceTest, DefaultOptionsMatchExistingBehavior)
+{
+  cudf::test::strings_column_wrapper strings{"abcdef", "xy", ""};
+  auto strings_column = cudf::strings_column_view(strings);
+  cudf::strings::slice_strings_options options;
+
+  auto expected = cudf::strings::slice_strings(strings_column, 1, 3);
+  auto results  = cudf::strings::slice_strings(strings_column,
+                                              cudf::numeric_scalar<cudf::size_type>(1),
+                                              cudf::numeric_scalar<cudf::size_type>(3),
+                                              cudf::numeric_scalar<cudf::size_type>(1),
+                                              options);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, *expected);
+
+  auto starts = cudf::test::fixed_width_column_wrapper<cudf::size_type>({0, 1, 1});
+  auto stops  = cudf::test::fixed_width_column_wrapper<cudf::size_type>({2, 2, 5});
+  expected    = cudf::strings::slice_strings(strings_column, starts, stops);
+  results     = cudf::strings::slice_strings(strings_column, starts, stops, options);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, *expected);
+}
+
+TEST_F(StringsSliceTest, MissingLengthToEndOptions)
+{
+  cudf::test::strings_column_wrapper strings{"abcdef"};
+  auto strings_column = cudf::strings_column_view(strings);
+
+  cudf::strings::slice_strings_options options;
+  options.negative_start = cudf::strings::negative_start_policy::RELATIVE_TO_END;
+  options.bounds         = cudf::strings::slice_bounds_policy::START_AND_LENGTH;
+  options.missing_length = cudf::strings::missing_length_policy::TO_END;
+
+  auto results = cudf::strings::slice_strings(strings_column,
+                                              cudf::numeric_scalar<cudf::size_type>(-2),
+                                              cudf::numeric_scalar<cudf::size_type>(0, false),
+                                              cudf::numeric_scalar<cudf::size_type>(1),
+                                              options);
+
+  cudf::test::strings_column_wrapper expected{"ef"};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+}
+
+TEST_F(StringsSliceTest, StartAndStopOptions)
+{
+  cudf::test::strings_column_wrapper strings{"abcdef", "abcdef"};
+  auto strings_column = cudf::strings_column_view(strings);
+  auto starts         = cudf::test::fixed_width_column_wrapper<cudf::size_type>({2, -2});
+  auto stops          = cudf::test::fixed_width_column_wrapper<cudf::size_type>({4, 6});
+
+  cudf::strings::slice_strings_options options;
+  options.start_indexing = cudf::strings::start_indexing_policy::ONE_BASED;
+  options.negative_start = cudf::strings::negative_start_policy::RELATIVE_TO_END;
+  options.bounds         = cudf::strings::slice_bounds_policy::START_AND_STOP;
+
+  auto results = cudf::strings::slice_strings(strings_column, starts, stops, options);
+
+  cudf::test::strings_column_wrapper expected{"bcd", "ef"};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+}
+
+TEST_F(StringsSliceTest, NegativeLengthPreserveOptions)
+{
+  cudf::test::strings_column_wrapper strings{"abcdef"};
+  auto strings_column = cudf::strings_column_view(strings);
+  auto starts         = cudf::test::fixed_width_column_wrapper<cudf::size_type>({3});
+  auto lengths        = cudf::test::fixed_width_column_wrapper<cudf::size_type>({-1});
+
+  cudf::strings::slice_strings_options options;
+  options.bounds = cudf::strings::slice_bounds_policy::START_AND_LENGTH;
+
+  auto results = cudf::strings::slice_strings(strings_column, starts, lengths, options);
+
+  cudf::test::strings_column_wrapper expected{""};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+}
+
+TEST_F(StringsSliceTest, AllNullsOptions)
+{
+  std::vector<char const*> h_strings{nullptr, nullptr};
+  cudf::test::strings_column_wrapper strings(
+    h_strings.begin(),
+    h_strings.end(),
+    thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
+  auto strings_column = cudf::strings_column_view(strings);
+
+  cudf::strings::slice_strings_options options;
+  options.bounds = cudf::strings::slice_bounds_policy::START_AND_LENGTH;
+
+  auto results = cudf::strings::slice_strings(strings_column,
+                                              cudf::numeric_scalar<cudf::size_type>(1),
+                                              cudf::numeric_scalar<cudf::size_type>(2),
+                                              cudf::numeric_scalar<cudf::size_type>(1),
+                                              options);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, strings);
+}
+
 TEST_F(StringsSliceTest, NullPositions)
 {
   cudf::test::strings_column_wrapper strings{"a", "bc", "def", "ghij", "klmno", "pqrstu", "vwxyz"};
@@ -303,6 +475,21 @@ TEST_F(StringsSliceTest, Error)
 
   auto indexes_bad = cudf::test::fixed_width_column_wrapper<float>({1});
   EXPECT_THROW(cudf::strings::slice_strings(strings_view, indexes_bad, indexes_bad),
+               cudf::logic_error);
+
+  cudf::strings::slice_strings_options options;
+  options.bounds = cudf::strings::slice_bounds_policy::START_AND_LENGTH;
+  EXPECT_THROW(cudf::strings::slice_strings(strings_view,
+                                            cudf::numeric_scalar<cudf::size_type>(0),
+                                            cudf::numeric_scalar<cudf::size_type>(1),
+                                            cudf::numeric_scalar<cudf::size_type>(2),
+                                            options),
+               cudf::logic_error);
+  EXPECT_THROW(cudf::strings::slice_strings(strings_view, indexes, indexes, options),
+               cudf::logic_error);
+  EXPECT_THROW(cudf::strings::slice_strings(strings_view, indexes_null, indexes_null, options),
+               cudf::logic_error);
+  EXPECT_THROW(cudf::strings::slice_strings(strings_view, indexes_bad, indexes_bad, options),
                cudf::logic_error);
 }
 


### PR DESCRIPTION
## Summary
- Add neutral `slice_strings_options` policies for start indexing, negative starts, start/length bounds, negative lengths, and missing lengths.
- Add policy-aware `slice_strings` overloads for scalar and per-row bounds while preserving the existing default zero-based `[start, stop)` behavior.
- Extend string slice tests for default compatibility, length-based bounds, missing length behavior, negative starts/lengths, nulls, and invalid inputs.

## Test plan
- Built and ran filtered cuDF `STRINGS_TEST` coverage for the new slice options paths in the `cudf-spark-jni` Docker environment.
- Verified downstream Velox Spark substring integration against CPU results.
- Ran the downstream Velox substring benchmark below in the Velox CUDA container.

## Motivation
Downstream users need to express substring semantics where the second argument is a length rather than an exclusive stop position, and where start/length edge cases differ from the current default cuDF slicing rules. Today those semantics must be assembled outside cuDF with multiple operators, temporary columns, and downstream-specific logic. One example is at https://github.com/facebookincubator/velox/pull/17849.

This change keeps the public API engine-neutral by adding composable policies instead of introducing engine-specific branching or naming in cuDF. The default options preserve the existing zero-based `[start, stop)` behavior, while downstreams can opt into start/length interpretation, one-based starts, end-relative negative starts, clamped negative lengths, and max-size missing lengths through the same `slice_strings` API.

## Performance
Measured in a downstream Velox prototype using the new options path versus the current multi-step cuDF implementation. The benchmark uses 256K rows, short strings of 24 chars, long strings of 256 chars, and here comes the perf results.

```text
GPU: NVIDIA RTX 5880 Ada Generation
CUDA: 12.9 / nvcc V12.9.86

multi_step_cudf_slice_constant_short_strings       22.73s
cudf_slice_options_constant_short_strings          22.22s  (1.02x)

multi_step_cudf_slice_columns_short_strings        21.74s
cudf_slice_options_columns_short_strings            6.26s  (3.47x)

multi_step_cudf_slice_constant_long_strings        19.81s
cudf_slice_options_constant_long_strings           19.95s  (0.99x)

multi_step_cudf_slice_columns_long_strings         19.78s
cudf_slice_options_columns_long_strings             6.77s  (2.92x)
```

The options path is effectively flat for constant start/length arguments and about 2.9x-3.5x faster for per-row start/length columns because it avoids the downstream multi-step composition.

