### PR TITLE
[FEA] Use the conda package for croaring instead of fetching via CPM

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -16,6 +16,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cramjam
+- croaring ==4.4.2
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cramjam
-- croaring ==4.4.2
+- croaring==4.4.2
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -16,6 +16,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cramjam
+- croaring ==4.4.2
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cramjam
-- croaring ==4.4.2
+- croaring==4.4.2
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -16,6 +16,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cramjam
+- croaring ==4.4.2
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cramjam
-- croaring ==4.4.2
+- croaring==4.4.2
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -16,6 +16,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cramjam
+- croaring ==4.4.2
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cramjam
-- croaring ==4.4.2
+- croaring==4.4.2
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -16,6 +16,9 @@ c_stdlib_version:
 cmake_version:
   - ">=4.0"
 
+croaring_version:
+  - "=4.4.2"
+
 dlpack_version:
   - ">=0.8,<1.0"
 

--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -96,12 +96,12 @@ cache:
           - libcufile-dev
       - cuda-version =${{ cuda_version }}
       - libnvcomp-dev ${{ nvcomp_version }}
+      - croaring ${{ croaring_version }}
       - dlpack ${{ dlpack_version }}
       - librdkafka
       - flatbuffers =${{ flatbuffers_version }}
       - rapids-logger =0.2
       - zlib ${{ zlib_version }}
-      - croaring =4.4.2
 
 outputs:
   - package:
@@ -365,7 +365,7 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - libcurand-dev
         - cuda-cudart-dev
-        - croaring =4.4.2
+        - croaring ${{ croaring_version }}
         - cuda-sanitizer-api
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}

--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -101,6 +101,7 @@ cache:
       - flatbuffers =${{ flatbuffers_version }}
       - rapids-logger =0.2
       - zlib ${{ zlib_version }}
+      - croaring =4.4.2
 
 outputs:
   - package:
@@ -364,6 +365,7 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - libcurand-dev
         - cuda-cudart-dev
+        - croaring =4.4.2
         - cuda-sanitizer-api
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -385,8 +385,10 @@ include(cmake/thirdparty/get_cccl.cmake)
 # find rmm, should come after including CCCL to allow overriding the CCCL version used for testing
 include(cmake/thirdparty/get_rmm.cmake)
 
-# find croaring
-include(cmake/thirdparty/get_croaring.cmake)
+# find croaring, needed by tests and benchmarks
+if(CUDF_BUILD_TESTS OR CUDF_BUILD_BENCHMARKS)
+  include(cmake/thirdparty/get_croaring.cmake)
+endif()
 
 # find flatbuffers
 include(cmake/thirdparty/get_flatbuffers.cmake)

--- a/cpp/cmake/thirdparty/get_croaring.cmake
+++ b/cpp/cmake/thirdparty/get_croaring.cmake
@@ -1,16 +1,16 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
 
-# Use CPM to clone CRoaring and set up the necessary targets and include directories.
+# Find or build the CRoaring library needed for libcudf tests and benchmarks.
 function(find_and_configure_roaring VERSION EXCLUDE_FROM_ALL)
 
   rapids_cpm_find(
     roaring ${VERSION}
-    GLOBAL_TARGETS roaring
+    GLOBAL_TARGETS roaring::roaring
     CPM_ARGS
     GIT_REPOSITORY https://github.com/RoaringBitmap/CRoaring.git
     GIT_TAG v${VERSION}
@@ -27,6 +27,10 @@ function(find_and_configure_roaring VERSION EXCLUDE_FROM_ALL)
   )
   if(roaring_ADDED)
     set_target_properties(roaring PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  elseif(NOT TARGET roaring AND TARGET roaring::roaring)
+    # When found via find_package (e.g. conda), the target is namespaced. Create an alias so
+    # consumers can use the non-namespaced name.
+    add_library(roaring ALIAS roaring::roaring)
   endif()
 
   if(DEFINED roaring_SOURCE_DIR)
@@ -38,5 +42,5 @@ function(find_and_configure_roaring VERSION EXCLUDE_FROM_ALL)
 
 endfunction()
 
-set(roaring_VERSION_cudf "4.3.11")
+set(roaring_VERSION_cudf "4.4.2")
 find_and_configure_roaring(${roaring_VERSION_cudf} ${CUDF_EXCLUDE_DEPS_FROM_ALL})

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -997,6 +997,7 @@ dependencies:
       - output_types: conda
         packages:
           - *cmake_ver
+          - croaring ==4.4.2
           - cuda-sanitizer-api
   # packages we want in the 'test_cpp' group in 'files', for CI, but which
   # shouldn't be added to 'all' for building a development environment

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -629,6 +629,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
+          - croaring==4.4.2
           - flatbuffers==24.3.25
           - librdkafka>=2.11.1,<2.12.0
   depends_on_libnvcomp:
@@ -997,7 +998,6 @@ dependencies:
       - output_types: conda
         packages:
           - *cmake_ver
-          - croaring ==4.4.2
           - cuda-sanitizer-api
   # packages we want in the 'test_cpp' group in 'files', for CI, but which
   # shouldn't be added to 'all' for building a development environment


### PR DESCRIPTION
## Description

Closes #20002.

This updates libcudf test and benchmark builds to use the conda `croaring` package when it is available, while preserving the CPM fallback for non-conda builds. CRoaring lookup is gated behind `CUDF_BUILD_TESTS` or `CUDF_BUILD_BENCHMARKS` so normal libcudf builds do not require the dependency.

The PR also pins CRoaring/croaring to 4.4.2 consistently across CMake, the libcudf conda recipe, generated conda environments, and `dependencies.yaml`.

## Testing

- `configure-cudf-cpp -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF` completed without a CRoaring lookup.
- Built/ran `PARQUET_DELETION_VECTORS_TEST`.
- Built/ran `STREAM_ROARING_BITMAP_TEST`.
- Built/ran `ROARING_BITMAP_TEST`.
- Built `PARQUET_DELETION_VECTORS_NVBENCH`.
- `pre-commit run rapids-dependency-file-generator --files dependencies.yaml conda/recipes/libcudf/recipe.yaml conda/recipes/libcudf/conda_build_config.yaml conda/environments/all_cuda-129_arch-aarch64.yaml conda/environments/all_cuda-129_arch-x86_64.yaml conda/environments/all_cuda-133_arch-aarch64.yaml conda/environments/all_cuda-133_arch-x86_64.yaml` passed.