### PR TITLE
Relax librdkafka pinning

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - libnvcomp-dev==5.2.0.10
 - libnvjitlink-dev
 - librapidsmpf==26.8.*,>=0.0.0a0
-- librdkafka>=2.11.1,<2.12.0
+- librdkafka>=2.14.2,<2.15.0a0
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - libnvcomp-dev==5.2.0.10
 - libnvjitlink-dev
 - librapidsmpf==26.8.*,>=0.0.0a0
-- librdkafka>=2.14.2,<2.15.0a0
+- librdkafka<2.15.0a0
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - libnvcomp-dev==5.2.0.10
 - libnvjitlink-dev
 - librapidsmpf==26.8.*,>=0.0.0a0
-- librdkafka>=2.11.1,<2.12.0
+- librdkafka>=2.14.2,<2.15.0a0
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - libnvcomp-dev==5.2.0.10
 - libnvjitlink-dev
 - librapidsmpf==26.8.*,>=0.0.0a0
-- librdkafka>=2.14.2,<2.15.0a0
+- librdkafka<2.15.0a0
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - libnvcomp-dev==5.2.0.10
 - libnvjitlink-dev
 - librapidsmpf==26.8.*,>=0.0.0a0
-- librdkafka>=2.11.1,<2.12.0
+- librdkafka>=2.14.2,<2.15.0a0
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - libnvcomp-dev==5.2.0.10
 - libnvjitlink-dev
 - librapidsmpf==26.8.*,>=0.0.0a0
-- librdkafka>=2.14.2,<2.15.0a0
+- librdkafka<2.15.0a0
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - libnvcomp-dev==5.2.0.10
 - libnvjitlink-dev
 - librapidsmpf==26.8.*,>=0.0.0a0
-- librdkafka>=2.11.1,<2.12.0
+- librdkafka>=2.14.2,<2.15.0a0
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - libnvcomp-dev==5.2.0.10
 - libnvjitlink-dev
 - librapidsmpf==26.8.*,>=0.0.0a0
-- librdkafka>=2.14.2,<2.15.0a0
+- librdkafka<2.15.0a0
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -630,7 +630,7 @@ dependencies:
       - output_types: conda
         packages:
           - flatbuffers==24.3.25
-          - librdkafka>=2.14.2,<2.15.0a0
+          - librdkafka<2.15.0a0
   depends_on_libnvcomp:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -630,7 +630,7 @@ dependencies:
       - output_types: conda
         packages:
           - flatbuffers==24.3.25
-          - librdkafka>=2.11.1,<2.12.0
+          - librdkafka>=2.14.2,<2.15.0a0
   depends_on_libnvcomp:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description
Relaxes the conda constraint on `librdkafka` from the current tight `>=2.11.1,<2.12.0` range to an upper-bound-only `<2.15.0a0` range.

This keeps the ABI-compatible upper bound for the current 2.14 series while allowing conda to select the newest compatible `librdkafka` available from conda-forge. In local testing, the reduced RAPIDS development environment resolved `librdkafka 2.14.2` and `python-confluent-kafka 2.14.2`.

Addresses #21957.

## Testing
- [x] Ran `rapids-dependency-file-generator`
- [x] Refreshed reduced dev env with `rapids-make-conda-env --repo rmm --repo rapidsmpf --repo ucxx --repo kvikio --repo cudf`
- [x] Confirmed env resolved `librdkafka 2.14.2` and `python-confluent-kafka 2.14.2`
- [x] Confirmed `confluent_kafka.libversion()` reports `2.14.2`
- [x] Ran `clean-cudf_kafka-cpp && build-cudf_kafka-cpp -j0 && test-cudf_kafka-cpp`