### PR TITLE
Use matplotlib-base instead of matplotlib in conda test deps

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -51,7 +51,7 @@ dependencies:
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make
-- matplotlib<3.11
+- matplotlib-base<3.11
 - mmh3
 - moto>=4.0.8
 - msgpack-python

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -51,7 +51,7 @@ dependencies:
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make
-- matplotlib<3.11
+- matplotlib-base<3.11
 - mmh3
 - moto>=4.0.8
 - msgpack-python

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -51,7 +51,7 @@ dependencies:
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make
-- matplotlib<3.11
+- matplotlib-base<3.11
 - mmh3
 - moto>=4.0.8
 - msgpack-python

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -51,7 +51,7 @@ dependencies:
 - librmm==26.8.*,>=0.0.0a0
 - libucxx==0.51.*,>=0.0.0a0
 - make
-- matplotlib<3.11
+- matplotlib-base<3.11
 - mmh3
 - moto>=4.0.8
 - msgpack-python

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1608,7 +1608,7 @@ dependencies:
         packages:
           # Pinned until pandas 3.0.4 releases with matplotlib 3.11 compat fix
           # (https://github.com/pandas-dev/pandas/pull/65742)
-          - matplotlib<3.11
+          - matplotlib-base<3.11
           - numexpr
           - odfpy
           - pyxlsb


### PR DESCRIPTION
Use `matplotlib-base` instead of `matplotlib` in the conda test dependencies to avoid pulling in Qt. The Qt dependency tree causes conda solver hangs in the combined RAPIDS devcontainer environment.

`matplotlib-base` provides everything except interactive GUI backends (Qt, Tk, GTK), which are not needed — the pandas test suite uses the non-interactive `Agg` backend.