### PR TITLE
Fix mypy arg-type for from_buffers after pyarrow-stubs bump

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -585,7 +585,7 @@ def _handle_nulls(arrow_array: pa.Array, nested: bool = False) -> pa.Array:
                 ]
             )
             # Only need validity buffer for structs
-            buffers = cast("list[pa.Buffer]", arrow_array.buffers()[:1])
+            buffers = cast("list[pa.Buffer | None]", arrow_array.buffers()[:1])
             return pa.StructArray.from_buffers(
                 new_struct_type,
                 len(arrow_array),
@@ -605,7 +605,7 @@ def _handle_nulls(arrow_array: pa.Array, nested: bool = False) -> pa.Array:
         )
 
         if new_values is not values or has_non_nullable_field:
-            buffers = cast("list[pa.Buffer]", arrow_array.buffers()[:2])
+            buffers = cast("list[pa.Buffer | None]", arrow_array.buffers()[:2])
             list_type = pa.list_(
                 pa.field(value_field.name, new_values.type, nullable=True)
             )


### PR DESCRIPTION
## Description
With https://github.com/zen-xu/pyarrow-stubs/pull/284, I started seeing CI errors like: 

[full log](https://github.com/rapidsai/cudf/actions/runs/28163211751/job/83408657615?pr=22951)
```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

python/cudf/cudf/core/column/column.py:592: error: Argument 3 to "from_buffers" of "Array" has incompatible type "list[Buffer]"; expected "list[Buffer | None]"  [arg-type]
python/cudf/cudf/core/column/column.py:592: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
python/cudf/cudf/core/column/column.py:592: note: Consider using "Sequence" instead, which is covariant
python/cudf/cudf/core/column/column.py:615: error: Argument 3 to "from_buffers" of "Array" has incompatible type "list[Buffer]"; expected "list[Buffer | None]"  [arg-type]
python/cudf/cudf/core/column/column.py:615: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
python/cudf/cudf/core/column/column.py:615: note: Consider using "Sequence" instead, which is covariant
python/cudf/cudf/core/groupby/groupby.py:573: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
python/cudf/cudf/core/groupby/groupby.py:596: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 2 errors in 1 file (checked 615 source files)
```


