### PR TITLE
Add regex-flags member variable to internal libcudf reprog class

### DIFF
--- a/cpp/include/cudf/strings/regex/regex_program.hpp
+++ b/cpp/include/cudf/strings/regex/regex_program.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -46,6 +46,7 @@ struct regex_program {
   regex_program()                                = delete;
   regex_program(regex_program const&)            = delete;
   regex_program& operator=(regex_program const&) = delete;
+  ~regex_program();
 
   /**
    * @brief Move constructor
@@ -104,8 +105,6 @@ struct regex_program {
    * @return Size of the working memory in bytes
    */
   [[nodiscard]] std::size_t compute_working_memory_size(int32_t num_strings) const;
-
-  ~regex_program();
 
  private:
   std::string _pattern;

--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -1071,13 +1071,15 @@ reprog reprog::create_from(std::string_view pattern,
                            regex_flags const flags,
                            capture_groups const capture)
 {
-  reprog rtn;
+  reprog rtn(flags);
   auto pattern32 = string_to_char32_vector(pattern);
   regex_compiler const compiler(pattern32.data(), flags, capture, rtn);
-  // for debugging, it can be helpful to call rtn.print(flags) here to dump
+  // for debugging, it can be helpful to call rtn.print() here to dump
   // out the instructions that have been created from the given pattern
   return rtn;
 }
+
+reprog::reprog(regex_flags flags) : _flags{flags} {}
 
 void reprog::optimize() { collapse_nops(); }
 
@@ -1247,9 +1249,9 @@ match_flags reprog::compute_match_flags() const
 }
 
 #ifndef NDEBUG
-void reprog::print(regex_flags const flags)
+void reprog::print() const
 {
-  printf("Flags = 0x%08x\n", static_cast<uint32_t>(flags));
+  printf("Flags = 0x%08x\n", static_cast<uint32_t>(_flags));
   printf("Instructions:\n");
   for (std::size_t i = 0; i < _insts.size(); i++) {
     reinst const& inst = _insts[i];

--- a/cpp/src/strings/regex/regcomp.h
+++ b/cpp/src/strings/regex/regcomp.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -138,7 +138,7 @@ class reprog {
   [[nodiscard]] match_flags compute_match_flags() const;
 
 #ifndef NDEBUG
-  void print(regex_flags const flags);
+  void print() const;
 #endif
 
  private:
@@ -147,8 +147,9 @@ class reprog {
   int32_t _startinst_id{};              // id of first instruction
   std::vector<int32_t> _startinst_ids;  // short-cut to speed-up ORs
   int32_t _num_capturing_groups{};
+  regex_flags _flags{};
 
-  reprog() = default;
+  reprog(regex_flags);
   void collapse_nops();
   void build_start_ids();
   void check_for_errors(int32_t id, int32_t next_id);

--- a/cpp/src/strings/regex/regcomp.h
+++ b/cpp/src/strings/regex/regcomp.h
@@ -147,7 +147,7 @@ class reprog {
   int32_t _startinst_id{};              // id of first instruction
   std::vector<int32_t> _startinst_ids;  // short-cut to speed-up ORs
   int32_t _num_capturing_groups{};
-  regex_flags _flags{};
+  [[maybe_unused]] regex_flags _flags{};
 
   reprog(regex_flags);
   void collapse_nops();

--- a/cpp/src/strings/search/count.cu
+++ b/cpp/src/strings/search/count.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -49,6 +49,7 @@ struct counter_fn {
     return count;
   }
 };
+}  // namespace
 
 std::unique_ptr<column> count(strings_column_view const& input,
                               string_scalar const& target,
@@ -78,7 +79,6 @@ std::unique_ptr<column> count(strings_column_view const& input,
 
   return results;
 }
-}  // namespace
 
 }  // namespace detail
 


### PR DESCRIPTION
## Description
Adds new member variable to hold the regex-flags specified by the regex-program interface so that it may be referenced more easily later for fast-path checking. This is some common changes needed in #22178 and #21936 and will help reduce the size of the changes for both and hopefully reduce confusion on the changes needed there.
Cleanup of related files is included as well.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
