### PR TITLE
Support building and testing cudf-java on JDK 17/21

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -437,9 +437,21 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.gmaven</groupId>
-                    <artifactId>gmaven-plugin</artifactId>
-                    <version>1.5</version>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.groovy</groupId>
+                            <artifactId>groovy</artifactId>
+                            <version>4.0.21</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.groovy</groupId>
+                            <artifactId>groovy-ant</artifactId>
+                            <version>4.0.21</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
@@ -553,8 +565,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>setproperty</id>
@@ -563,18 +575,19 @@
                             <goal>execute</goal>
                         </goals>
                         <configuration>
-                            <source>
+                            <scripts>
+                              <script><![CDATA[
                                 def sout = new StringBuffer(), serr = new StringBuffer()
                                 //This only works on linux
                                 def proc = 'ldd ${native.build.path}/libcudfjni.so'.execute()
                                 proc.consumeProcessOutput(sout, serr)
                                 proc.waitForOrKill(10000)
-                                def libcudf = ~/libcudf.*\\.so\\s+=>\\s+(.*)libcudf.*\\.so\\s+.*/
+                                def libcudf = ~/libcudf.*\.so\s+=>\s+(.*)libcudf.*\.so\s+.*/
                                 def cudfm = libcudf.matcher(sout)
                                 if (cudfm.find()) {
-                                    pom.properties['native.cudf.path'] = cudfm.group(1)
+                                    project.properties['native.cudf.path'] = cudfm.group(1)
                                 } else {
-                                    fail("Could not find cudf as a dependency of libcudfjni out> $sout err> $serr")
+                                    throw new RuntimeException("Could not find cudf as a dependency of libcudfjni out> $sout err> $serr matcher> $cudfm")
                                 }
 
                                 def nvccout = new StringBuffer(), nvccerr = new StringBuffer()
@@ -585,11 +598,12 @@
                                 def cm = cudaPattern.matcher(nvccout)
                                 if (cm.find()) {
                                     def classifier = 'cuda' + cm.group(1)
-                                    pom.properties['cuda.classifier'] = classifier
+                                    project.properties['cuda.classifier'] = classifier
                                 } else {
-                                    fail('could not find CUDA version')
+                                    throw new RuntimeException('could not find CUDA version')
                                 }
-                            </source>
+                              ]]></script>
+                            </scripts>
                         </configuration>
                     </execution>
                 </executions>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -417,6 +417,38 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>netty-jdk9plus</id>
+            <activation><jdk>[9,)</jdk></activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                    <version>${netty.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
+                    <version>${netty.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <properties>
+                <!-- Override netty version for JDK 21 compatibility -->
+                <netty.version>4.1.100.Final</netty.version>
+            </properties>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
## Description

The cudf Java bindings could not be built or tested on recent JDKs. This PR
fixes that while preserving JDK 8 compatibility. It is split into two commits,
addressing two independent problems.

### 1. Migrate `gmaven-plugin` → `gmavenplus-plugin` (build-time, all JDKs)

`gmaven-plugin:1.5` bundles an old Groovy that fails under the strong
encapsulation enforced from JDK 16+, breaking the `execute` step that derives
`native.cudf.path` and `cuda.classifier`.

- Replace it with `gmavenplus-plugin:3.0.0` (Groovy 4.0.21).
- Port the `setproperty` execution to the `gmavenplus` config: wrap the script in
  `<scripts>`/`<script>` CDATA, use `project.properties` instead of
  `pom.properties`, and `throw new RuntimeException(...)` instead of `fail(...)`.
- `gmavenplus 3.0.0` and Groovy 4.0 still support JDK 8, so this is applied
  unconditionally (no version profile needed).

### 2. Override Netty for JDK 21 test compatibility (test-only, JDK 9+)

On JDK 21 the private `java.nio.DirectByteBuffer(long, int)` constructor was
replaced by `(long, long)`[^1]. Arrow 0.15.1's transitive Netty `4.1.27.Final` only
looks for the `(long, int)` form, so it cannot create a no-cleaner direct buffer
and throws `UnsupportedOperationException` from `ArrowColumnVectorTest`:

> java.lang.UnsupportedOperationException: sun.misc.Unsafe or
> java.nio.DirectByteBuffer.<init>(long, int) not available

This is a **missing constructor, not an access problem**, so no amount of
`--add-opens` can fix it on 4.1.27.

- Override `netty-buffer`/`netty-common` to `4.1.100.Final` (the first release
  that handles JDK 21's constructor change) — `test` scope only.
- Add `--add-opens=java.base/java.nio=ALL-UNNAMED` and
  `-Dio.netty.tryReflectionSetAccessible=true` so Netty can reflectively access
  the constructor.

Both are confined to a `<jdk>[9,)</jdk>` profile so JDK 8 builds are unaffected.
(The `--add-opens` is required from JDK 9+; the Netty bump is strictly only
needed for 21+, but 4.1.100 is binary-compatible across 9+.) The override is
`test`-scoped and does **not** change the published artifact.

## Testing

- `ArrowColumnVectorTest` now passes on JDK 21 (previously errored).
- Changes are limited to `java/pom.xml`; the published cudf jar and its runtime
  dependencies are unchanged (Netty override is test-scoped).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

[^1]: https://github.com/openjdk/jdk/commit/a56598f5a534cc9223367e7faa8433ea38661db9#diff-07e887b66bc2bb925923fbea2a404e35425b65a9eb5e0e5a76caeded2a33cdc7R183