### PR TITLE
Work around pola-rs/polars#23214 in streaming dataframe scan

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -31,6 +31,7 @@ DESELECTED_TESTS=(
     "tests/unit/io/test_write.py::test_write_async[read_parquet-<lambda>]" # kvikio file creation error in CI
     "tests/unit/io/test_write.py::test_write_async[<lambda>-<lambda>0]" # kvikio file creation error in CI
     "tests/unit/io/test_write.py::test_write_async[<lambda>-<lambda>2]" # kvikio file creation error in CI
+    "tests/unit/operations/test_random.py::test_shuffle_group_by_reseed" # https://github.com/rapidsai/cudf/issues/22964
 )
 
 if [[ $(arch) == "aarch64" ]]; then

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
@@ -5,8 +5,11 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import math
 from typing import TYPE_CHECKING, Any
+
+import polars as pl
 
 import pylibcudf as plc
 from cudf_streaming.channel_metadata import ChannelMetadata
@@ -193,14 +196,34 @@ async def dataframescan_node(
 
         # Build list of IR slices to read
         ir_slices = []
+        # Partial workaround for
+        # https://github.com/pola-rs/polars/issues/23214 If a struct column
+        # has nulls and is sliced then polars exports invalid validity
+        # buffers. We can't detect this exact state because we can't know
+        # when the column is sliced.
+        copy_slice = any(
+            isinstance(dt, pl.Struct)
+            for dt in pl.datatypes.unpack_dtypes(ir.df.dtypes(), include_compound=True)
+        )
+
         for seq_num in range(local_count):
             offset = local_offset * rows_per_partition + seq_num * rows_per_partition
             if offset >= nrows:
                 break
+            sliced = ir.df.slice(offset, rows_per_partition)
+            if copy_slice:
+                # OK, we have structs that might have nulls, and we're
+                # slicing. So let's copy to contiguous storage. This is
+                # hacky and doesn't handle the case where we didn't slice
+                # but the user sliced the input.
+                f = io.BytesIO()
+                sliced.serialize_binary(f)
+                f.seek(0)
+                sliced = pl._plr.PyDataFrame.deserialize_binary(f)
             ir_slices.append(
                 DataFrameScan(
                     ir.schema,
-                    ir.df.slice(offset, rows_per_partition),
+                    sliced,
                     ir.projection,
                 )
             )


### PR DESCRIPTION
## Description
If we have a dataframe with struct columns then if those columns have nulls somewhere a slice of that dataframe is not exported to arrow correctly by Polars.

To, partially, workaround this bug apply the big hammer of just serialising and deserialising the dataframe. This ensures that a sliced frame doesn't export in an invalid way to arrow.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
