### PR TITLE
Move lists_column_device_view and structs_column_device_view to cudf public namespace

### DIFF
--- a/cpp/include/cudf/detail/row_operator/equality.cuh
+++ b/cpp/include/cudf/detail/row_operator/equality.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -322,11 +322,11 @@ class device_row_comparator {
         }
         if (lcol.type().id() == type_id::STRUCT) {
           if (lcol.num_child_columns() == 0) { return true; }
-          lcol = detail::structs_column_device_view(lcol).get_sliced_child(0);
-          rcol = detail::structs_column_device_view(rcol).get_sliced_child(0);
+          lcol = structs_column_device_view(lcol).get_sliced_child(0);
+          rcol = structs_column_device_view(rcol).get_sliced_child(0);
         } else if (lcol.type().id() == type_id::LIST) {
-          auto l_list_col = detail::lists_column_device_view(lcol);
-          auto r_list_col = detail::lists_column_device_view(rcol);
+          auto l_list_col = lists_column_device_view(lcol);
+          auto r_list_col = lists_column_device_view(rcol);
 
           auto lsizes = make_list_size_iterator(l_list_col);
           auto rsizes = make_list_size_iterator(r_list_col);

--- a/cpp/include/cudf/detail/row_operator/hashing.cuh
+++ b/cpp/include/cudf/detail/row_operator/hashing.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -192,9 +192,9 @@ class device_row_hasher {
         }
         if (curr_col.type().id() == type_id::STRUCT) {
           if (curr_col.num_child_columns() == 0) { return hash; }
-          curr_col = detail::structs_column_device_view(curr_col).get_sliced_child(0);
+          curr_col = structs_column_device_view(curr_col).get_sliced_child(0);
         } else if (curr_col.type().id() == type_id::LIST) {
-          auto list_col   = detail::lists_column_device_view(curr_col);
+          auto list_col   = lists_column_device_view(curr_col);
           auto list_sizes = make_list_size_iterator(list_col);
           hash            = detail::accumulate(
             list_sizes, list_sizes + list_col.size(), hash, [](auto hash, auto size) {

--- a/cpp/include/cudf/detail/row_operator/lexicographic.cuh
+++ b/cpp/include/cudf/detail/row_operator/lexicographic.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -421,8 +421,8 @@ class device_row_comparator {
                                  cuda::std::numeric_limits<int>::max());
         }
 
-        lcol = detail::structs_column_device_view(lcol).get_sliced_child(0);
-        rcol = detail::structs_column_device_view(rcol).get_sliced_child(0);
+        lcol = structs_column_device_view(lcol).get_sliced_child(0);
+        rcol = structs_column_device_view(rcol).get_sliced_child(0);
         ++depth;
       }
 
@@ -467,8 +467,8 @@ class device_row_comparator {
       column_device_view rcol = _rhs.slice(rhs_element_index, 1);
 
       while (lcol.type().id() == type_id::LIST) {
-        lcol = detail::lists_column_device_view(lcol).get_sliced_child();
-        rcol = detail::lists_column_device_view(rcol).get_sliced_child();
+        lcol = lists_column_device_view(lcol).get_sliced_child();
+        rcol = lists_column_device_view(rcol).get_sliced_child();
       }
 
       auto const l_offsets = _l_dremel_device_view->offsets;

--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ namespace detail {
 template <typename IndexIterator>
 rmm::device_uvector<unbound_list_view> list_vector_from_column(
   unbound_list_view::label_type label,
-  cudf::detail::lists_column_device_view const& lists_column,
+  cudf::lists_column_device_view const& lists_column,
   IndexIterator index_begin,
   IndexIterator index_end,
   rmm::cuda_stream_view stream,
@@ -174,20 +174,19 @@ std::unique_ptr<column> scatter(column_view const& source,
   auto const scatter_map_size   = cuda::std::distance(scatter_map_begin, scatter_map_end);
   auto const source_vector =
     list_vector_from_column(unbound_list_view::label_type::SOURCE,
-                            cudf::detail::lists_column_device_view(*source_device_view),
+                            cudf::lists_column_device_view(*source_device_view),
                             cuda::counting_iterator<size_type>{0},
                             cuda::counting_iterator{static_cast<size_type>(scatter_map_size)},
                             stream,
                             mr);
 
   auto const target_device_view = column_device_view::create(target, stream);
-  auto target_vector =
-    list_vector_from_column(unbound_list_view::label_type::TARGET,
-                            cudf::detail::lists_column_device_view(*target_device_view),
-                            cuda::counting_iterator<size_type>{0},
-                            cuda::counting_iterator<size_type>{num_rows},
-                            stream,
-                            mr);
+  auto target_vector            = list_vector_from_column(unbound_list_view::label_type::TARGET,
+                                               cudf::lists_column_device_view(*target_device_view),
+                                               cuda::counting_iterator<size_type>{0},
+                                               cuda::counting_iterator<size_type>{num_rows},
+                                               stream,
+                                               mr);
 
   return scatter_impl(
     source_vector, target_vector, scatter_map_begin, scatter_map_end, source, target, stream, mr);
@@ -250,20 +249,19 @@ std::unique_ptr<column> scatter(scalar const& slr,
   auto const scatter_map_size   = cuda::std::distance(scatter_map_begin, scatter_map_end);
   auto const source_vector =
     list_vector_from_column(unbound_list_view::label_type::SOURCE,
-                            cudf::detail::lists_column_device_view(*source_device_view),
+                            cudf::lists_column_device_view(*source_device_view),
                             cuda::make_constant_iterator<size_type>(0),
                             cuda::make_constant_iterator<size_type>(0) + scatter_map_size,
                             stream,
                             mr);
 
   auto const target_device_view = column_device_view::create(target, stream);
-  auto target_vector =
-    list_vector_from_column(unbound_list_view::label_type::TARGET,
-                            cudf::detail::lists_column_device_view(*target_device_view),
-                            cuda::counting_iterator<size_type>{0},
-                            cuda::counting_iterator<size_type>{num_rows},
-                            stream,
-                            mr);
+  auto target_vector            = list_vector_from_column(unbound_list_view::label_type::TARGET,
+                                               cudf::lists_column_device_view(*target_device_view),
+                                               cuda::counting_iterator<size_type>{0},
+                                               cuda::counting_iterator<size_type>{num_rows},
+                                               stream,
+                                               mr);
 
   return scatter_impl(
     source_vector, target_vector, scatter_map_begin, scatter_map_end, wrapped, target, stream, mr);

--- a/cpp/include/cudf/lists/detail/scatter_helper.cuh
+++ b/cpp/include/cudf/lists/detail/scatter_helper.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -39,7 +39,7 @@ struct unbound_list_view {
    */
   enum class label_type : bool { SOURCE, TARGET };
 
-  using lists_column_device_view = cudf::detail::lists_column_device_view;
+  using lists_column_device_view = cudf::lists_column_device_view;
   using list_device_view         = cudf::list_device_view;
 
   unbound_list_view()                                    = default;
@@ -56,7 +56,7 @@ struct unbound_list_view {
    * @param row_index Index of the row in lists_column that this instance represents
    */
   __device__ inline unbound_list_view(label_type scatter_source_label,
-                                      cudf::detail::lists_column_device_view const& lists_column,
+                                      cudf::lists_column_device_view const& lists_column,
                                       size_type const& row_index)
     : _label{scatter_source_label}, _row_index{row_index}
   {

--- a/cpp/include/cudf/lists/list_device_view.cuh
+++ b/cpp/include/cudf/lists/list_device_view.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -21,7 +21,7 @@ namespace CUDF_EXPORT cudf {
  * a list of elements of arbitrary type (including further nested lists).
  */
 class list_device_view {
-  using lists_column_device_view = cudf::detail::lists_column_device_view;
+  using lists_column_device_view = cudf::lists_column_device_view;
 
  public:
   list_device_view() = default;
@@ -325,14 +325,13 @@ class list_device_view {
  *
  */
 struct list_size_functor {
-  detail::lists_column_device_view const d_column;  ///< The list column to access
+  lists_column_device_view const d_column;  ///< The list column to access
   /**
    * @brief Constructor
    *
    * @param d_col The cudf::lists_column_device_view whose rows are being accessed
    */
-  CUDF_HOST_DEVICE inline list_size_functor(detail::lists_column_device_view const& d_col)
-    : d_column(d_col)
+  CUDF_HOST_DEVICE inline list_size_functor(lists_column_device_view const& d_col) : d_column(d_col)
   {
   }
   /**
@@ -363,7 +362,7 @@ struct list_size_functor {
  * @param c The list_column_device_view to iterate over
  * @return An iterator that returns the size of the list by row index
  */
-CUDF_HOST_DEVICE auto inline make_list_size_iterator(detail::lists_column_device_view const& c)
+CUDF_HOST_DEVICE auto inline make_list_size_iterator(lists_column_device_view const& c)
 {
   return detail::make_counting_transform_iterator(0, list_size_functor{c});
 }

--- a/cpp/include/cudf/lists/lists_column_device_view.cuh
+++ b/cpp/include/cudf/lists/lists_column_device_view.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,7 +10,7 @@
 
 #include <cuda_runtime.h>
 
-namespace cudf::detail {
+namespace cudf {
 
 /**
  * @brief Given a column_device_view, an instance of this class provides a
@@ -103,4 +103,4 @@ class lists_column_device_view : private column_device_view {
   }
 };
 
-}  // namespace cudf::detail
+}  // namespace cudf

--- a/cpp/include/cudf/lists/lists_column_device_view.cuh
+++ b/cpp/include/cudf/lists/lists_column_device_view.cuh
@@ -16,6 +16,8 @@ namespace cudf {
  * @brief Given a column_device_view, an instance of this class provides a
  * wrapper on this compound column for list operations.
  * Analogous to list_column_view.
+ *
+ * @ingroup column_classes
  */
 class lists_column_device_view : private column_device_view {
  public:

--- a/cpp/include/cudf/structs/structs_column_device_view.cuh
+++ b/cpp/include/cudf/structs/structs_column_device_view.cuh
@@ -13,6 +13,8 @@ namespace cudf {
  * @brief Given a column_device_view, an instance of this class provides a
  * wrapper on this compound column for struct operations.
  * Analogous to struct_column_view.
+ *
+ * @ingroup column_classes
  */
 class structs_column_device_view : private column_device_view {
  public:

--- a/cpp/include/cudf/structs/structs_column_device_view.cuh
+++ b/cpp/include/cudf/structs/structs_column_device_view.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -7,9 +7,7 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/types.hpp>
 
-namespace CUDF_EXPORT cudf {
-
-namespace detail {
+namespace cudf {
 
 /**
  * @brief Given a column_device_view, an instance of this class provides a
@@ -71,6 +69,4 @@ class structs_column_device_view : private column_device_view {
   }
 };
 
-}  // namespace detail
-
-}  // namespace CUDF_EXPORT cudf
+}  // namespace cudf

--- a/cpp/src/io/parquet/experimental/variant_extract.cu
+++ b/cpp/src/io/parquet/experimental/variant_extract.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -448,8 +448,8 @@ __device__ cuda::std::optional<device_span<uint8_t const>> decode_string(
 
 // Returns the metadata and value list bytes for a given row from device views
 __device__ cuda::std::pair<device_span<uint8_t const>, device_span<uint8_t const>>
-metadata_and_value_at(cudf::detail::lists_column_device_view const& metadata,
-                      cudf::detail::lists_column_device_view const& values,
+metadata_and_value_at(cudf::lists_column_device_view const& metadata,
+                      cudf::lists_column_device_view const& values,
                       size_type row)
 {
   auto const meta_begin = metadata.offset_at(row);
@@ -472,8 +472,8 @@ constexpr int block_size = 256;
  * null, or whose path does not resolve, are marked null in `d_null_mask` with a size of 0.
  */
 CUDF_KERNEL __launch_bounds__(block_size) void locate_variant_fields_kernel(
-  cudf::detail::lists_column_device_view metadata,
-  cudf::detail::lists_column_device_view values,
+  cudf::lists_column_device_view metadata,
+  cudf::lists_column_device_view values,
   column_device_view path,
   device_span<size_type> d_sizes,
   device_span<size_type> d_src_offsets,
@@ -515,7 +515,7 @@ CUDF_KERNEL __launch_bounds__(block_size) void locate_variant_fields_kernel(
  */
 template <typename T>
 CUDF_KERNEL __launch_bounds__(block_size) void cast_variant_int_kernel(
-  cudf::detail::lists_column_device_view values, device_span<T> d_output, bitmask_type* d_null_mask)
+  cudf::lists_column_device_view values, device_span<T> d_output, bitmask_type* d_null_mask)
 {
   auto const num_rows = static_cast<size_type>(d_output.size());
   auto const tid      = cudf::detail::grid_1d::global_thread_id<block_size>();
@@ -552,7 +552,7 @@ CUDF_KERNEL __launch_bounds__(block_size) void cast_variant_int_kernel(
  * decode to a string, are marked null in `d_null_mask` with size 0.
  */
 struct cast_variant_string_fn {
-  cudf::detail::lists_column_device_view d_values;
+  cudf::lists_column_device_view d_values;
   bitmask_type* d_null_mask;
   size_type* d_sizes;
   char* d_chars;
@@ -597,7 +597,7 @@ void validate_variant_child(column_view const& child)
 }
 
 struct cast_variant_fn {
-  cudf::detail::lists_column_device_view values;
+  cudf::lists_column_device_view values;
   size_type num_rows;
   data_type desired_type;
   bitmask_type* d_null_mask;
@@ -717,8 +717,8 @@ std::unique_ptr<column> get_variant_field(column_view const& variant_column,
 
   auto meta_device_view = column_device_view::create(meta_view, stream);
   auto val_device_view  = column_device_view::create(val_view, stream);
-  cudf::detail::lists_column_device_view meta_lists_device_view(*meta_device_view);
-  cudf::detail::lists_column_device_view val_lists_device_view(*val_device_view);
+  cudf::lists_column_device_view meta_lists_device_view(*meta_device_view);
+  cudf::lists_column_device_view val_lists_device_view(*val_device_view);
 
   rmm::device_uvector<size_type> d_sizes(num_rows, stream, temp_mr);
   // Caches the per-row intra-value byte offset
@@ -788,7 +788,7 @@ std::unique_ptr<column> cast_variant(column_view const& values,
   if (num_rows == 0) { return make_empty_column(desired_type); }
 
   auto val_device_view = column_device_view::create(values, stream);
-  cudf::detail::lists_column_device_view val_lists_device_view(*val_device_view);
+  cudf::lists_column_device_view val_lists_device_view(*val_device_view);
 
   // Initialize the null mask from the values column (or all-valid)
   auto null_mask    = values.nullable()

--- a/cpp/src/io/parquet/parquet_gpu.cuh
+++ b/cpp/src/io/parquet/parquet_gpu.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -73,7 +73,7 @@ inline size_type __device__ row_to_value_idx(size_type idx,
       idx += col.offset();
       col = col.child(0);
     } else {
-      auto list_col = cudf::detail::lists_column_device_view(col);
+      auto list_col = cudf::lists_column_device_view(col);
       auto child    = list_col.child();
       if (parquet_col.output_as_byte_array && child.type().id() == type_id::UINT8) { break; }
       idx = list_col.offset_at(idx);

--- a/cpp/src/lists/contains.cu
+++ b/cpp/src/lists/contains.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -199,7 +199,7 @@ std::unique_ptr<column> dispatch_index_of(lists_column_view const& lists,
   auto const input_it      = cudf::detail::make_counting_transform_iterator(
     size_type{0},
     cuda::proclaim_return_type<list_device_view>(
-      [lists = cudf::detail::lists_column_device_view{*lists_cdv_ptr}] __device__(auto const idx) {
+      [lists = cudf::lists_column_device_view{*lists_cdv_ptr}] __device__(auto const idx) {
         return list_device_view{lists, idx};
       }));
 
@@ -345,15 +345,15 @@ std::unique_ptr<column> contains_nulls(lists_column_view const& lists,
     rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     out_begin,
     out_begin + lists.size(),
-    cuda::proclaim_return_type<bool>([lists = cudf::detail::lists_column_device_view{
-                                        *lists_cdv_ptr}] __device__(auto const list_idx) {
-      auto const list = list_device_view{lists, list_idx};
-      return list.is_null() ||
-             thrust::any_of(thrust::seq,
-                            cuda::counting_iterator<cudf::size_type>{0},
-                            cuda::counting_iterator{list.size()},
-                            [&list](auto const idx) { return list.is_null(idx); });
-    }));
+    cuda::proclaim_return_type<bool>(
+      [lists = cudf::lists_column_device_view{*lists_cdv_ptr}] __device__(auto const list_idx) {
+        auto const list = list_device_view{lists, list_idx};
+        return list.is_null() ||
+               thrust::any_of(thrust::seq,
+                              cuda::counting_iterator<cudf::size_type>{0},
+                              cuda::counting_iterator{list.size()},
+                              [&list](auto const idx) { return list.is_null(idx); });
+      }));
 
   return output;
 }

--- a/cpp/src/lists/copying/scatter_helper.cu
+++ b/cpp/src/lists/copying/scatter_helper.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,8 +40,8 @@ namespace detail {
 std::pair<rmm::device_buffer, size_type> construct_child_nullmask(
   rmm::device_uvector<unbound_list_view> const& parent_list_vector,
   column_view const& parent_list_offsets,
-  cudf::detail::lists_column_device_view const& source_lists,
-  cudf::detail::lists_column_device_view const& target_lists,
+  cudf::lists_column_device_view const& source_lists,
+  cudf::lists_column_device_view const& target_lists,
   size_type num_child_rows,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
@@ -156,8 +156,8 @@ struct list_child_constructor {
       column_device_view::create(source_lists_column_view.parent(), stream);
     auto target_column_device_view =
       column_device_view::create(target_lists_column_view.parent(), stream);
-    auto source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
-    auto target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
+    auto source_lists = cudf::lists_column_device_view(*source_column_device_view);
+    auto target_lists = cudf::lists_column_device_view(*target_column_device_view);
 
     auto const num_child_rows{
       cudf::detail::get_value<size_type>(list_offsets, list_offsets.size() - 1, stream)};
@@ -215,8 +215,8 @@ struct list_child_constructor {
       column_device_view::create(source_lists_column_view.parent(), stream);
     auto target_column_device_view =
       column_device_view::create(target_lists_column_view.parent(), stream);
-    auto source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
-    auto target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
+    auto source_lists = cudf::lists_column_device_view(*source_column_device_view);
+    auto target_lists = cudf::lists_column_device_view(*target_column_device_view);
 
     auto const num_child_rows{
       cudf::detail::get_value<size_type>(list_offsets, list_offsets.size() - 1, stream)};
@@ -278,8 +278,8 @@ struct list_child_constructor {
       column_device_view::create(source_lists_column_view.parent(), stream);
     auto target_column_device_view =
       column_device_view::create(target_lists_column_view.parent(), stream);
-    auto source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
-    auto target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
+    auto source_lists = cudf::lists_column_device_view(*source_column_device_view);
+    auto target_lists = cudf::lists_column_device_view(*target_column_device_view);
 
     auto const num_child_rows{
       cudf::detail::get_value<size_type>(list_offsets, list_offsets.size() - 1, stream)};
@@ -372,8 +372,8 @@ struct list_child_constructor {
       column_device_view::create(source_lists_column_view.parent(), stream);
     auto const target_column_device_view =
       column_device_view::create(target_lists_column_view.parent(), stream);
-    auto const source_lists = cudf::detail::lists_column_device_view(*source_column_device_view);
-    auto const target_lists = cudf::detail::lists_column_device_view(*target_column_device_view);
+    auto const source_lists = cudf::lists_column_device_view(*source_column_device_view);
+    auto const target_lists = cudf::lists_column_device_view(*target_column_device_view);
 
     auto const source_structs = source_lists_column_view.child();
     auto const target_structs = target_lists_column_view.child();

--- a/cpp/src/text/minhash.cu
+++ b/cpp/src/text/minhash.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -180,7 +180,7 @@ CUDF_KERNEL void minhash_seed_kernel(cudf::column_device_view const d_strings,
  * @param d_results Final results vector (used for the proactive initialize)
  */
 template <typename HashFunction, typename hash_value_type = typename HashFunction::result_type>
-CUDF_KERNEL void minhash_ngrams_kernel(cudf::detail::lists_column_device_view const d_input,
+CUDF_KERNEL void minhash_ngrams_kernel(cudf::lists_column_device_view const d_input,
                                        hash_value_type seed,
                                        cudf::size_type ngrams,
                                        hash_value_type* d_hashes,
@@ -558,7 +558,7 @@ std::unique_ptr<cudf::column> minhash_ngrams_fn(
   auto d_threshold_count = cudf::detail::device_scalar<cudf::size_type>(
     0, stream, cudf::get_current_device_resource_ref());
 
-  auto d_list = cudf::detail::lists_column_device_view(*d_input);
+  auto d_list = cudf::lists_column_device_view(*d_input);
   minhash_ngrams_kernel<HashFunction>
     <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(d_list,
                                                                          seed,

--- a/java/src/main/native/src/ColumnViewJni.cu
+++ b/java/src/main/native/src/ColumnViewJni.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -91,8 +91,8 @@ void post_process_list_overlap(cudf::column_view const& lhs,
     rmm::exec_policy_nosync(stream),
     validity.begin(),
     validity.end(),
-    [lhs            = cudf::detail::lists_column_device_view{*lhs_cdv_ptr},
-     rhs            = cudf::detail::lists_column_device_view{*rhs_cdv_ptr},
+    [lhs            = cudf::lists_column_device_view{*lhs_cdv_ptr},
+     rhs            = cudf::lists_column_device_view{*rhs_cdv_ptr},
      overlap_result = *overlap_cdv_ptr] __device__(auto const idx) {
       if (overlap_result.is_null(idx) || overlap_result.template element<bool>(idx)) {
         return true;


### PR DESCRIPTION
## Description
Moves the `cudf::detail::lists_column_device_view` and `cudf::detail::structs_column_device_view` to the `cudf` namespace (out of the detail namespace). The .cuh files that defined these classes were already in the public folders (non-detail folder).
These are useful when building custom kernels and creates consistency with the `cudf::column_device_view` it references.

Closes #21702 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
