### PR TITLE
Fix `cudf.pandas --line-profile` clobbering `__file__`

### DIFF
--- a/python/cudf/cudf/pandas/__main__.py
+++ b/python/cudf/cudf/pandas/__main__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -13,10 +13,37 @@ import code
 import runpy
 import sys
 import tempfile
+import types
 from contextlib import contextmanager
 
 from . import install
 from .profiler import Profiler, lines_with_profiling
+
+
+def _run_instrumented_as_main(code_path, file_path):
+    """Execute the script at ``code_path`` as ``__main__``, exposing
+    ``file_path`` as ``__file__``.
+
+    The line profiler runs an *instrumented copy* of the user's script written
+    to a temporary file. Compiling with ``code_path`` as the code object's
+    filename keeps per-line profiling output and tracebacks pointed at that
+    instrumented source, while ``__file__`` (and ``sys.argv[0]``, set by the
+    caller) continue to refer to the original script. This lets scripts that
+    locate sibling files relative to ``__file__`` work under ``--line-profile``
+    just as they do without it (GH #23010).
+    """
+    with open(code_path) as f:
+        code_obj = compile(f.read(), code_path, "exec")
+    main_module = types.ModuleType("__main__")
+    main_module.__file__ = file_path
+    main_module.__loader__ = None
+    main_module.__spec__ = None
+    saved_main = sys.modules["__main__"]
+    sys.modules["__main__"] = main_module
+    try:
+        exec(code_obj, main_module.__dict__)
+    finally:
+        sys.modules["__main__"] = saved_main
 
 
 @contextmanager
@@ -100,7 +127,14 @@ def main():
         elif len(args.args) >= 1:
             # Remove ourself from argv and continue
             sys.argv[:] = args.args
-            runpy.run_path(args.args[0], run_name="__main__")
+            if args.line_profile and script_name is not None:
+                # ``fn`` (args.args[0]) is an instrumented copy of the script in
+                # a temporary file. Run it so that ``__file__`` and
+                # ``sys.argv[0]`` still refer to the original script.
+                sys.argv[0] = script_name
+                _run_instrumented_as_main(args.args[0], script_name)
+            else:
+                runpy.run_path(args.args[0], run_name="__main__")
         else:
             if sys.stdin.isatty():
                 banner = f"Python {sys.version} on {sys.platform}"

--- a/python/cudf/cudf_pandas_tests/test_main.py
+++ b/python/cudf/cudf_pandas_tests/test_main.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess
@@ -34,6 +34,28 @@ def test_run_cudf_pandas_with_script():
 
     assert res != ""
     assert res == expect
+
+
+def test_run_cudf_pandas_line_profile_preserves_file(tmp_path):
+    # GH #23010: ``--line-profile`` runs an instrumented copy of the script
+    # from a temp file. ``__file__`` must still refer to the original script so
+    # scripts that locate sibling files relative to ``__file__`` keep working.
+    (tmp_path / "sibling.txt").write_text("hello-sibling")
+    script = tmp_path / "script.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            from pathlib import Path
+            sibling = Path(__file__).resolve().parent / "sibling.txt"
+            print("FILE:", __file__)
+            print("CONTENT:", sibling.read_text())
+            """
+        )
+    )
+
+    res = _run_python(cudf_pandas=True, command=f"--line-profile {script}")
+    assert "CONTENT: hello-sibling" in res
+    assert str(script) in res
 
 
 def test_run_cudf_pandas_with_script_with_cmd_args():

--- a/python/cudf/cudf_pandas_tests/test_main.py
+++ b/python/cudf/cudf_pandas_tests/test_main.py
@@ -14,6 +14,7 @@ def _run_python(*, cudf_pandas, command):
         executable + command,
         shell=True,
         text=True,
+        encoding="utf-8",
     )
 
 


### PR DESCRIPTION
## Description

closes #23010

`python -m cudf.pandas --line-profile <script>` writes an *instrumented copy* of the script to a temporary file and executes it via `runpy.run_path(<temp>)`, which sets `__file__` to that temporary path. Scripts that locate sibling resources relative to `__file__` (e.g. `Path(__file__).resolve().parent.parent / "data" / "file.parquet"`) then resolve to the wrong location and fail:

```
FileNotFoundError: /data/nyc_parking_violations_2022.parquet
```

The same script runs fine **without** `--line-profile` (it is executed directly, so `__file__` is correct).

### Root cause / fix

The per-line profiler needs the executed code object's filename to be the *instrumented* temp file — it reads source lines via `inspect.stack().code_context` (→ `linecache` on `co_filename`) and shifts line numbers back to the original — so the temp filename can't simply be swapped for the real one.

This PR keeps the code object's filename pointed at the temp file (per-line profiling output and tracebacks are unchanged) but executes it in a `__main__` module whose `__file__` — and `sys.argv[0]` — refer to the **original** script. This matches the behavior of running without `--line-profile`, so scripts that resolve paths relative to `__file__` keep working.

### Tests

Adds `test_run_cudf_pandas_line_profile_preserves_file`: runs `python -m cudf.pandas --line-profile` on a script that reads a sibling file via `__file__` and asserts it succeeds (and that `__file__` is the original script path). The function profiler (`--profile`) was never affected — it executes the original script directly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
