### PR TITLE
Bound mypy pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
         additional_dependencies: [
           "polars>=1.35,<1.39",
           "numpy>=1.26",
-          pyarrow-stubs,
-          "pyarrow<24.0.0",  # https://github.com/rapidsai/cudf/issues/22229
-          pytest,
-          types-cachetools,
+          "pyarrow-stubs>=19.0",
+          "pyarrow>=19.0.0,<24.0.0",  # https://github.com/rapidsai/cudf/issues/22229
+          "pytest>=8.0.0,<9.1.0",
+          "types-cachetools>=5.5.0",
           "rmm-cu12==26.8.*,>=0.0.0a0; sys_platform=='linux'",
           "--extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/"
         ]


### PR DESCRIPTION
## Description
Bound the mypy pre-commit hook's additional dependencies so local and CI hook environments do not resolve unconstrained package versions differently.

This adds lower bounds for previously bare dependencies and aligns the pyarrow/pytest bounds with existing project constraints.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

Verification:
- `pre-commit run mypy --all-files`
- `pre-commit run --all-files --show-diff-on-failure`