### PR TITLE
Cull unused CudaStreamPoolConfig and dependents

### DIFF
--- a/docs/cudf/source/cudf_polars/options.md
+++ b/docs/cudf/source/cudf_polars/options.md
@@ -117,7 +117,6 @@ Environment variables follow these patterns:
 | `raise_on_fail`          | Raise an error instead of falling back to CPU execution.                                                                      | `False`                   |
 | `parquet_options`        | Parquet configuration, dict or {class}`~cudf_polars.utils.config.ParquetOptions`.                                             | —                         |
 | `memory_resource_config` | RMM configuration, dict or {class}`~cudf_polars.utils.config.MemoryResourceConfig`.                                           | —                         |
-| `cuda_stream_policy`     | CUDA stream policy (`"default"`, `"pool"`, or a configuration dict).                                                          | —                         |
 | `hardware_binding`       | Hardware binding policy. Pass a {class}`~cudf_polars.engine.hardware_binding.HardwareBindingPolicy` for fine-grained control. | `HardwareBindingPolicy()` |
 | `allow_gpu_sharing`      | When `False` (default), the engine raises if multiple ranks share the same physical GPU.                                      | `False`                   |
 

--- a/python/cudf_polars/cudf_polars/engine/options.py
+++ b/python/cudf_polars/cudf_polars/engine/options.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # ruff: noqa: RUF009  -- _opt() returns dataclasses.field(), not a mutable default
 """Unified streaming options for the RapidsMPF frontend."""
@@ -268,10 +268,6 @@ class StreamingOptions:
         :class:`~cudf_polars.utils.config.MemoryResourceConfig`.
         Env: ``CUDF_POLARS__MEMORY_RESOURCE_CONFIG__*``.
         Category: engine.
-    cuda_stream_policy
-        CUDA stream policy (``"default"``, ``"pool"`` or config dict).
-        Env: ``CUDF_POLARS__CUDA_STREAM_POLICY``.
-        Category: engine.
     hardware_binding
         Hardware binding policy. Pass a :class:`~cudf_polars.engine.hardware_binding.HardwareBindingPolicy`
         instance for fine-grained control.
@@ -352,9 +348,6 @@ class StreamingOptions:
     raise_on_fail: bool | Unspecified = _opt("engine")
     parquet_options: dict[str, Any] | ParquetOptions | Unspecified = _opt("engine")
     memory_resource_config: MemoryResourceConfig | Unspecified = _opt("engine")
-    cuda_stream_policy: Literal["default", "pool"] | dict[str, Any] | Unspecified = (
-        _opt("engine", "CUDF_POLARS__CUDA_STREAM_POLICY")
-    )
     hardware_binding: HardwareBindingPolicy | Unspecified = _opt(
         "engine", "CUDF_POLARS__HARDWARE_BINDING", _parse_hardware_binding
     )
@@ -495,10 +488,6 @@ class StreamingOptions:
         dyn = getattr(args, "dynamic_planning", None)
         dynamic_planning: Any = None if dyn is False else UNSPECIFIED
 
-        # Special: stream_policy "auto" or absent → UNSPECIFIED
-        sp = getattr(args, "stream_policy", None)
-        cuda_stream_policy: Any = UNSPECIFIED if (sp is None or sp == "auto") else sp
-
         # target_partition_size: canonical dest from _add_cli_args; fall back to
         # "blocksize" for legacy benchmark scripts that predate this module.
         target_partition_size = (
@@ -530,7 +519,6 @@ class StreamingOptions:
             raise_on_fail=_get("raise_on_fail"),
             parquet_options=_get("parquet_options"),
             memory_resource_config=_get("memory_resource_config"),
-            cuda_stream_policy=cuda_stream_policy,
         )
 
     @staticmethod
@@ -742,16 +730,6 @@ class StreamingOptions:
             help=textwrap.dedent("""\
                 Enable dynamic planning. Use --no-dynamic-planning to disable.
                 Env: CUDF_POLARS__EXECUTOR__DYNAMIC_PLANNING. Built-in default: enabled."""),
-        )
-        g.add_argument(
-            "--stream-policy",
-            dest="stream_policy",
-            default=None,
-            type=str,
-            choices=["auto", "default", "new", "pool"],
-            help=textwrap.dedent("""\
-                CUDA stream pool policy. "auto" defers to the built-in default.
-                Env: CUDF_POLARS__CUDA_STREAM_POLICY. Built-in default: default."""),
         )
         g.add_argument(
             "--parquet-options",

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -28,8 +28,6 @@ import importlib.util
 import json
 import os
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
-
-from rmm.pylibrmm import CudaStreamFlags, CudaStreamPool
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -762,74 +760,6 @@ ExecutorType = TypeVar("ExecutorType", StreamingExecutor, InMemoryExecutor)
 
 
 @dataclasses.dataclass(frozen=True, eq=True)
-class CUDAStreamPoolConfig:
-    """
-    Configuration for the CUDA stream pool.
-
-    Parameters
-    ----------
-    pool_size
-        The size of the CUDA stream pool.
-    flags
-        The flags to use for the CUDA stream pool.
-    """
-
-    pool_size: int = 16
-    flags: CudaStreamFlags = CudaStreamFlags.NON_BLOCKING
-
-    def build(self) -> CudaStreamPool:
-        return CudaStreamPool(
-            pool_size=self.pool_size,
-            flags=self.flags,
-        )
-
-
-def _convert_cuda_stream_policy(
-    user_cuda_stream_policy: dict | str,
-) -> CUDAStreamPoolConfig | None:
-    match user_cuda_stream_policy:
-        case "default":
-            return None
-        case "pool":
-            return CUDAStreamPoolConfig()
-        case dict():
-            return CUDAStreamPoolConfig(**user_cuda_stream_policy)
-        case str():
-            # assume it's a JSON encoded CUDAStreamPoolConfig
-            try:
-                d = json.loads(user_cuda_stream_policy)
-            except json.JSONDecodeError:
-                raise ValueError(
-                    f"Invalid CUDA stream policy: '{user_cuda_stream_policy}'"
-                ) from None
-            match d:
-                case {"pool_size": int(), "flags": int()}:
-                    return CUDAStreamPoolConfig(
-                        pool_size=d["pool_size"], flags=CudaStreamFlags(d["flags"])
-                    )
-                case {"pool_size": int(), "flags": str()}:
-                    # convert the string names to enums
-                    return CUDAStreamPoolConfig(
-                        pool_size=d["pool_size"],
-                        flags=CudaStreamFlags(CudaStreamFlags.__members__[d["flags"]]),
-                    )
-                case _:
-                    try:
-                        return CUDAStreamPoolConfig(**d)
-                    except TypeError:
-                        raise ValueError(
-                            f"Invalid CUDA stream policy: {user_cuda_stream_policy}"
-                        ) from None
-
-
-def _default_cuda_stream_policy() -> CUDAStreamPoolConfig | None:
-    v = os.environ.get("CUDF_POLARS__CUDA_STREAM_POLICY")
-    if v is None:
-        return None
-    return _convert_cuda_stream_policy(v)
-
-
-@dataclasses.dataclass(frozen=True, eq=True)
 class ConfigOptions(Generic[ExecutorType]):
     """
     Configuration for the polars GPUEngine.
@@ -848,10 +778,6 @@ class ConfigOptions(Generic[ExecutorType]):
     device
         The GPU used to run the query. If not provided, the
         query uses the current CUDA device.
-    cuda_stream_policy
-        The policy to use for CUDA streams. ``None`` (the default) uses the
-        default CUDA stream. A :class:`~cudf_polars.utils.config.CUDAStreamPoolConfig`
-        can be used to configure a stream pool.
     """
 
     raise_on_fail: bool = False
@@ -863,9 +789,6 @@ class ConfigOptions(Generic[ExecutorType]):
     )
     device: int | None = None
     memory_resource_config: MemoryResourceConfig | None = None
-    cuda_stream_policy: CUDAStreamPoolConfig | None = dataclasses.field(
-        default_factory=_default_cuda_stream_policy
-    )
 
     @classmethod
     def from_polars_engine(
@@ -880,7 +803,6 @@ class ConfigOptions(Generic[ExecutorType]):
             "parquet_options",
             "raise_on_fail",
             "memory_resource_config",
-            "cuda_stream_policy",
             "hardware_binding",
         }
 
@@ -950,30 +872,5 @@ class ConfigOptions(Generic[ExecutorType]):
             "device": engine.device,
             "memory_resource_config": user_memory_resource_config,
         }
-
-        # Handle "cuda-stream-policy".
-        # The default will depend on the executor.
-        user_cuda_stream_policy = engine.config.get(
-            "cuda_stream_policy", None
-        ) or os.environ.get("CUDF_POLARS__CUDA_STREAM_POLICY", None)
-
-        cuda_stream_policy: CUDAStreamPoolConfig | None
-
-        if user_cuda_stream_policy is None:
-            if executor.name == "streaming":
-                cuda_stream_policy = CUDAStreamPoolConfig()
-            else:
-                cuda_stream_policy = None
-        else:
-            cuda_stream_policy = _convert_cuda_stream_policy(user_cuda_stream_policy)
-
-        if isinstance(cuda_stream_policy, CUDAStreamPoolConfig) and (
-            executor.name != "streaming"
-        ):
-            raise ValueError(
-                "A stream pool is only supported by the streaming executor."
-            )
-
-        kwargs["cuda_stream_policy"] = cuda_stream_policy
 
         return cls(**kwargs)

--- a/python/cudf_polars/tests/streaming/test_options.py
+++ b/python/cudf_polars/tests/streaming/test_options.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for StreamingOptions."""
 
@@ -93,11 +93,8 @@ def test_engine_options_empty_when_all_unspecified() -> None:
 
 
 def test_engine_options_includes_set_fields() -> None:
-    result = StreamingOptions(
-        raise_on_fail=True, cuda_stream_policy="pool"
-    ).to_engine_options()
+    result = StreamingOptions(raise_on_fail=True).to_engine_options()
     assert result["raise_on_fail"] is True
-    assert result["cuda_stream_policy"] == "pool"
     assert "log" not in result
 
 
@@ -281,21 +278,6 @@ def test_from_argparse_dynamic_planning() -> None:
             argparse.Namespace(dynamic_planning=False)
         ).dynamic_planning
         is None
-    )
-
-
-def test_from_argparse_stream_policy() -> None:
-    assert isinstance(
-        StreamingOptions._from_argparse(
-            argparse.Namespace(stream_policy="auto")
-        ).cuda_stream_policy,
-        Unspecified,
-    )
-    assert (
-        StreamingOptions._from_argparse(
-            argparse.Namespace(stream_policy="pool")
-        ).cuda_stream_policy
-        == "pool"
     )
 
 

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -12,7 +12,6 @@ from polars.testing.asserts import assert_frame_equal
 
 import rmm
 from rmm._cuda import gpu
-from rmm.pylibrmm import CudaStreamFlags
 
 import cudf_polars.callback
 import cudf_polars.utils.config
@@ -27,12 +26,10 @@ from cudf_polars.testing.asserts import (
     assert_ir_translation_raises,
 )
 from cudf_polars.utils.config import (
-    CUDAStreamPoolConfig,
     Cluster,
     ConfigOptions,
     MemoryResourceConfig,
     StreamingExecutor,
-    _default_cuda_stream_policy,
 )
 from cudf_polars.utils.cuda_stream import get_cuda_stream
 
@@ -353,7 +350,6 @@ def test_config_option_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
         m.setenv("CUDF_POLARS__EXECUTOR__MAX_ROWS_PER_PARTITION", "42")
         m.setenv("CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE", "100")
         m.setenv("CUDF_POLARS__EXECUTOR__BROADCAST_LIMIT", "44")
-        m.setenv("CUDF_POLARS__CUDA_STREAM_POLICY", "default")
 
         engine = pl.GPUEngine()
         config = ConfigOptions.from_polars_engine(engine)
@@ -363,7 +359,6 @@ def test_config_option_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
         assert config.executor.max_rows_per_partition == 42
         assert config.executor.target_partition_size == 100
         assert config.executor.broadcast_limit == 44
-        assert config.cuda_stream_policy is None
 
 
 def test_target_partition_from_env(
@@ -529,121 +524,6 @@ def test_ir_execution_context() -> None:
     context = IRExecutionContext()
     assert context.get_cuda_stream is get_cuda_stream
     context.get_cuda_stream()  # no exception
-
-
-def test_cuda_stream_pool():
-    pool_config = CUDAStreamPoolConfig()
-    pool = pool_config.build()
-
-    assert pool.get_pool_size() == 16
-
-    # override the defaults
-    pool_config = CUDAStreamPoolConfig(pool_size=32, flags=CudaStreamFlags.NON_BLOCKING)
-    pool = pool_config.build()
-    assert pool.get_pool_size() == 32
-
-
-def test_cuda_stream_policy_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Default from engine
-    config = ConfigOptions.from_polars_engine(pl.GPUEngine())
-    assert isinstance(config.cuda_stream_policy, CUDAStreamPoolConfig)
-
-    config = ConfigOptions.from_polars_engine(pl.GPUEngine(executor="streaming"))
-    assert isinstance(config.cuda_stream_policy, CUDAStreamPoolConfig)
-
-    # Default from env
-    monkeypatch.setenv("CUDF_POLARS__CUDA_STREAM_POLICY", "default")
-    config = ConfigOptions.from_polars_engine(pl.GPUEngine())
-    assert config.cuda_stream_policy is None
-
-    config = ConfigOptions.from_polars_engine(pl.GPUEngine(executor="streaming"))
-    assert config.cuda_stream_policy is None
-
-
-def test_default_cuda_stream_policy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("CUDF_POLARS__CUDA_STREAM_POLICY", raising=False)
-    assert _default_cuda_stream_policy() is None
-
-    monkeypatch.setenv("CUDF_POLARS__CUDA_STREAM_POLICY", "pool")
-    result = _default_cuda_stream_policy()
-    assert isinstance(result, CUDAStreamPoolConfig)
-
-
-def test_cuda_stream_policy_from_config() -> None:
-    engine = pl.GPUEngine(
-        executor="streaming",
-        cuda_stream_policy={
-            "pool_size": 32,
-            "flags": rmm.pylibrmm.CudaStreamFlags.NON_BLOCKING,
-        },
-    )
-    config = ConfigOptions.from_polars_engine(engine)
-    assert isinstance(config.cuda_stream_policy, CUDAStreamPoolConfig)
-    assert config.cuda_stream_policy.pool_size == 32
-    assert config.cuda_stream_policy.flags == rmm.pylibrmm.CudaStreamFlags.NON_BLOCKING
-    config.cuda_stream_policy.build().get_stream()  # no exception
-
-
-@pytest.mark.parametrize(
-    "env",
-    [
-        "default",
-        "pool",
-        '{"pool_size": 32, "flags": "SYNC_DEFAULT"}',
-        '{"pool_size": 32, "flags": 0}',
-        '{"pool_size": 32}',
-    ],
-)
-def test_cuda_stream_policy_from_env(monkeypatch: pytest.MonkeyPatch, env: str) -> None:
-    monkeypatch.setenv("CUDF_POLARS__CUDA_STREAM_POLICY", env)
-    engine = pl.GPUEngine(executor="streaming")
-    config = ConfigOptions.from_polars_engine(engine)
-    if env == "default":
-        assert config.cuda_stream_policy is None
-    else:
-        assert isinstance(config.cuda_stream_policy, CUDAStreamPoolConfig)
-        if env == "pool":
-            assert config.cuda_stream_policy.pool_size == 16
-            assert config.cuda_stream_policy.flags == CudaStreamFlags.NON_BLOCKING
-        else:
-            assert config.cuda_stream_policy.pool_size == 32
-
-
-def test_cuda_stream_policy_from_env_invalid(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("CUDF_POLARS__CUDA_STREAM_POLICY", '{"foo": "bar"}')
-    with pytest.raises(ValueError, match="Invalid CUDA stream policy"):
-        ConfigOptions.from_polars_engine(pl.GPUEngine())
-
-
-def test_cuda_stream_policy_default_rapidsmpf(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Default from engine
-    config = ConfigOptions.from_polars_engine(pl.GPUEngine(executor="streaming"))
-    assert isinstance(config.cuda_stream_policy, CUDAStreamPoolConfig)
-    assert config.cuda_stream_policy.pool_size == 16
-    assert config.cuda_stream_policy.flags == rmm.pylibrmm.CudaStreamFlags.NON_BLOCKING
-
-    # "default" user argument overrides pool default
-    monkeypatch.setenv("CUDF_POLARS__CUDA_STREAM_POLICY", "default")
-    config = ConfigOptions.from_polars_engine(pl.GPUEngine(executor="streaming"))
-    assert config.cuda_stream_policy is None
-
-
-def test_cuda_stream_policy_pool_in_memory_unsupported() -> None:
-    with pytest.raises(
-        ValueError,
-        match=r"A stream pool is only supported by the streaming executor.",
-    ):
-        ConfigOptions.from_polars_engine(
-            pl.GPUEngine(
-                executor="in-memory",
-                cuda_stream_policy={"pool_size": 32, "flags": "NON_BLOCKING"},
-            )
-        )
-
-
-def test_validate_cuda_stream_policy() -> None:
-    with pytest.raises(ValueError, match="Invalid CUDA stream policy: 'foo'"):
-        ConfigOptions.from_polars_engine(pl.GPUEngine(cuda_stream_policy="foo"))
 
 
 def test_validate_dynamic_planning() -> None:


### PR DESCRIPTION
## Description
Since the refactor of the engines, this has never been used. When generating an engine programmatically, if we want to control the number of streams cudf-polars uses we should use StreamingOptions(num_streams=...). By design, neither the default singleton engine nor the in-memory executor expose this configuration option. We can therefore just remove all this code.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
