### PR TITLE
Avoid unnecessary copy when `TableChunk` data is already packed

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/allgather.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/collectives/allgather.py
@@ -6,11 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cudf_streaming.partition_utils import (
-    packed_data_from_cudf_packed_columns,
-    unpack_and_concat,
-)
-from pylibcudf.contiguous_split import pack
+from cudf_streaming.partition_utils import unpack_and_concat
 from rapidsmpf.streaming.coll.allgather import AllGather
 
 if TYPE_CHECKING:
@@ -70,17 +66,7 @@ class AllGatherManager:
             )
             self._manager.allgather.insert(
                 sequence_number,
-                # TODO: Avoid unnecessary copies.
-                # See https://github.com/rapidsai/rapidsmpf/issues/933
-                packed_data_from_cudf_packed_columns(
-                    pack(
-                        chunk.table_view(),
-                        chunk.stream,
-                        mr=self._manager.context.br().device_mr,
-                    ),
-                    chunk.stream,
-                    self._manager.context.br(),
-                ),
+                chunk.into_packed_data(self._manager.context.br()),
             )
             del chunk
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follow up from https://github.com/rapidsai/rapidsmpf/issues/933. If the `TableChunk` already has packed data, we can avoid a copy.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
