### PR TITLE
Fix ptr null check in packed_data_from_cudf_packed_columns

### DIFF
--- a/python/cudf_streaming/cudf_streaming/partition_utils.pyx
+++ b/python/cudf_streaming/cudf_streaming/partition_utils.pyx
@@ -321,7 +321,7 @@ cpdef object packed_data_from_cudf_packed_columns(
     cdef cpp_BufferResource* _br = br.ptr()
     cdef PackedData ret = PackedData.__new__(PackedData)
     with nogil:
-        if not (packed_columns.c_obj != NULL and
+        if not (packed_columns.c_obj.get() != NULL and
                 deref(packed_columns.c_obj).metadata and
                 deref(packed_columns.c_obj).gpu_data):
             raise ValueError("Cannot release empty PackedColumns")


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Split out from https://github.com/rapidsai/cudf/pull/23035/changes/d7de68d25c03a0a8b14b96e2acdf1b43fae06ca6

Fixes CI failures: https://github.com/rapidsai/cudf/actions/runs/28402849820/job/84162181059?pr=23018

<details>

```
FAILED: [code=1] CMakeFiles/cudf_streaming_partition_utils.dir/partition_utils.cxx.o
 │ │       sccache $BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++ -DCCCL_DISABLE_PDL -DCUB_DISABLE_NAMESPACE_MAGIC -DCUB_IGNORE_NAMESPACE_MAGIC_ERROR -DPy_LIMITED_API=0x030b0000 -DRAPIDSMPF_HAVE_CUPTI -DRAPIDSMPF_HAVE_MPI -DRAPIDSMPF_HAVE_NUMA -DRAPIDSMPF_HAVE_SLURM -DRAPIDSMPF_HAVE_STREAMING -DRAPIDSMPF_HAVE_UCXX -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_DISABLE_ABI_NAMESPACE -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DTHRUST_IGNORE_ABI_NAMESPACE_ERROR -DUCXX_ENABLE_CCCL -Dcudf_streaming_partition_utils_EXPORTS -I$PREFIX/include/rapids -isystem $PREFIX/include/python3.11 -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -fno-merge-constants -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/cudf-streaming-26.08.00a776 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix  -I$PREFIX/targets/x86_64-linux/include -I$BUILD_PREFIX/targets/x86_64-linux/include -O3 -DNDEBUG -std=gnu++20 -fPIC -MD -MT CMakeFiles/cudf_streaming_partition_utils.dir/partition_utils.cxx.o -MF CMakeFiles/cudf_streaming_partition_utils.dir/partition_utils.cxx.o.d -o CMakeFiles/cudf_streaming_partition_utils.dir/partition_utils.cxx.o -c $SRC_DIR/python/cudf_streaming/build/cp311-abi3-linux_x86_64/partition_utils.cxx
 │ │       $SRC_DIR/python/cudf_streaming/build/cp311-abi3-linux_x86_64/partition_utils.cxx: In function 'PyObject* __pyx_f_14cudf_streaming_15partition_utils_packed_data_from_cudf_packed_columns(__pyx_obj_9pylibcudf_16contiguous_split_PackedColumns*, __pyx_obj_3rmm_8pylibrmm_6stream_Stream*, __pyx_obj_9rapidsmpf_6memory_15buffer_resource_BufferResource*, int)':
 │ │       $SRC_DIR/python/cudf_streaming/build/cp311-abi3-linux_x86_64/partition_utils.cxx:23160:95: error: call of overloaded 'unique_ptr(NULL)' is ambiguous
 │ │       23160 |         __pyx_t_2 = (__pyx_v_packed_columns->c_obj != ((std::unique_ptr<cudf::packed_columns> )NULL));
 │ │             |                                                                                               ^~~~~~
 │ │       In file included from $BUILD_PREFIX/lib/gcc/x86_64-conda-linux-gnu/14.3.0/include/c++/memory:78,
 │ │                        from $SRC_DIR/python/cudf_streaming/build/cp311-abi3-linux_x86_64/partition_utils.cxx:1233:
 │ │       $BUILD_PREFIX/lib/gcc/x86_64-conda-linux-gnu/14.3.0/include/c++/bits/unique_ptr.h:353:19: note: candidate: 'constexpr std::unique_ptr<_Tp, _Dp>::unique_ptr(std::nullptr_t) [with _Del = std::default_delete<cudf::packed_columns>; <template-parameter-2-2> = void; _Tp = cudf::packed_columns; _Dp = std::default_delete<cudf::packed_columns>; std::nullptr_t = std::nullptr_t]'
```

</details>

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
