### PR TITLE
Use DeviceFind-backed boolean reductions

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -211,6 +211,7 @@ ConfigureNVBench(TYPE_DISPATCHER_NVBENCH type_dispatcher/type_dispatcher.cu)
 ConfigureNVBench(
   REDUCTION_NVBENCH
   reduction/anyall.cpp
+  reduction/detail_anyall.cu
   reduction/dictionary.cpp
   reduction/distinct_count.cpp
   reduction/histogram.cpp

--- a/cpp/benchmarks/reduction/detail_anyall.cu
+++ b/cpp/benchmarks/reduction/detail_anyall.cu
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <benchmarks/common/memory_stats.hpp>
+#include <benchmarks/common/nvbench_utilities.hpp>
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/algorithms/reduce.cuh>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <nvbench/nvbench.cuh>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+template <typename DataType>
+std::unique_ptr<cudf::column> make_detail_anyall_input(cudf::size_type size,
+                                                       std::string const& kind_str,
+                                                       std::string const& pattern,
+                                                       rmm::cuda_stream_view stream)
+{
+  auto values = cudf::make_fixed_width_column(cudf::data_type{cudf::type_to_id<DataType>()},
+                                              size,
+                                              cudf::mask_state::UNALLOCATED,
+                                              stream,
+                                              cudf::get_current_device_resource_ref());
+  using host_value_type = std::conditional_t<std::is_same_v<DataType, bool>, int8_t, DataType>;
+
+  // "first" and "last" place the decisive value for each detail reduction at that position.
+  auto const fill_value = kind_str == "any" ? host_value_type{0} : host_value_type{1};
+  auto const find_value = kind_str == "any" ? host_value_type{1} : host_value_type{0};
+  auto host_values      = std::vector<host_value_type>(size, fill_value);
+
+  if (pattern == "first") {
+    host_values.front() = find_value;
+  } else if (pattern == "last") {
+    host_values.back() = find_value;
+  } else {
+    CUDF_EXPECTS(pattern == "none", "Unsupported detail_anyall benchmark pattern.");
+  }
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(values->mutable_view().template begin<DataType>(),
+                                host_values.data(),
+                                sizeof(DataType) * size,
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
+
+  return values;
+}
+
+template <typename DataType>
+static void detail_anyall(nvbench::state& state, nvbench::type_list<DataType>)
+{
+  auto const size     = static_cast<cudf::size_type>(state.get_int64("size"));
+  auto const kind_str = state.get_string("kind");
+  auto const pattern  = state.get_string("pattern");
+
+  auto stream       = cudf::get_default_stream();
+  auto const values = make_detail_anyall_input<DataType>(size, kind_str, pattern, stream);
+
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.add_element_count(size);
+  state.add_global_memory_reads<DataType>(size);
+  state.add_global_memory_writes<nvbench::int8_t>(1);
+
+  bool result                 = false;
+  auto const mem_stats_logger = cudf::memory_stats_logger();
+  state.exec(nvbench::exec_tag::sync, [&values, &kind_str, stream, &result](nvbench::launch&) {
+    auto const input = values->view();
+    auto const begin = input.template begin<DataType>();
+    auto const end   = input.template end<DataType>();
+    auto predicate   = [] __device__(DataType value) { return value != DataType{0}; };
+
+    result = kind_str == "any" ? cudf::detail::any_of(begin, end, predicate, stream)
+                               : cudf::detail::all_of(begin, end, predicate, stream);
+  });
+  state.add_buffer_size(
+    mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
+
+  set_throughputs(state);
+}
+
+using Types = nvbench::type_list<bool, int32_t>;
+
+NVBENCH_BENCH_TYPES(detail_anyall, NVBENCH_TYPE_AXES(Types))
+  .set_name("detail_anyall")
+  .set_type_axes_names({"DataType"})
+  .add_string_axis("kind", {"any", "all"})
+  .add_string_axis("pattern", {"first", "last", "none"})
+  .add_int64_axis("size", {100'000, 10'000'000, 100'000'000});

--- a/cpp/benchmarks/reduction/detail_anyall.cu
+++ b/cpp/benchmarks/reduction/detail_anyall.cu
@@ -79,7 +79,7 @@ static void detail_anyall(nvbench::state& state, nvbench::type_list<DataType>)
     auto const input = values->view();
     auto const begin = input.template begin<DataType>();
     auto const end   = input.template end<DataType>();
-    auto predicate   = [] __device__(DataType value) { return value != DataType{0}; };
+    auto predicate   = [] __device__(DataType value) -> bool { return value != DataType{0}; };
 
     result = kind_str == "any" ? cudf::detail::any_of(begin, end, predicate, stream)
                                : cudf::detail::all_of(begin, end, predicate, stream);

--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cudf/detail/device_scalar.hpp>
+#include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
@@ -19,6 +20,8 @@
 #include <cuda/stream_ref>
 
 namespace cudf::detail {
+
+inline constexpr cudf::size_type device_find_if_small_input_threshold = 1'000'000;
 
 /**
  * @brief Check if a predicate is true for any element in a device-accessible range using
@@ -266,28 +269,12 @@ OutputType transform_reduce(InputIterator begin,
   auto result =
     cudf::detail::device_scalar<OutputType>(stream, cudf::get_current_device_resource_ref());
 
-  size_t temp_storage_bytes = 0;
-  CUDF_CUDA_TRY(cub::DeviceReduce::TransformReduce(nullptr,
-                                                   temp_storage_bytes,
-                                                   begin,
-                                                   result.data(),
-                                                   num_items,
-                                                   reduce_op,
-                                                   transform_op,
-                                                   init,
-                                                   stream.value()));
-
-  rmm::device_buffer d_temp_storage(
-    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
-  CUDF_CUDA_TRY(cub::DeviceReduce::TransformReduce(d_temp_storage.data(),
-                                                   temp_storage_bytes,
-                                                   begin,
-                                                   result.data(),
-                                                   num_items,
-                                                   reduce_op,
-                                                   transform_op,
-                                                   init,
-                                                   stream.value()));
+  auto env = cuda::std::execution::env{
+    cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{stream.value()}},
+    cuda::std::execution::prop{cuda::mr::get_memory_resource_t{},
+                               cudf::get_current_device_resource_ref()}};
+  CUDF_CUDA_TRY(cub::DeviceReduce::TransformReduce(
+    begin, result.data(), num_items, reduce_op, transform_op, init, env));
 
   // Copy result back to host via pinned memory
   return result.value(stream);
@@ -311,8 +298,13 @@ OutputType transform_reduce(InputIterator begin,
 template <typename TransformOp, typename InputIterator>
 bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
+  auto const num_items = cuda::std::distance(begin, end);
+  if (num_items <= static_cast<decltype(num_items)>(device_find_if_small_input_threshold)) {
+    return transform_reduce(begin, end, op, true, cuda::std::logical_and<bool>{}, stream);
+  }
+
   return not device_find_if(
-    begin, end, [op] __device__(auto const& val) { return not op(val); }, stream);
+    begin, end, [op] __device__(auto const& val) -> bool { return not op(val); }, stream);
 }
 
 /**
@@ -333,6 +325,11 @@ bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_st
 template <typename TransformOp, typename InputIterator>
 bool any_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
+  auto const num_items = cuda::std::distance(begin, end);
+  if (num_items <= static_cast<decltype(num_items)>(device_find_if_small_input_threshold)) {
+    return transform_reduce(begin, end, op, false, cuda::std::logical_or<bool>{}, stream);
+  }
+
   return device_find_if(begin, end, op, stream);
 }
 

--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,12 +12,57 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/device/device_find.cuh>
 #include <cub/device/device_reduce.cuh>
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/stream_ref>
 
 namespace cudf::detail {
+
+/**
+ * @brief Check if a predicate is true for any element in a device-accessible range using
+ * `cub::DeviceFind::FindIf`
+ *
+ * @tparam Predicate **[inferred]** Type of the unary predicate
+ * @tparam InputIterator **[inferred]** Type of device-accessible input iterator
+ *
+ * @param begin Device-accessible iterator to start of input values
+ * @param end Device-accessible iterator to end of input values
+ * @param predicate Predicate operator to apply to each element
+ * @param stream CUDA stream to use
+ * @return true if the predicate is true for any element, false otherwise
+ */
+template <typename Predicate, typename InputIterator>
+bool device_find_if(InputIterator begin,
+                    InputIterator end,
+                    Predicate predicate,
+                    rmm::cuda_stream_view stream)
+{
+  auto const num_items = cuda::std::distance(begin, end);
+  if (num_items == 0) { return false; }
+
+  using offset_type = cub::detail::choose_offset_t<decltype(num_items)>;
+
+  auto result =
+    cudf::detail::device_scalar<offset_type>(stream, cudf::get_current_device_resource_ref());
+
+  size_t temp_storage_bytes = 0;
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(
+    nullptr, temp_storage_bytes, begin, result.data(), predicate, num_items, stream.value()));
+
+  rmm::device_buffer d_temp_storage(
+    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        begin,
+                                        result.data(),
+                                        predicate,
+                                        num_items,
+                                        stream.value()));
+
+  return result.value(stream) != static_cast<offset_type>(num_items);
+}
 
 /**
  * @brief Helper to reduce a device-accessible iterator using a binary operation
@@ -274,7 +319,8 @@ OutputType transform_reduce(InputIterator begin,
 template <typename TransformOp, typename InputIterator>
 bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
-  return transform_reduce(begin, end, op, true, cuda::std::logical_and<bool>{}, stream);
+  return not device_find_if(
+    begin, end, [op] __device__(auto const& val) { return not op(val); }, stream);
 }
 
 /**
@@ -295,7 +341,7 @@ bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_st
 template <typename TransformOp, typename InputIterator>
 bool any_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
-  return transform_reduce(begin, end, op, false, cuda::std::logical_or<bool>{}, stream);
+  return device_find_if(begin, end, op, stream);
 }
 
 /**

--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -47,19 +47,11 @@ bool device_find_if(InputIterator begin,
   auto result =
     cudf::detail::device_scalar<offset_type>(stream, cudf::get_current_device_resource_ref());
 
-  size_t temp_storage_bytes = 0;
-  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(
-    nullptr, temp_storage_bytes, begin, result.data(), predicate, num_items, stream.value()));
-
-  rmm::device_buffer d_temp_storage(
-    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
-  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(d_temp_storage.data(),
-                                        temp_storage_bytes,
-                                        begin,
-                                        result.data(),
-                                        predicate,
-                                        num_items,
-                                        stream.value()));
+  auto env = cuda::std::execution::env{
+    cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{stream.value()}},
+    cuda::std::execution::prop{cuda::mr::get_memory_resource_t{},
+                               cudf::get_current_device_resource_ref()}};
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(begin, result.data(), predicate, num_items, env));
 
   return result.value(stream) != static_cast<offset_type>(num_items);
 }

--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -27,8 +27,8 @@ inline constexpr cudf::size_type device_find_if_small_input_threshold = 1'000'00
  * @brief Check if a predicate is true for any element in a device-accessible range using
  * `cub::DeviceFind::FindIf`
  *
- * @tparam Predicate **[inferred]** Type of the unary predicate
- * @tparam InputIterator **[inferred]** Type of device-accessible input iterator
+ * @tparam Predicate Type of the unary predicate
+ * @tparam InputIterator Type of device-accessible input iterator
  *
  * @param begin Device-accessible iterator to start of input values
  * @param end Device-accessible iterator to end of input values
@@ -45,7 +45,8 @@ bool device_find_if(InputIterator begin,
   auto const num_items = cuda::std::distance(begin, end);
   if (num_items == 0) { return false; }
 
-  using offset_type = cub::detail::choose_offset_t<decltype(num_items)>;
+  using offset_type =
+    cuda::std::conditional_t<(sizeof(num_items) <= 4), uint32_t, unsigned long long>;
 
   auto result =
     cudf::detail::device_scalar<offset_type>(stream, cudf::get_current_device_resource_ref());

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf/copying.hpp>
@@ -45,7 +45,7 @@ bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_vie
 
   auto const row_begin = cuda::counting_iterator<cudf::size_type>{0};
   auto const row_end   = row_begin + input.size();
-  return cudf::detail::count_if(row_begin, row_end, is_dirty_row, stream) > 0;
+  return cudf::detail::any_of(row_begin, row_end, is_dirty_row, stream);
 }
 
 }  // namespace

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -39,7 +39,8 @@ bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_vie
                               : lists_column_view{input}.offsets(),
     input.offset());
   auto const d_input      = cudf::column_device_view::create(input, stream);
-  auto const is_dirty_row = [d_input = *d_input, offsets] __device__(size_type const& row_idx) {
+  auto const is_dirty_row = [d_input = *d_input,
+                             offsets] __device__(size_type const& row_idx) -> bool {
     return d_input.is_null_nocheck(row_idx) && (offsets[row_idx] != offsets[row_idx + 1]);
   };
 

--- a/cpp/src/interop/to_arrow_host.cu
+++ b/cpp/src/interop/to_arrow_host.cu
@@ -7,6 +7,7 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/interop.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
@@ -433,18 +434,18 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
   auto d_offsets =
     cudf::detail::offsetalator_factory::make_input_iterator(col.offsets(), col.offset());
 
-  // count the number of long-ish strings -- ones that cannot be inlined
-  auto const num_longer_strings = thrust::count_if(
-    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+  // Check whether all strings are long-ish -- ones that cannot be inlined.
+  auto const all_strings_longer = cudf::detail::all_of(
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{col.size()},
     [d_offsets] __device__(auto idx) {
       return d_offsets[idx + 1] - d_offsets[idx] > NANOARROW_BINARY_VIEW_INLINE_SIZE;
-    });
+    },
+    stream);
 
   // gather all the long-ish strings into a single strings column
   auto [unused_col, longer_strings] = [&] {
-    if (num_longer_strings == col.size()) {
+    if (all_strings_longer) {
       // we can use the input column as is for the remainder of this function
       return std::pair{cudf::make_empty_column(cudf::type_id::STRING), col};
     }

--- a/cpp/src/interop/to_arrow_host.cu
+++ b/cpp/src/interop/to_arrow_host.cu
@@ -438,7 +438,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
   auto const all_strings_longer = cudf::detail::all_of(
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{col.size()},
-    [d_offsets] __device__(auto idx) {
+    [d_offsets] __device__(auto idx) -> bool {
       return d_offsets[idx + 1] - d_offsets[idx] > NANOARROW_BINARY_VIEW_INLINE_SIZE;
     },
     stream);
@@ -452,7 +452,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
     auto indices = make_counting_transform_iterator(
       0,
       cuda::proclaim_return_type<cudf::strings::detail::string_index_pair>(
-        [d_strings = *d_strings] __device__(auto idx) {
+        [d_strings = *d_strings] __device__(auto idx) -> cudf::strings::detail::string_index_pair {
           if (d_strings.is_null(idx)) {
             return cudf::strings::detail::string_index_pair{nullptr, 0};
           }
@@ -482,7 +482,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
     // compute buffer boundaries (less than 2GB per buffer)
     auto buffer_indices  = rmm::device_uvector<int64_t>(num_buffers, stream);
     auto const bound_itr = make_counting_transform_iterator(
-      0, cuda::proclaim_return_type<int64_t>([] __device__(auto idx) {
+      0, cuda::proclaim_return_type<int64_t>([] __device__(auto idx) -> int64_t {
         return (idx + 1) * max_size;
       }));
     thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -495,7 +495,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
                       buffer_indices.begin(),
                       buffer_indices.end(),
                       buffer_offsets.begin(),
-                      [d_offsets] __device__(auto idx) { return d_offsets[idx]; });
+                      [d_offsets] __device__(auto idx) -> int64_t { return d_offsets[idx]; });
     auto h_offsets = make_std_vector(buffer_offsets, stream);
 
     // build up the variadic buffers needed

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_stream.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/cuda_memcpy.hpp>
@@ -44,7 +45,6 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <thrust/count.h>
 #include <thrust/host_vector.h>
 
 #include <algorithm>
@@ -996,13 +996,8 @@ table_with_metadata read_csv(cudf::io::datasource* source,
         auto const is_quoted = device_span<bool>(is_quoted_flags[str_col_idx]);
         auto* buffer         = &out_buffers[col_idx];
 
-        // Count how many rows were quoted to determine the fast path
-        auto const num_quoted = thrust::count(
-          rmm::exec_policy_nosync(col_stream, cudf::get_current_device_resource_ref()),
-          is_quoted.begin(),
-          is_quoted.end(),
-          true);
-        if (num_quoted == 0) {
+        auto const is_quoted_row = [] __device__(auto const flag) { return flag; };
+        if (cudf::detail::none_of(is_quoted.begin(), is_quoted.end(), is_quoted_row, col_stream)) {
           // Fast path: no rows were quoted, skip replacement entirely
           out_columns[col_idx] = make_column(*buffer, nullptr, std::nullopt, col_stream);
         } else {
@@ -1015,7 +1010,7 @@ table_with_metadata read_csv(cudf::io::datasource* source,
             -1,
             col_stream,
             mr);
-          if (std::cmp_equal(num_quoted, num_records)) {
+          if (cudf::detail::all_of(is_quoted.begin(), is_quoted.end(), is_quoted_row, col_stream)) {
             // Fast path: all rows were quoted, apply replacement to all
             out_columns[col_idx] = std::move(replaced_all_col);
           } else {

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -204,7 +204,7 @@ template <typename C>
 void erase_except_last(C& container, rmm::cuda_stream_view stream)
 {
   cudf::detail::device_single_thread(
-    [span = device_span<typename C::value_type>{container}] __device__() mutable {
+    [span = device_span<typename C::value_type>{container}] __device__() mutable -> void {
       span.front() = span.back();
     },
     stream);
@@ -996,7 +996,7 @@ table_with_metadata read_csv(cudf::io::datasource* source,
         auto const is_quoted = device_span<bool>(is_quoted_flags[str_col_idx]);
         auto* buffer         = &out_buffers[col_idx];
 
-        auto const is_quoted_row = [] __device__(auto const flag) { return flag; };
+        auto const is_quoted_row = [] __device__(auto const flag) -> bool { return flag; };
         if (cudf::detail::none_of(is_quoted.begin(), is_quoted.end(), is_quoted_row, col_stream)) {
           // Fast path: no rows were quoted, skip replacement entirely
           out_columns[col_idx] = make_column(*buffer, nullptr, std::nullopt, col_stream);
@@ -1037,7 +1037,7 @@ table_with_metadata read_csv(cudf::io::datasource* source,
               replaced_all_iter,
               replaced_all_iter + num_records,
               original_iter,
-              [is_quoted] __device__(size_type idx) { return is_quoted[idx]; },
+              [is_quoted] __device__(size_type idx) -> bool { return is_quoted[idx]; },
               col_stream,
               mr);
           }

--- a/cpp/src/io/json/json_tree.cu
+++ b/cpp/src/io/json/json_tree.cu
@@ -268,17 +268,12 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
   };
 
   // Look for ErrorBegin and report the point of error.
-  if (auto const error_count =
-        thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                      tokens.begin(),
-                      tokens.end(),
-                      token_t::ErrorBegin);
-      error_count > 0) {
-    auto const error_location =
-      thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                   tokens.begin(),
-                   tokens.end(),
-                   token_t::ErrorBegin);
+  auto const error_location =
+    thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 tokens.begin(),
+                 tokens.end(),
+                 token_t::ErrorBegin);
+  if (error_location != tokens.end()) {
     auto error_index = cudf::detail::make_host_vector<SymbolOffsetT>(
       device_span<SymbolOffsetT const>{
         token_indices.data() + cuda::std::distance(tokens.begin(), error_location), 1},

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -694,12 +694,12 @@ void detect_malformed_pages(device_span<PageInfo const> pages,
     }
 
     // all non-zero row counts must be the same
-    auto const chk =
-      cudf::detail::count_if(compacted_row_counts_begin,
-                             compacted_row_counts_end,
-                             row_counts_different{static_cast<size_type>(found_row_count)},
-                             stream);
-    CUDF_EXPECTS(chk == 0,
+    auto const row_counts_match =
+      cudf::detail::none_of(compacted_row_counts_begin,
+                            compacted_row_counts_end,
+                            row_counts_different{static_cast<size_type>(found_row_count)},
+                            stream);
+    CUDF_EXPECTS(row_counts_match,
                  "Encountered malformed parquet page data (row count mismatch in page data)");
   }
 }

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -194,7 +194,7 @@ std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& in
     0,
     cuda::proclaim_return_type<std::ptrdiff_t>(
       [offsets_begin = offsets.begin<size_type>(),
-       offsets_end   = offsets.end<size_type>()] __device__(size_type i) {
+       offsets_end   = offsets.end<size_type>()] __device__(size_type i) -> std::ptrdiff_t {
         return cuda::std::distance(
           offsets_begin,
           cuda::std::prev(thrust::upper_bound(thrust::seq, offsets_begin, offsets_end, i)));
@@ -217,7 +217,7 @@ std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& in
              ? cudf::detail::valid_if(
                  cuda::counting_iterator<size_type>{0},
                  cuda::counting_iterator<size_type>{0} + num_output_values,
-                 [percentiles = *percentiles_cdv] __device__(size_type i) {
+                 [percentiles = *percentiles_cdv] __device__(size_type i) -> bool {
                    return percentiles.is_valid(i % percentiles.size());
                  },
                  stream,
@@ -353,7 +353,7 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
   auto const all_empty_rows = cudf::detail::all_of(
     detail::size_begin(input),
     detail::size_begin(input) + input.size(),
-    [] __device__(auto const x) { return x == 0; },
+    [] __device__(auto const x) -> bool { return x == 0; },
     stream);
   auto row_size_iter = cuda::make_constant_iterator(all_empty_rows ? 0 : percentiles.size());
   thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -350,11 +350,11 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
   // output is a list column with each row containing percentiles.size() percentile values
   auto offsets = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, input.size() + 1, mask_state::UNALLOCATED, stream, mr);
-  auto const all_empty_rows = cudf::detail::count_if(
-                                detail::size_begin(input),
-                                detail::size_begin(input) + input.size(),
-                                [] __device__(auto const x) { return x == 0; },
-                                stream) == static_cast<std::size_t>(input.size());
+  auto const all_empty_rows = cudf::detail::all_of(
+    detail::size_begin(input),
+    detail::size_begin(input) + input.size(),
+    [] __device__(auto const x) { return x == 0; },
+    stream);
   auto row_size_iter = cuda::make_constant_iterator(all_empty_rows ? 0 : percentiles.size());
   thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          row_size_iter,

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -9,6 +9,7 @@
 #include "detail/rolling_udf.cuh"
 #include "detail/rolling_utils.cuh"
 
+#include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/groupby/sort_helper.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
@@ -24,7 +25,6 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/functional>
-#include <cuda/std/functional>
 
 #include <concepts>
 #include <span>
@@ -385,12 +385,11 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
           return nulls_per_group[i] < (d_offsets[i + 1] - d_offsets[i]) &&
                  d_orderby.is_null_nocheck(d_offsets[i]);
         }));
-    auto is_before =
-      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                     it,
-                     it + offsets.size() - 1,
-                     false,
-                     cuda::std::logical_or<>{});
+    auto is_before = cudf::detail::any_of(
+      it,
+      it + offsets.size() - 1,
+      [] __device__(bool has_boundary_null) { return has_boundary_null; },
+      stream);
     return is_before ? null_order::BEFORE : null_order::AFTER;
   } else {
     // Sort order is DESCENDING
@@ -407,12 +406,11 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
           return nulls_per_group[i] < (d_offsets[i + 1] - d_offsets[i]) &&
                  d_orderby.is_null_nocheck(d_offsets[i + 1] - 1);
         }));
-    auto is_before =
-      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                     it,
-                     it + offsets.size() - 1,
-                     false,
-                     cuda::std::logical_or<>{});
+    auto is_before = cudf::detail::any_of(
+      it,
+      it + offsets.size() - 1,
+      [] __device__(bool has_boundary_null) { return has_boundary_null; },
+      stream);
     return is_before ? null_order::BEFORE : null_order::AFTER;
   }
 }

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -388,7 +388,7 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
     auto is_before = cudf::detail::any_of(
       it,
       it + offsets.size() - 1,
-      [] __device__(bool has_boundary_null) { return has_boundary_null; },
+      [] __device__(bool has_boundary_null) -> bool { return has_boundary_null; },
       stream);
     return is_before ? null_order::BEFORE : null_order::AFTER;
   } else {
@@ -409,7 +409,7 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
     auto is_before = cudf::detail::any_of(
       it,
       it + offsets.size() - 1,
-      [] __device__(bool has_boundary_null) { return has_boundary_null; },
+      [] __device__(bool has_boundary_null) -> bool { return has_boundary_null; },
       stream);
     return is_before ? null_order::BEFORE : null_order::AFTER;
   }

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -70,14 +70,14 @@ struct contains_scalar_dispatch {
       d_haystack->optional_begin<DType>(cudf::nullate::DYNAMIC{haystack.has_nulls()});
     auto const end = d_haystack->optional_end<DType>(cudf::nullate::DYNAMIC{haystack.has_nulls()});
 
-    return cudf::detail::count_if(
-             begin,
-             end,
-             [d_needle] __device__(auto const val_pair) {
-               auto needle = get_scalar_value<Element>(d_needle);
-               return val_pair.has_value() && (needle == *val_pair);
-             },
-             stream) > 0;
+    return cudf::detail::any_of(
+      begin,
+      end,
+      [d_needle] __device__(auto const val_pair) {
+        auto needle = get_scalar_value<Element>(d_needle);
+        return val_pair.has_value() && (needle == *val_pair);
+      },
+      stream);
   }
 
   template <typename Element>
@@ -127,10 +127,11 @@ struct contains_scalar_dispatch {
         return d_comp(idx, rhs_index_type{0});  // compare haystack[idx] == needle[0].
       });
 
-    return thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                         d_results.begin(),
-                         d_results.end(),
-                         true) > 0;
+    return cudf::detail::any_of(
+      d_results.begin(),
+      d_results.end(),
+      [] __device__(auto const result) { return result; },
+      stream);
   }
 };
 

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -73,7 +73,7 @@ struct contains_scalar_dispatch {
     return cudf::detail::any_of(
       begin,
       end,
-      [d_needle] __device__(auto const val_pair) {
+      [d_needle] __device__(auto const val_pair) -> bool {
         auto needle = get_scalar_value<Element>(d_needle);
         return val_pair.has_value() && (needle == *val_pair);
       },
@@ -120,7 +120,7 @@ struct contains_scalar_dispatch {
       begin,
       end,
       d_results.begin(),
-      [d_comp, check_nulls, d_haystack = *haystack_cdv_ptr] __device__(auto const idx) {
+      [d_comp, check_nulls, d_haystack = *haystack_cdv_ptr] __device__(auto const idx) -> bool {
         if (check_nulls && d_haystack.is_null_nocheck(static_cast<size_type>(idx))) {
           return false;
         }
@@ -130,7 +130,7 @@ struct contains_scalar_dispatch {
     return cudf::detail::any_of(
       d_results.begin(),
       d_results.end(),
-      [] __device__(auto const result) { return result; },
+      [] __device__(auto const result) -> bool { return result; },
       stream);
   }
 };

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -48,7 +48,10 @@ bool is_sorted(cudf::table_view const& in,
                       });
 
     return cudf::detail::all_of(
-      d_results.begin(), d_results.end(), [] __device__(bool result) { return result; }, stream);
+      d_results.begin(),
+      d_results.end(),
+      [] __device__(bool result) -> bool { return result; },
+      stream);
   } else {
     auto const device_comparator = comparator.less<false>(has_nested_nulls(in));
 

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -1,8 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/row_operator/lexicographic.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
@@ -17,7 +18,6 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <thrust/count.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 
@@ -47,10 +47,8 @@ bool is_sorted(cudf::table_view const& in,
                         return (idx == 0) || device_comparator(idx - 1, idx);
                       });
 
-    return thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                         d_results.begin(),
-                         d_results.end(),
-                         false) == 0;
+    return cudf::detail::all_of(
+      d_results.begin(), d_results.end(), [] __device__(bool result) { return result; }, stream);
   } else {
     auto const device_comparator = comparator.less<false>(has_nested_nulls(in));
 

--- a/cpp/src/table/table_equal.cu
+++ b/cpp/src/table/table_equal.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,6 @@
 
 #include <cub/device/device_transform.cuh>
 #include <cuda/iterator>
-#include <cuda/std/functional>
 
 namespace cudf {
 namespace detail {
@@ -44,8 +43,8 @@ template <bool has_nested_columns>
       return rows_equal(detail::row::lhs_index_type{i}, detail::row::rhs_index_type{i});
     },
     stream.value()));
-  return cudf::detail::reduce(
-    eq_rows.begin(), eq_rows.end(), true, cuda::std::logical_and<bool>{}, stream);
+  return cudf::detail::all_of(
+    eq_rows.begin(), eq_rows.end(), [] __device__(bool row_equal) { return row_equal; }, stream);
 }
 
 }  // namespace

--- a/cpp/src/table/table_equal.cu
+++ b/cpp/src/table/table_equal.cu
@@ -44,7 +44,10 @@ template <bool has_nested_columns>
     },
     stream.value()));
   return cudf::detail::all_of(
-    eq_rows.begin(), eq_rows.end(), [] __device__(bool row_equal) { return row_equal; }, stream);
+    eq_rows.begin(),
+    eq_rows.end(),
+    [] __device__(bool row_equal) -> bool { return row_equal; },
+    stream);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Contributes to #22703.

This PR combines the FindIf / boolean-reduction follow-up work that was initially split across #23044, #23045, #23047, and #23048. The superseded follow-up PRs are closed; this PR contains the complete source diff.

The shared helper change updates `cudf::detail::all_of`, `any_of`, and `none_of` in `cpp/include/cudf/detail/algorithms/reduce.cuh` to use `cub::DeviceFind::FindIf` instead of `transform_reduce` for boolean existence checks. `all_of` searches for the first predicate failure, `any_of` searches for the first predicate success, and `none_of` continues to delegate through `any_of`.

The call-site changes replace count/full-reduction patterns where only existence, nonexistence, or all-of semantics are needed:

- `cpp/src/search/contains_scalar.cu`
- `cpp/src/io/json/json_tree.cu`
- `cpp/src/io/parquet/reader_impl_chunking_utils.cu`
- `cpp/src/interop/to_arrow_host.cu`
- `cpp/src/io/csv/reader_impl.cu`
- `cpp/src/sort/is_sorted.cu`
- `cpp/src/copying/purge_nonempty_nulls.cu`
- `cpp/src/quantiles/tdigest/tdigest.cu`
- `cpp/src/table/table_equal.cu`
- `cpp/src/rolling/grouped_rolling.cu`

The nested scalar contains path still materializes its temporary boolean result buffer, but it now reduces that buffer with `any_of`. Avoiding that temporary remains a larger compile-time/runtime tradeoff and is not included here.

Validation on the combined branch:

- `build-all -j0` completed when the `rapids-dev cuda13.3-conda` worktree/devcontainer was initialized.
- `build-cudf-cpp` passed after combining all commits into this branch.
- `test-cudf-cpp -j10` passed: 119/119 tests.

Benchmark comparisons are posted in a separate PR comment.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
