### PR TITLE
Use any_of for scalar contains

### DIFF
--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,12 +12,57 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/device/device_find.cuh>
 #include <cub/device/device_reduce.cuh>
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/stream_ref>
 
 namespace cudf::detail {
+
+/**
+ * @brief Check if a predicate is true for any element in a device-accessible range using
+ * `cub::DeviceFind::FindIf`
+ *
+ * @tparam Predicate **[inferred]** Type of the unary predicate
+ * @tparam InputIterator **[inferred]** Type of device-accessible input iterator
+ *
+ * @param begin Device-accessible iterator to start of input values
+ * @param end Device-accessible iterator to end of input values
+ * @param predicate Predicate operator to apply to each element
+ * @param stream CUDA stream to use
+ * @return true if the predicate is true for any element, false otherwise
+ */
+template <typename Predicate, typename InputIterator>
+bool device_find_if(InputIterator begin,
+                    InputIterator end,
+                    Predicate predicate,
+                    rmm::cuda_stream_view stream)
+{
+  auto const num_items = cuda::std::distance(begin, end);
+  if (num_items == 0) { return false; }
+
+  using offset_type = cub::detail::choose_offset_t<decltype(num_items)>;
+
+  auto result =
+    cudf::detail::device_scalar<offset_type>(stream, cudf::get_current_device_resource_ref());
+
+  size_t temp_storage_bytes = 0;
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(
+    nullptr, temp_storage_bytes, begin, result.data(), predicate, num_items, stream.value()));
+
+  rmm::device_buffer d_temp_storage(
+    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        begin,
+                                        result.data(),
+                                        predicate,
+                                        num_items,
+                                        stream.value()));
+
+  return result.value(stream) != static_cast<offset_type>(num_items);
+}
 
 /**
  * @brief Helper to reduce a device-accessible iterator using a binary operation
@@ -274,7 +319,8 @@ OutputType transform_reduce(InputIterator begin,
 template <typename TransformOp, typename InputIterator>
 bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
-  return transform_reduce(begin, end, op, true, cuda::std::logical_and<bool>{}, stream);
+  return not device_find_if(
+    begin, end, [op] __device__(auto const& val) { return not op(val); }, stream);
 }
 
 /**
@@ -295,7 +341,7 @@ bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_st
 template <typename TransformOp, typename InputIterator>
 bool any_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
-  return transform_reduce(begin, end, op, false, cuda::std::logical_or<bool>{}, stream);
+  return device_find_if(begin, end, op, stream);
 }
 
 /**

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -70,14 +70,14 @@ struct contains_scalar_dispatch {
       d_haystack->optional_begin<DType>(cudf::nullate::DYNAMIC{haystack.has_nulls()});
     auto const end = d_haystack->optional_end<DType>(cudf::nullate::DYNAMIC{haystack.has_nulls()});
 
-    return cudf::detail::count_if(
-             begin,
-             end,
-             [d_needle] __device__(auto const val_pair) {
-               auto needle = get_scalar_value<Element>(d_needle);
-               return val_pair.has_value() && (needle == *val_pair);
-             },
-             stream) > 0;
+    return cudf::detail::any_of(
+      begin,
+      end,
+      [d_needle] __device__(auto const val_pair) {
+        auto needle = get_scalar_value<Element>(d_needle);
+        return val_pair.has_value() && (needle == *val_pair);
+      },
+      stream);
   }
 
   template <typename Element>
@@ -127,10 +127,11 @@ struct contains_scalar_dispatch {
         return d_comp(idx, rhs_index_type{0});  // compare haystack[idx] == needle[0].
       });
 
-    return thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                         d_results.begin(),
-                         d_results.end(),
-                         true) > 0;
+    return cudf::detail::any_of(
+      d_results.begin(),
+      d_results.end(),
+      [] __device__(auto const result) { return result; },
+      stream);
   }
 };
 


### PR DESCRIPTION
## Description
Contributes to #22703.

This updates scalar `cudf::contains` search paths in `cpp/src/search/contains_scalar.cu` so they express existence checks with `cudf::detail::any_of` instead of computing a full count and comparing it with zero.

Changed call sites:
- Fixed-width scalar contains: `cudf::detail::count_if(...) > 0` -> `cudf::detail::any_of(...)`.
- Nested scalar contains: keep the existing temporary boolean result buffer for compile-time reasons, but replace `thrust::count(..., true) > 0` with `cudf::detail::any_of(...)` over that buffer.

This draft PR is stacked on #23044, so it currently includes the central `any_of` / `all_of` DeviceFind helper commit. The search-specific commit is `168b10f37fd5321087392eeca0eb3add04ba6bc9`; this can be rebased after #23044 lands.

Validation:
- `build-cudf-cpp`
- `test-cudf-cpp -j10` (119/119 passed after repairing a root-owned generated `libcudf_kernel_cache` entry in the local devcontainer)

Benchmark comparison was collected in the `rapids-dev cuda13.3-conda` devcontainer on an NVIDIA RTX 6000 Ada Generation. The baseline is `edc3696e97682a06c5cf592d7d3d142f18444e17`, the branch point from `upstream/main` when the worktree was created; the branch result is `168b10f37fd5321087392eeca0eb3add04ba6bc9`.

Only the affected scalar search benchmark was run and reported: `SEARCH_NVBENCH / contains_scalar`. There is no separate nested scalar-contains benchmark in this suite, so no unrelated `contains_table` or string contains benchmarks are included.

NVBench comparison threshold was 5%. Rows shown below are the rows reported by `nvbench_compare.py`; the other 15 configurations were below the 5% threshold or within noise.

| data_size | has_nulls | main GPU time | branch GPU time | diff | NVBench status |
| --- | --- | ---: | ---: | ---: | --- |
| 2^10 | false | 17.786 us | 28.024 us | +57.56% | SLOW |
| 2^20 | false | 30.023 us | 31.912 us | +6.29% | SAME, within noise |
| 2^10 | true | 24.364 us | 28.342 us | +16.33% | SLOW |

For larger inputs (`2^22` through `2^26`) both null and non-null configurations were below the 5% reporting threshold. The branch also reduced reported peak temporary memory for the fixed-width benchmark from about 33.8 KiB on main to 519 B on the branch for non-small inputs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
