### PR TITLE
Use boolean reductions in IO call sites

### DIFF
--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,12 +12,57 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/device/device_find.cuh>
 #include <cub/device/device_reduce.cuh>
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/stream_ref>
 
 namespace cudf::detail {
+
+/**
+ * @brief Check if a predicate is true for any element in a device-accessible range using
+ * `cub::DeviceFind::FindIf`
+ *
+ * @tparam Predicate **[inferred]** Type of the unary predicate
+ * @tparam InputIterator **[inferred]** Type of device-accessible input iterator
+ *
+ * @param begin Device-accessible iterator to start of input values
+ * @param end Device-accessible iterator to end of input values
+ * @param predicate Predicate operator to apply to each element
+ * @param stream CUDA stream to use
+ * @return true if the predicate is true for any element, false otherwise
+ */
+template <typename Predicate, typename InputIterator>
+bool device_find_if(InputIterator begin,
+                    InputIterator end,
+                    Predicate predicate,
+                    rmm::cuda_stream_view stream)
+{
+  auto const num_items = cuda::std::distance(begin, end);
+  if (num_items == 0) { return false; }
+
+  using offset_type = cub::detail::choose_offset_t<decltype(num_items)>;
+
+  auto result =
+    cudf::detail::device_scalar<offset_type>(stream, cudf::get_current_device_resource_ref());
+
+  size_t temp_storage_bytes = 0;
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(
+    nullptr, temp_storage_bytes, begin, result.data(), predicate, num_items, stream.value()));
+
+  rmm::device_buffer d_temp_storage(
+    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        begin,
+                                        result.data(),
+                                        predicate,
+                                        num_items,
+                                        stream.value()));
+
+  return result.value(stream) != static_cast<offset_type>(num_items);
+}
 
 /**
  * @brief Helper to reduce a device-accessible iterator using a binary operation
@@ -274,7 +319,8 @@ OutputType transform_reduce(InputIterator begin,
 template <typename TransformOp, typename InputIterator>
 bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
-  return transform_reduce(begin, end, op, true, cuda::std::logical_and<bool>{}, stream);
+  return not device_find_if(
+    begin, end, [op] __device__(auto const& val) { return not op(val); }, stream);
 }
 
 /**
@@ -295,7 +341,7 @@ bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_st
 template <typename TransformOp, typename InputIterator>
 bool any_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
-  return transform_reduce(begin, end, op, false, cuda::std::logical_or<bool>{}, stream);
+  return device_find_if(begin, end, op, stream);
 }
 
 /**

--- a/cpp/src/interop/to_arrow_host.cu
+++ b/cpp/src/interop/to_arrow_host.cu
@@ -7,6 +7,7 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/interop.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
@@ -433,18 +434,18 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
   auto d_offsets =
     cudf::detail::offsetalator_factory::make_input_iterator(col.offsets(), col.offset());
 
-  // count the number of long-ish strings -- ones that cannot be inlined
-  auto const num_longer_strings = thrust::count_if(
-    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+  // Check whether all strings are long-ish -- ones that cannot be inlined.
+  auto const all_strings_longer = cudf::detail::all_of(
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{col.size()},
     [d_offsets] __device__(auto idx) {
       return d_offsets[idx + 1] - d_offsets[idx] > NANOARROW_BINARY_VIEW_INLINE_SIZE;
-    });
+    },
+    stream);
 
   // gather all the long-ish strings into a single strings column
   auto [unused_col, longer_strings] = [&] {
-    if (num_longer_strings == col.size()) {
+    if (all_strings_longer) {
       // we can use the input column as is for the remainder of this function
       return std::pair{cudf::make_empty_column(cudf::type_id::STRING), col};
     }

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_stream.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/cuda_memcpy.hpp>
@@ -44,7 +45,6 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
-#include <thrust/count.h>
 #include <thrust/host_vector.h>
 
 #include <algorithm>
@@ -996,13 +996,8 @@ table_with_metadata read_csv(cudf::io::datasource* source,
         auto const is_quoted = device_span<bool>(is_quoted_flags[str_col_idx]);
         auto* buffer         = &out_buffers[col_idx];
 
-        // Count how many rows were quoted to determine the fast path
-        auto const num_quoted = thrust::count(
-          rmm::exec_policy_nosync(col_stream, cudf::get_current_device_resource_ref()),
-          is_quoted.begin(),
-          is_quoted.end(),
-          true);
-        if (num_quoted == 0) {
+        auto const is_quoted_row = [] __device__(auto const flag) { return flag; };
+        if (cudf::detail::none_of(is_quoted.begin(), is_quoted.end(), is_quoted_row, col_stream)) {
           // Fast path: no rows were quoted, skip replacement entirely
           out_columns[col_idx] = make_column(*buffer, nullptr, std::nullopt, col_stream);
         } else {
@@ -1015,7 +1010,7 @@ table_with_metadata read_csv(cudf::io::datasource* source,
             -1,
             col_stream,
             mr);
-          if (std::cmp_equal(num_quoted, num_records)) {
+          if (cudf::detail::all_of(is_quoted.begin(), is_quoted.end(), is_quoted_row, col_stream)) {
             // Fast path: all rows were quoted, apply replacement to all
             out_columns[col_idx] = std::move(replaced_all_col);
           } else {

--- a/cpp/src/io/json/json_tree.cu
+++ b/cpp/src/io/json/json_tree.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -268,17 +268,12 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
   };
 
   // Look for ErrorBegin and report the point of error.
-  if (auto const error_count =
-        thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                      tokens.begin(),
-                      tokens.end(),
-                      token_t::ErrorBegin);
-      error_count > 0) {
-    auto const error_location =
-      thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                   tokens.begin(),
-                   tokens.end(),
-                   token_t::ErrorBegin);
+  auto const error_location =
+    thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 tokens.begin(),
+                 tokens.end(),
+                 token_t::ErrorBegin);
+  if (error_location != tokens.end()) {
     auto error_index = cudf::detail::make_host_vector<SymbolOffsetT>(
       device_span<SymbolOffsetT const>{
         token_indices.data() + cuda::std::distance(tokens.begin(), error_location), 1},

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -679,12 +679,12 @@ void detect_malformed_pages(device_span<PageInfo const> pages,
     }
 
     // all non-zero row counts must be the same
-    auto const chk =
-      cudf::detail::count_if(compacted_row_counts_begin,
-                             compacted_row_counts_end,
-                             row_counts_different{static_cast<size_type>(found_row_count)},
-                             stream);
-    CUDF_EXPECTS(chk == 0,
+    auto const row_counts_match =
+      cudf::detail::none_of(compacted_row_counts_begin,
+                            compacted_row_counts_end,
+                            row_counts_different{static_cast<size_type>(found_row_count)},
+                            stream);
+    CUDF_EXPECTS(row_counts_match,
                  "Encountered malformed parquet page data (row count mismatch in page data)");
   }
 }


### PR DESCRIPTION
## Description
Contributes to #22703.

This updates IO-adjacent boolean existence/allness checks to use `find_if`-backed boolean reductions instead of computing counts when only boolean semantics are needed.

Changed call sites:
- JSON tree construction: remove a redundant `thrust::count` before `thrust::find` on the `ErrorBegin` error path.
- Parquet chunking validation: replace `count_if(...) == 0` with `cudf::detail::none_of(...)` for nonzero row-count mismatch detection.
- Arrow host string-view export: replace `count_if(...) == col.size()` with `cudf::detail::all_of(...)` for the all-long-strings fast path.
- CSV reader quote handling: replace `thrust::count(..., true)` with `none_of` / `all_of` checks for the no-quoted-rows and all-quoted-rows fast paths.

This draft PR is stacked on #23044, so it currently includes the central `any_of` / `all_of` DeviceFind helper commit. The IO-specific commit is `1743e6c545eddd192a0f9dc07a35df2ff8128f43`; this can be rebased after #23044 lands.

Validation:
- `build-cudf-cpp`
- `test-cudf-cpp -j10` (119/119 passed)

Benchmark comparison was collected in the `rapids-dev cuda13.3-conda` devcontainer on an NVIDIA RTX 6000 Ada Generation. The baseline is `edc3696e97682a06c5cf592d7d3d142f18444e17`, the branch point from `upstream/main` when the worktree was created; the branch result is `1743e6c545eddd192a0f9dc07a35df2ff8128f43`.

Only benchmarks that exercise changed source paths were run and reported:
- `CSV_READER_NVBENCH / csv_read_data_type` with `data_type=STRING`, `io=DEVICE_BUFFER` exercises the no-quoted-rows CSV fast path.
- `PARQUET_READER_CHUNKS_NVBENCH / parquet_read_subrowgroup_chunks` with `T=STRING` exercises Parquet chunk/page validation.

The JSON change is only for invalid-input error reporting, and there is no existing NVBench case for that path. I also did not find an existing `to_arrow_host_stringview` NVBench case for the Arrow string-view export path, so no unrelated `to_arrow_host` benchmark is reported.

NVBench comparison threshold was 5%; no benchmark configuration met or exceeded that reporting threshold.

| Benchmark | Configuration | main GPU time | branch GPU time | diff | Notes |
| --- | --- | ---: | ---: | ---: | --- |
| `csv_read_data_type` | `STRING`, `DEVICE_BUFFER` | 43.726 ms | 45.842 ms | +4.84% | below threshold; noisy (`~22%`) |
| `parquet_read_subrowgroup_chunks` | `run_length=1` | 42.330 ms | 42.415 ms | +0.20% | below threshold |
| `parquet_read_subrowgroup_chunks` | `run_length=32` | 35.414 ms | 35.772 ms | +1.01% | below threshold |

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
