### PR TITLE
[codex] Use boolean reductions in core call sites

### DIFF
--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,12 +12,57 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/device/device_find.cuh>
 #include <cub/device/device_reduce.cuh>
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/stream_ref>
 
 namespace cudf::detail {
+
+/**
+ * @brief Check if a predicate is true for any element in a device-accessible range using
+ * `cub::DeviceFind::FindIf`
+ *
+ * @tparam Predicate **[inferred]** Type of the unary predicate
+ * @tparam InputIterator **[inferred]** Type of device-accessible input iterator
+ *
+ * @param begin Device-accessible iterator to start of input values
+ * @param end Device-accessible iterator to end of input values
+ * @param predicate Predicate operator to apply to each element
+ * @param stream CUDA stream to use
+ * @return true if the predicate is true for any element, false otherwise
+ */
+template <typename Predicate, typename InputIterator>
+bool device_find_if(InputIterator begin,
+                    InputIterator end,
+                    Predicate predicate,
+                    rmm::cuda_stream_view stream)
+{
+  auto const num_items = cuda::std::distance(begin, end);
+  if (num_items == 0) { return false; }
+
+  using offset_type = cub::detail::choose_offset_t<decltype(num_items)>;
+
+  auto result =
+    cudf::detail::device_scalar<offset_type>(stream, cudf::get_current_device_resource_ref());
+
+  size_t temp_storage_bytes = 0;
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(
+    nullptr, temp_storage_bytes, begin, result.data(), predicate, num_items, stream.value()));
+
+  rmm::device_buffer d_temp_storage(
+    temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
+  CUDF_CUDA_TRY(cub::DeviceFind::FindIf(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        begin,
+                                        result.data(),
+                                        predicate,
+                                        num_items,
+                                        stream.value()));
+
+  return result.value(stream) != static_cast<offset_type>(num_items);
+}
 
 /**
  * @brief Helper to reduce a device-accessible iterator using a binary operation
@@ -274,7 +319,8 @@ OutputType transform_reduce(InputIterator begin,
 template <typename TransformOp, typename InputIterator>
 bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
-  return transform_reduce(begin, end, op, true, cuda::std::logical_and<bool>{}, stream);
+  return not device_find_if(
+    begin, end, [op] __device__(auto const& val) { return not op(val); }, stream);
 }
 
 /**
@@ -295,7 +341,7 @@ bool all_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_st
 template <typename TransformOp, typename InputIterator>
 bool any_of(InputIterator begin, InputIterator end, TransformOp op, rmm::cuda_stream_view stream)
 {
-  return transform_reduce(begin, end, op, false, cuda::std::logical_or<bool>{}, stream);
+  return device_find_if(begin, end, op, stream);
 }
 
 /**

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf/copying.hpp>
@@ -45,7 +45,7 @@ bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_vie
 
   auto const row_begin = cuda::counting_iterator<cudf::size_type>{0};
   auto const row_end   = row_begin + input.size();
-  return cudf::detail::count_if(row_begin, row_end, is_dirty_row, stream) > 0;
+  return cudf::detail::any_of(row_begin, row_end, is_dirty_row, stream);
 }
 
 }  // namespace

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -350,11 +350,11 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
   // output is a list column with each row containing percentiles.size() percentile values
   auto offsets = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, input.size() + 1, mask_state::UNALLOCATED, stream, mr);
-  auto const all_empty_rows = cudf::detail::count_if(
-                                detail::size_begin(input),
-                                detail::size_begin(input) + input.size(),
-                                [] __device__(auto const x) { return x == 0; },
-                                stream) == static_cast<std::size_t>(input.size());
+  auto const all_empty_rows = cudf::detail::all_of(
+    detail::size_begin(input),
+    detail::size_begin(input) + input.size(),
+    [] __device__(auto const x) { return x == 0; },
+    stream);
   auto row_size_iter = cuda::make_constant_iterator(all_empty_rows ? 0 : percentiles.size());
   thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          row_size_iter,

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,7 @@
 #include "detail/rolling_udf.cuh"
 #include "detail/rolling_utils.cuh"
 
+#include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/groupby/sort_helper.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
@@ -24,7 +25,6 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/functional>
-#include <cuda/std/functional>
 
 #include <concepts>
 
@@ -384,12 +384,11 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
           return nulls_per_group[i] < (d_offsets[i + 1] - d_offsets[i]) &&
                  d_orderby.is_null_nocheck(d_offsets[i]);
         }));
-    auto is_before =
-      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                     it,
-                     it + offsets.size() - 1,
-                     false,
-                     cuda::std::logical_or<>{});
+    auto is_before = cudf::detail::any_of(
+      it,
+      it + offsets.size() - 1,
+      [] __device__(bool has_boundary_null) { return has_boundary_null; },
+      stream);
     return is_before ? null_order::BEFORE : null_order::AFTER;
   } else {
     // Sort order is DESCENDING
@@ -406,12 +405,11 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
           return nulls_per_group[i] < (d_offsets[i + 1] - d_offsets[i]) &&
                  d_orderby.is_null_nocheck(d_offsets[i + 1] - 1);
         }));
-    auto is_before =
-      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                     it,
-                     it + offsets.size() - 1,
-                     false,
-                     cuda::std::logical_or<>{});
+    auto is_before = cudf::detail::any_of(
+      it,
+      it + offsets.size() - 1,
+      [] __device__(bool has_boundary_null) { return has_boundary_null; },
+      stream);
     return is_before ? null_order::BEFORE : null_order::AFTER;
   }
 }

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -1,8 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/row_operator/lexicographic.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
@@ -17,7 +18,6 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
-#include <thrust/count.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 
@@ -47,10 +47,8 @@ bool is_sorted(cudf::table_view const& in,
                         return (idx == 0) || device_comparator(idx - 1, idx);
                       });
 
-    return thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                         d_results.begin(),
-                         d_results.end(),
-                         false) == 0;
+    return cudf::detail::all_of(
+      d_results.begin(), d_results.end(), [] __device__(bool result) { return result; }, stream);
   } else {
     auto const device_comparator = comparator.less<false>(has_nested_nulls(in));
 

--- a/cpp/src/table/table_equal.cu
+++ b/cpp/src/table/table_equal.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,6 @@
 
 #include <cub/device/device_transform.cuh>
 #include <cuda/iterator>
-#include <cuda/std/functional>
 
 namespace cudf {
 namespace detail {
@@ -44,8 +43,8 @@ template <bool has_nested_columns>
       return rows_equal(detail::row::lhs_index_type{i}, detail::row::rhs_index_type{i});
     },
     stream.value()));
-  return cudf::detail::reduce(
-    eq_rows.begin(), eq_rows.end(), true, cuda::std::logical_and<bool>{}, stream);
+  return cudf::detail::all_of(
+    eq_rows.begin(), eq_rows.end(), [] __device__(bool row_equal) { return row_equal; }, stream);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Related to #22703.

This is stacked on #23044. Because GitHub compares this branch against `main`, the PR diff includes the central `DeviceFind` helper commit until #23044 lands. The core-specific commit is `8fcf0e24c18` (`Use boolean reductions in core call sites`).

This PR updates the remaining high-confidence non-IO, non-search call sites from #22703 to use boolean existence/all reductions instead of computing counts or full boolean reductions when the exact count is not needed:

- `is_sorted` nested-column path uses `cudf::detail::all_of` over the materialized comparison results.
- `purge_nonempty_nulls` uses `cudf::detail::any_of` for dirty null-row detection.
- `tdigest::percentile_approx` uses `cudf::detail::all_of` for the all-empty-row check.
- `tables_equal` uses `cudf::detail::all_of` over row equality results.
- grouped rolling null-order deduction uses `cudf::detail::any_of` instead of `thrust::reduce(..., logical_or)`.

Validation:

- `build-all -j0` completed in the `rapids-dev cuda13.3-conda` devcontainer when the worktree was initialized.
- `build-cudf-cpp` passed on this branch after hooks updated formatting/copyright.
- `test-cudf-cpp -j10` passed: 119/119 tests.

Benchmark comparison against branch-point `upstream/main` (`edc3696e976`) on NVIDIA RTX 6000 Ada Generation, device 0. Target SHA: `8fcf0e24c186`.

Only `ROLLING_NVBENCH::range_grouped_rolling_sum` is reported here because it is the existing measured NVBench path that directly exercises a changed call site (`deduce_null_order`) with grouped order-by nulls. No existing measured NVBench case was reported for the sort, copying, `tdigest::percentile_approx`, or table-equality call sites: sort/table equality have no direct benchmark in this build, tdigest benchmarks cover merge/reduce rather than `percentile_approx`, and copying only reaches `purge_nonempty_nulls` during benchmark input generation.

Command:

```bash
ROLLING_NVBENCH -d 0 -b range_grouped_rolling_sum   -a "num_rows[pow2]=[14,22,24]"   -a preceding_range=100   -a following_range=100   -a has_nulls=1   -a "cardinality=[10,1000000]"
```

| num_rows | cardinality | main GPU | target GPU | diff | noise main/target | status | main peak mem | target peak mem |
|---:|---:|---:|---:|---:|---:|---|---:|---:|
| 2^14 | 10 | 166.338 us | 172.366 us | +3.62% | 2.92% / 3.30% | same / below 5% | 320.053 KiB | 320.053 KiB |
| 2^22 | 10 | 517.282 us | 522.809 us | +1.07% | 0.66% / 0.75% | same / below 5% | 80.000 MiB | 80.000 MiB |
| 2^24 | 10 | 2.004 ms | 2.017 ms | +0.62% | 0.76% / 0.68% | same / below 5% | 320.000 MiB | 320.000 MiB |
| 2^14 | 1000000 | 167.294 us | 177.796 us | +6.28% | 2.57% / 3.40% | SLOW | 384.014 KiB | 384.014 KiB |
| 2^22 | 1000000 | 870.694 us | 886.009 us | +1.76% | 0.43% / 0.55% | same / below 5% | 82.042 MiB | 82.042 MiB |
| 2^24 | 1000000 | 2.246 ms | 2.266 ms | +0.89% | 0.24% / 0.24% | same / below 5% | 323.444 MiB | 323.444 MiB |

Notable change: `range_grouped_rolling_sum` at `num_rows=2^14`, `cardinality=1000000` slowed from 167.294 us to 177.796 us (+6.28%, noise 2.57% / 3.40%). Larger measured configs were below the 5% reporting threshold.

Benchmark artifacts are in `/tmp/cudf-findif-22703-artifacts/core/20260630_200129` in the devcontainer.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
