### PR TITLE
Add braces to prefetch_noexcept location var to fix clang-tidy reported error

### DIFF
--- a/cpp/src/utilities/prefetch.cpp
+++ b/cpp/src/utilities/prefetch.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -51,7 +51,7 @@ cudaError_t prefetch_noexcept(void const* ptr,
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
   cudaMemLocation location{
     (device_id.value() == cudaCpuDeviceId) ? cudaMemLocationTypeHost : cudaMemLocationTypeDevice,
-    device_id.value()};
+    {device_id.value()}};
   constexpr int flags = 0;
   auto result         = cudaMemPrefetchAsync(ptr, size, location, flags, stream.value());
 #else


### PR DESCRIPTION
## Description
Fixes a clang-tidy reported error:
```
cpp/src/utilities/prefetch.cpp:54:5: error: suggest braces around initialization of subobject [clang-diagnostic-missing-braces,-warnings-as-errors]
   54 |     device_id.value()};
      |     ^~~~~~~~~~~~~~~~~
      |     {                }
```
Reference: https://github.com/rapidsai/cudf/actions/runs/28523775732/job/84555399492?pr=23031#step:13:1460

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
