### PR TITLE
Plumb statistics object into ProgressThread for all engines

### DIFF
--- a/python/cudf_polars/cudf_polars/engine/core.py
+++ b/python/cudf_polars/cudf_polars/engine/core.py
@@ -65,6 +65,35 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+def reset_statistics_from_options(
+    statistics: Statistics, options: Options
+) -> Statistics:
+    """
+    Reset the enabled state of a statistics object from options.
+
+    Parameters
+    ----------
+    statistics
+        Statistics to reset.
+    options
+        Options providing new enabled setting.
+
+    Returns
+    -------
+    Statistics
+        Reset statistics object.
+
+    Notes
+    -----
+    Does not clear the statistics.
+    """
+    if Statistics.from_options(options).enabled:
+        statistics.enable()
+    else:
+        statistics.disable()
+    return statistics
+
+
 def resolve_rapidsmpf_options(rapidsmpf_options: Options | None) -> Options:
     """
     Resolve ``rapidsmpf_options`` and apply cross-frontend defaults.

--- a/python/cudf_polars/cudf_polars/engine/dask.py
+++ b/python/cudf_polars/cudf_polars/engine/dask.py
@@ -35,6 +35,7 @@ from cudf_polars.engine.core import (
     StreamingEngine,
     check_reserved_keys,
     evaluate_on_rank,
+    reset_statistics_from_options,
     resolve_rapidsmpf_options,
 )
 from cudf_polars.engine.hardware_binding import (
@@ -119,6 +120,7 @@ class _WorkerContext:
     base_mr: rmm.mr.DeviceMemoryResource | None
     quent_logger: cudf_polars.quent._logging.QuentLogger | None
     quent_worker: cudf_polars.quent._types.Worker
+    statistics: Statistics
     mr: RmmResourceAdaptor | None = None  # set after `Context` is built (below).
 
 
@@ -173,12 +175,13 @@ def _setup_root(
     bind_to_gpu(hardware_binding)
     memory_resource_config = memory_resource_config or MemoryResourceConfig.default()
     base_mr = memory_resource_config.create_memory_resource()
+    statistics = Statistics.from_options(options)
     comm = new_communicator(
         nranks=nranks,
         ucx_worker=None,
         root_ucxx_address=None,
         options=options,
-        progress_thread=ProgressThread(),
+        progress_thread=ProgressThread(statistics),
     )
 
     quent_worker = cudf_polars.quent._types.Worker(
@@ -204,6 +207,7 @@ def _setup_root(
             base_mr=base_mr,
             quent_worker=quent_worker,
             quent_logger=quent_logger,
+            statistics=statistics,
         ),
     )
     return get_root_ucxx_address(comm)
@@ -272,12 +276,13 @@ def _setup_worker(
         )
         base_mr = memory_resource_config.create_memory_resource()
         root_addr = ucx_api.UCXAddress.create_from_buffer(root_ucxx_address_as_bytes)
+        statistics = Statistics.from_options(options)
         comm = new_communicator(
             nranks=nranks,
             ucx_worker=None,
             root_ucxx_address=root_addr,
             options=options,
-            progress_thread=ProgressThread(),
+            progress_thread=ProgressThread(statistics),
         )
     else:
         # Root worker: comm and mr were created in _setup_root.
@@ -285,6 +290,7 @@ def _setup_worker(
         assert mp_ctx.comm is not None
         base_mr = mp_ctx.base_mr
         comm = mp_ctx.comm
+        statistics = mp_ctx.statistics
 
     barrier(comm)
     worker_id = worker_ids[comm.rank]
@@ -293,7 +299,6 @@ def _setup_worker(
         engine=cudf_polars.quent.Engine(id=engine_id),
         instance_name=f"rank-{comm.rank}",
     )
-    statistics = Statistics.from_options(options)
     ctx = Context.from_options(comm.logger, base_mr, options, statistics)
     # Set the current RMM device resource so all temporary allocations
     # in libcudf also use the same memory resource.
@@ -319,6 +324,7 @@ def _setup_worker(
         mr=mr,
         quent_worker=quent_worker,
         quent_logger=quent_logger,
+        statistics=statistics,
     )
     setattr(dask_worker, attr, mp_ctx)
     if mp_ctx.quent_logger is not None:
@@ -405,9 +411,10 @@ def _reset_worker(
     mp_ctx.ctx.shutdown()
     mp_ctx.ctx = None
     options = Options.deserialize(rapidsmpf_options_as_bytes)
-    statistics = Statistics.from_options(options)
+    mp_ctx.statistics = reset_statistics_from_options(mp_ctx.statistics, options)
+    mp_ctx.statistics.clear()
     mp_ctx.ctx = Context.from_options(
-        mp_ctx.comm.logger, mp_ctx.base_mr, options, statistics
+        mp_ctx.comm.logger, mp_ctx.base_mr, options, mp_ctx.statistics
     )
     mp_ctx.mr = mp_ctx.ctx.br().device_mr_adaptor()
     rmm.mr.set_current_device_resource(mp_ctx.mr)
@@ -438,7 +445,7 @@ def _get_statistics(
     mp_ctx: _WorkerContext = getattr(dask_worker, f"_cudf_polars_mp_context_{uid}")
     assert mp_ctx.comm is not None
     assert mp_ctx.ctx is not None
-    stats = mp_ctx.ctx.statistics()
+    stats = mp_ctx.statistics
     if clear:
         # Return a deep copy so it survives the in-place clear of `stats`.
         detached = stats.copy()

--- a/python/cudf_polars/cudf_polars/engine/default_singleton_engine.py
+++ b/python/cudf_polars/cudf_polars/engine/default_singleton_engine.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Single-GPU, single-instance specialization of :class:`~cudf_polars.engine.spmd.SPMDEngine`."""
 
@@ -15,6 +15,7 @@ from rapidsmpf.communicator.single import (
     new_communicator as single_communicator,
 )
 from rapidsmpf.progress_thread import ProgressThread
+from rapidsmpf.statistics import Statistics
 
 from cudf_polars.engine.core import (
     resolve_rapidsmpf_options,
@@ -141,9 +142,11 @@ def _build_engine() -> DefaultSingletonEngine:
     """
     with _state.lock:
         try:
+            options = resolve_rapidsmpf_options(None)
+            statistics = Statistics.from_options(options)
             comm = single_communicator(
-                progress_thread=ProgressThread(),
-                options=resolve_rapidsmpf_options(None),
+                progress_thread=ProgressThread(statistics),
+                options=options,
             )
             instance = DefaultSingletonEngine(comm=comm)
             assert instance.nranks == 1

--- a/python/cudf_polars/cudf_polars/engine/ray.py
+++ b/python/cudf_polars/cudf_polars/engine/ray.py
@@ -33,6 +33,7 @@ from cudf_polars.engine.core import (
     StreamingEngine,
     check_reserved_keys,
     evaluate_on_rank,
+    reset_statistics_from_options,
     resolve_rapidsmpf_options,
 )
 from cudf_polars.engine.hardware_binding import (
@@ -251,7 +252,7 @@ class RankActor:
             ucx_worker=None,
             root_ucxx_address=None,
             options=self._rapidsmpf_options,
-            progress_thread=ProgressThread(),
+            progress_thread=ProgressThread(self._rapidsmpf_statistics),
         )
         return get_root_ucxx_address(self._comm)
 
@@ -278,9 +279,10 @@ class RankActor:
                 ucx_worker=None,
                 root_ucxx_address=root_ucxx_address,
                 options=self._rapidsmpf_options,
-                progress_thread=ProgressThread(),
+                progress_thread=ProgressThread(self._rapidsmpf_statistics),
             )
         barrier(self._comm)
+        assert self._base_mr is not None
         self._ctx = Context.from_options(
             self._comm.logger,
             self._base_mr,
@@ -316,7 +318,10 @@ class RankActor:
         self._ctx.shutdown()
         self._ctx = None
         self._rapidsmpf_options = Options.deserialize(rapidsmpf_options_as_bytes)
-        self._rapidsmpf_statistics = Statistics.from_options(self._rapidsmpf_options)
+        self._rapidsmpf_statistics = reset_statistics_from_options(
+            self._rapidsmpf_statistics, self._rapidsmpf_options
+        )
+        self._rapidsmpf_statistics.clear()
         assert self._base_mr is not None
         self._ctx = Context.from_options(
             self._comm.logger,

--- a/python/cudf_polars/cudf_polars/engine/spmd.py
+++ b/python/cudf_polars/cudf_polars/engine/spmd.py
@@ -37,6 +37,7 @@ from cudf_polars.engine.core import (
     all_gather_host_data,
     check_reserved_keys,
     evaluate_on_rank,
+    reset_statistics_from_options,
     resolve_rapidsmpf_options,
 )
 from cudf_polars.engine.hardware_binding import (
@@ -368,6 +369,10 @@ class SPMDEngine(StreamingEngine):
     binding is skipped under ``rrun`` (which already performs its own binding),
     see ``HardwareBindingPolicy.skip_under_rrun``.
 
+    If a bootstrapped communicator is provided, the attached statistics
+    object is used for all statistics logging, and enabled/disabled
+    according to any options provided in ``rapidsmpf_options``.
+
     Examples
     --------
     Context-manager style (recommended for scripts):
@@ -416,17 +421,22 @@ class SPMDEngine(StreamingEngine):
         )
         base_mr = mr_config.create_memory_resource()
         if comm is None:
+            statistics = Statistics.from_options(self.rapidsmpf_options)
             if bootstrap.is_running_with_rrun():
                 comm = bootstrap.create_ucxx_comm(
-                    progress_thread=ProgressThread(),
+                    progress_thread=ProgressThread(statistics),
                     type=bootstrap.BackendType.AUTO,
                     options=self.rapidsmpf_options,
                 )
             else:
                 comm = single_communicator(
-                    progress_thread=ProgressThread(),
+                    progress_thread=ProgressThread(statistics),
                     options=self.rapidsmpf_options,
                 )
+        else:
+            statistics = reset_statistics_from_options(
+                comm.progress_thread.statistics, self.rapidsmpf_options
+            )
         # else: caller-provided comm; the caller retains ownership
 
         self._base_mr: rmm.mr.DeviceMemoryResource = base_mr
@@ -442,11 +452,6 @@ class SPMDEngine(StreamingEngine):
         try:
             # Register `_cleanup_ctx`, which shuts down whatever `self._ctx` points
             # to at engine shutdown time, i.e. the `Context` from the latest reset.
-            if self.rapidsmpf_options is not None:
-                statistics = Statistics.from_options(self.rapidsmpf_options)
-            else:
-                statistics = None
-
             self._ctx = Context.from_options(
                 comm.logger, base_mr, self.rapidsmpf_options, statistics
             )
@@ -596,10 +601,10 @@ class SPMDEngine(StreamingEngine):
         # resource is kept alive across resets, see :meth:`_cleanup_ctx`.
         self._ctx.shutdown()
 
-        if rapidsmpf_options is not None:
-            statistics = Statistics.from_options(rapidsmpf_options)
-        else:
-            statistics = None
+        statistics = reset_statistics_from_options(
+            self._comm.progress_thread.statistics, rapidsmpf_options
+        )
+        statistics.clear()
 
         self._ctx = Context.from_options(
             self._comm.logger, self._base_mr, rapidsmpf_options, statistics

--- a/python/cudf_polars/tests/streaming/test_statistics.py
+++ b/python/cudf_polars/tests/streaming/test_statistics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for ``gather_statistics`` / ``global_statistics`` on streaming engines."""
 
@@ -54,4 +54,7 @@ def test_statistics(engine: StreamingEngine) -> None:
     assert len(stats) == engine.nranks
     for s in stats:
         assert s.enabled
-        assert s.list_stat_names() == []
+        # The allgather of the statistics can return locally on a single
+        # rank and clear the stats before the allgather event loop is
+        # removed. So we might see an event loop stat, but no other.
+        assert s.list_stat_names() == [] or s.list_stat_names() == ["event-loop-total"]


### PR DESCRIPTION
## Description
We need this so that the communicators that we build have an active statistics object for keeping tack of communcation volume.

Previously we never noticed this because the only communication volume statistics we tracked were from the Shuffler that got its statistics from the buffer resource. However, it makes more sense to use the communicator since (for example) the allreduce implementation doesn't allocate and therefore doesn't have a buffer resource.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
