### PR TITLE
WIP: Split cudf-polars tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,10 @@ jobs:
       - wheel-build-cudf
       - wheel-tests-cudf
       - wheel-build-cudf-polars
-      - wheel-tests-cudf-polars
+      - wheel-tests-cudf-polars-in-memory
+      - wheel-tests-cudf-polars-spmd
+      - wheel-tests-cudf-polars-dask
+      - wheel-tests-cudf-polars-ray
       - cudf-polars-polars-tests
       - wheel-build-dask-cudf
       - wheel-tests-dask-cudf
@@ -663,7 +666,7 @@ jobs:
       package-name: cudf_polars
       package-type: python
       pure-wheel: true
-  wheel-tests-cudf-polars:
+  wheel-tests-cudf-polars-in-memory:
     needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
     permissions:
       actions: read
@@ -679,7 +682,58 @@ jobs:
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       build_type: pull-request
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      script: "env POLARS_VERSIONS=endpoints ci/test_wheel_cudf_polars.sh"
+      script: "env POLARS_VERSIONS=endpoints CUDF_POLARS_ENGINE=in-memory ci/test_wheel_cudf_polars.sh"
+  wheel-tests-cudf-polars-spmd:
+    needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
+    with:
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      build_type: pull-request
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      script: "env POLARS_VERSIONS=endpoints CUDF_POLARS_ENGINE=spmd ci/test_wheel_cudf_polars.sh"
+  wheel-tests-cudf-polars-dask:
+    needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
+    with:
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      build_type: pull-request
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      script: "env POLARS_VERSIONS=endpoints CUDF_POLARS_ENGINE=dask ci/test_wheel_cudf_polars.sh"
+  wheel-tests-cudf-polars-ray:
+    needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_nor_dask_cudf
+    with:
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      build_type: pull-request
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      script: "env POLARS_VERSIONS=endpoints CUDF_POLARS_ENGINE=ray ci/test_wheel_cudf_polars.sh"
   cudf-polars-polars-tests:
     needs: [wheel-build-cudf-polars, wheel-build-cudf-streaming, changed-files]
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -255,7 +255,7 @@ jobs:
       continue-on-error: true
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: "ci/test_cuml_compat.sh"
-  wheel-tests-cudf-polars:
+  wheel-tests-cudf-polars-in-memory:
     permissions:
       actions: read
       contents: read
@@ -270,7 +270,55 @@ jobs:
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-      script: "ci/test_wheel_cudf_polars.sh"
+      script: "env CUDF_POLARS_ENGINE=in-memory ci/test_wheel_cudf_polars.sh"
+  wheel-tests-cudf-polars-spmd:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    with:
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: "env CUDF_POLARS_ENGINE=spmd ci/test_wheel_cudf_polars.sh"
+  wheel-tests-cudf-polars-dask:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    with:
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: "env CUDF_POLARS_ENGINE=dask ci/test_wheel_cudf_polars.sh"
+  wheel-tests-cudf-polars-ray:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    with:
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: "env CUDF_POLARS_ENGINE=ray ci/test_wheel_cudf_polars.sh"
   cudf-polars-polars-tests:
     permissions:
       actions: read

--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -8,4 +8,6 @@ set -euo pipefail
 # Support invoking run_cudf_polars_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 
+# All CLI args are forwarded to pytest, including optional flags like
+# --cudf-polars-engine=<engine>.
 python -m pytest --cache-clear "$@" tests

--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -42,6 +42,11 @@ timeout 30m ./ci/run_custreamz_pytests.sh \
   --cov-report=term
 
 rapids-logger "pytest cudf-polars"
+cudf_polars_engine_args=()
+if [[ -n "${CUDF_POLARS_ENGINE:-}" ]]; then
+  cudf_polars_engine_args+=("--cudf-polars-engine=${CUDF_POLARS_ENGINE}")
+fi
+
 ./ci/run_cudf_polars_pytests.sh \
   -vv \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars.xml" \
@@ -52,7 +57,8 @@ rapids-logger "pytest cudf-polars"
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-polars-coverage.xml" \
   --cov-report=term \
   --durations=10 --durations-min=10 \
-  -ra
+  -ra \
+  "${cudf_polars_engine_args[@]}"
 
 rapids-logger "pytest cudf_streaming"
 timeout 30m ./ci/run_cudf_streaming_pytests.sh \

--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -40,6 +40,11 @@ set +e
 PASSED=()
 FAILED=()
 
+cudf_polars_engine_args=()
+if [[ -n "${CUDF_POLARS_ENGINE:-}" ]]; then
+    cudf_polars_engine_args+=("--cudf-polars-engine=${CUDF_POLARS_ENGINE}")
+fi
+
 for version in "${VERSIONS[@]}"; do
     rapids-logger "Testing cudf_polars with polars ${version}.*"
 
@@ -96,6 +101,7 @@ for version in "${VERSIONS[@]}"; do
         --dist=worksteal \
         --durations 10 --durations-min 10 \
         -ra \
+        "${cudf_polars_engine_args[@]}" \
         --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars-${version}.xml"
 
     test_exitcode=$?

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -19,6 +19,8 @@ from cudf_polars.testing.engine_utils import (
 )
 from cudf_polars.utils.versions import POLARS_VERSION_LT_140, POLARS_VERSION_LT_141
 
+SUPPORTED_CUDF_POLARS_ENGINES = ("in-memory", "spmd", "dask", "ray")
+
 
 @pytest.fixture
 def xfail_decimal_sum_precision_polars_140(request: pytest.FixtureRequest) -> None:
@@ -341,6 +343,21 @@ def timeout_seconds() -> int:
     return 30
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add cudf-polars-specific pytest options."""
+    group = parser.getgroup("cudf-polars", "cudf-polars test options")
+    group.addoption(
+        "--cudf-polars-engine",
+        action="store",
+        default=None,
+        choices=SUPPORTED_CUDF_POLARS_ENGINES,
+        help=(
+            "Restrict cudf-polars engine fixture parametrization to one "
+            "backend. Defaults to running all configured engines."
+        ),
+    )
+
+
 def pytest_configure(config: pytest.Config):
     config.addinivalue_line(
         "markers",
@@ -362,6 +379,17 @@ def pytest_configure(config: pytest.Config):
     config.addinivalue_line("filterwarnings", "ignore::DeprecationWarning")
 
 
+def _filter_fixture_engines(
+    engines: list[str], requested_engine: str | None
+) -> list[str]:
+    """Filter fixture parameters to a selected backend, if requested."""
+    if requested_engine is None:
+        return engines
+    if requested_engine == "spmd":
+        return [engine for engine in engines if engine in ("spmd", "spmd-small")]
+    return [engine for engine in engines if engine == requested_engine]
+
+
 def pytest_generate_tests(metafunc: pytest.Metafunc):
     """Parametrize the shared engine fixture without cartesian products."""
     fixtures = set(metafunc.fixturenames)
@@ -375,11 +403,14 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
     elif "dask_engine" in fixtures:
         engines = ["dask"]
     elif "streaming_engine" in fixtures or "streaming_engine_factory" in fixtures:
-        engines = STREAMING_ENGINE_FIXTURE_PARAMS
+        engines = list(STREAMING_ENGINE_FIXTURE_PARAMS)
     elif "engine" in fixtures:
-        engines = ALL_ENGINE_FIXTURE_PARAMS
+        engines = list(ALL_ENGINE_FIXTURE_PARAMS)
     else:
         raise AssertionError("Unknown engine fixture")
+
+    requested_engine = metafunc.config.getoption("--cudf-polars-engine")
+    engines = _filter_fixture_engines(engines, requested_engine)
 
     metafunc.parametrize(
         "_engine_param",


### PR DESCRIPTION
## Description

To reduce the wall time of a cudf-polars CI job, we split the test suite by engine.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
