### PR TITLE
fix(deps): try to dynamically load nvrtc from wheel

### DIFF
--- a/python/libcudf/libcudf/load.py
+++ b/python/libcudf/libcudf/load.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -35,10 +35,12 @@ def _load_wheel_installation(soname: str):
 
 def load_library():
     """Dynamically load libcudf.so and its dependencies"""
+
     try:
         from cuda.pathfinder import load_nvidia_dynamic_lib
 
         load_nvidia_dynamic_lib("nvJitLink")
+        load_nvidia_dynamic_lib("nvrtc")
     except ModuleNotFoundError:
         pass
 


### PR DESCRIPTION
## Description

In #22171 I'm experimenting with a new lighter-weight image for wheel testing. The base image we currently use for `citestwheel` is based on `cuda-devel` images, which have a bunch of libraries and CTK stuff installed. We're switching to `cuda-base`, which is more akin to a driver-only install.

That PR flagged up an issue where `nvrtc` wasn't found during loading, despite us installing `nvidia-cuda-nvrtc-cu12` in the CI environment.

I played around with the image and dependencies locally, and have a fix that I think makes sense, which is using `cuda.pathfinder`.

Here's a run from #22171 before the `cuda.pathfinder` change proposed in this PR: <https://github.com/rapidsai/cudf/actions/runs/28596669057/job/84800276604>

and after: <https://github.com/rapidsai/cudf/actions/runs/28602110769/job/84819200638?pr=22171>

xref https://github.com/rapidsai/build-planning/issues/143

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
