### PR TITLE
fix(pylibcudf): accept inf/-inf as valid FLOAT32 scalar values

### DIFF
--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from cpython cimport bool as py_bool
 from cython cimport no_gc_clear
+from libc.math cimport isinf
 from libc.stdint cimport (
     int8_t,
     int16_t,
@@ -425,7 +426,7 @@ def _(
     cdef type_id tid = c_dtype.id()
 
     if tid == type_id.FLOAT32:
-        if abs(py_val) > numeric_limits[float].max():
+        if not isinf(py_val) and abs(py_val) > numeric_limits[float].max():
             raise OverflowError(f"{py_val} out of range for FLOAT32 scalar")
         c_obj = make_numeric_scalar(c_dtype.c_obj, _cs, mr.get_mr())
         (<numeric_scalar[float]*>c_obj.get()).set_value(py_val, _cs)

--- a/python/pylibcudf/tests/test_scalar.py
+++ b/python/pylibcudf/tests/test_scalar.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import datetime
 import decimal
@@ -88,6 +88,10 @@ def test_to_py(py_scalar):
         (1, TypeId.DURATION_SECONDS),
         (1.0, TypeId.FLOAT32),
         (1.5, TypeId.FLOAT64),
+        (float("inf"), TypeId.FLOAT32),
+        (float("-inf"), TypeId.FLOAT32),
+        (float("inf"), TypeId.FLOAT64),
+        (float("-inf"), TypeId.FLOAT64),
         ("str", TypeId.STRING),
         (True, TypeId.BOOL8),
         (0, TypeId.BOOL8),


### PR DESCRIPTION
## Intent

Fix rapidsai/cudf#23094: pylibcudf.Scalar.from_py(float('inf'), DataType(TypeId.FLOAT32)) raised OverflowError instead of matching pyarrow's accept-inf behavior. Root cause: python/pylibcudf/pylibcudf/scalar.pyx's FLOAT32 branch of the float _from_py singledispatch handler compared abs(py_val) against numeric_limits[float].max(), and abs(inf) > max is True in Python, so infinities were wrongly rejected even though a C++ float represents infinity exactly. Fix: added 'from libc.math cimport isinf' and changed the overflow guard to 'if not isinf(py_val) and abs(py_val) > numeric_limits[float].max():' so infinities pass through while finite out-of-range values still raise OverflowError. NaN behavior is unchanged. Test: added 4 parametrize cases to the existing test_from_py_with_dtype test in python/pylibcudf/tests/test_scalar.py -- (inf, FLOAT32), (-inf, FLOAT32) as the actual failing-before/passing-after regression guard, plus (inf, FLOAT64) and (-inf, FLOAT64) for symmetry. Verified failing-before (OverflowError on both FLOAT32 cases) then passing-after by rebuilding the pylibcudf Cython scalar extension in isolation (a full pylibcudf build hit an unrelated pre-existing ABI break in io/experimental/hybrid_scan.cxx on origin/main HEAD, untouched by this diff). Full test_scalar.py: 118/118 pass. Full pylibcudf suite: 11212 passed, 1148 skipped, 1 unrelated pre-existing GPU OOM failure in test_column_from_array.py. pre-commit clean. Reviewed via a 3-agent fleet (quickreview, silent-failure-hunter, test-coverage) -- all APPROVE, zero blocking findings; the one should-fix raised (copyright header text change) was verified to be the repo's mandatory verify-copyright pre-commit hook auto-canonicalizing the SPDX header on any touched file, not a drive-by edit -- confirmed by reverting and re-running the hook, which rewrote it right back, so the hook's canonical output was kept. Smallest surgical diff: 2 files, 8 insertions, 3 deletions. DCO signed. Previous run failed at push because it targeted the upstream remote directly (403 permission denied) -- re-initialized the gate with --fork-url pointing at the fork remote (nethum529/cudf) so this run pushes to fork and opens a PR against rapidsai/cudf main. Do not merge.

## What Changed

- In `scalar.pyx`'s FLOAT32 branch of the float `_from_py` singledispatch handler, added an `isinf` check so `abs(py_val) > numeric_limits[float].max()` no longer flags infinities as overflow (infinity previously failed this comparison even though a C++ `float` represents it exactly).
- Finite out-of-range values still raise `OverflowError`; NaN handling is unchanged.
- Added `inf`/`-inf` regression cases to `test_from_py_with_dtype` in `test_scalar.py` for both FLOAT32 (the failing case) and FLOAT64 (for symmetry).

## Risk Assessment

✅ Low: Minimal, surgical fix (2 files, ~4 lines of real change) that adds a correct isinf() guard before the existing overflow comparison, with regression tests covering both FLOAT32/FLOAT64 and both signs of infinity; no other code paths are touched.

## Testing

Rebuilt only the `scalar.abi3.so` Cython extension target in isolation (ninja) at both the base and target commits in an existing dev checkout with a matching build cache, swapped each into the conda `cudf_dev` environment, and exercised the actual compiled binary: the base-commit build reproduced the exact reported OverflowError for FLOAT32 inf/-inf while FLOAT64 was unaffected, and the target-commit build returns inf/-inf correctly (matching pyarrow) while still rejecting finite out-of-range floats; the full 118-test test_scalar.py suite passes on the fixed build, and all external state (dev checkout, conda env .so, this worktree) was restored/left clean.

<details>
<summary>Evidence: Before/after end-to-end reproduction transcript</summary>

```text
Issue: rapidsai/cudf#23094 - pylibcudf.Scalar.from_py(float('inf'), DataType(TypeId.FLOAT32)) raised OverflowError.
Environment: conda env `cudf_dev` (Python 3.14.6, pylibcudf 26.8.0 built for this exact commit).
Verification method: isolated ninja rebuild of only the `scalar.abi3.so` Cython extension target
(`pylibcudf_scalar`) in a dev checkout at the same commit, swapped into the conda env site-packages,
so the *actual compiled binary* is exercised end-to-end (not a mock).

=== Reference: pyarrow's accept-inf behavior (the target behavior) ===
$ python -c "import pyarrow as pa; print(pa.scalar(float('inf'), type=pa.float32()))"
inf
$ python -c "import pyarrow as pa; print(pa.scalar(float('-inf'), type=pa.float32()))"
-inf

=== BEFORE FIX (scalar.pyx reverted to base commit 3652e808337c, rebuilt in isolation) ===
$ python -c "
import pylibcudf as plc
from pylibcudf.types import DataType, TypeId
s = plc.Scalar.from_py(float('inf'), DataType(TypeId.FLOAT32))
"
OverflowError: inf out of range for FLOAT32 scalar   <-- reproduces reported bug

$ python -m pytest python/pylibcudf/tests/test_scalar.py -k "test_from_py_with_dtype and (inf or -inf)" -v
FAILED test_from_py_with_dtype[inf-<type_id.FLOAT32: 9>]
FAILED test_from_py_with_dtype[-inf-<type_id.FLOAT32: 9>]
2 failed, 2 passed (FLOAT64 inf/-inf cases passed even before the fix, confirming the bug was
FLOAT32-specific, matching the root cause: abs(inf) > numeric_limits[float].max() in the FLOAT32 branch)

=== AFTER FIX (target commit 04625d8a671e, `if not isinf(py_val) and abs(py_val) > numeric_limits[float].max()`) ===
$ python -c "
import pylibcudf as plc
from pylibcudf.types import DataType, TypeId
print(plc.Scalar.from_py(float('inf'), DataType(TypeId.FLOAT32)).to_py())
print(plc.Scalar.from_py(float('-inf'), DataType(TypeId.FLOAT32)).to_py())
"
inf
-inf

Finite out-of-range values still correctly rejected (guard not broken):
$ python -c "
import pylibcudf as plc
from pylibcudf.types import DataType, TypeId
plc.Scalar.from_py(3.5e40, DataType(TypeId.FLOAT32))
"
OverflowError: 3.5e+40 out of range for FLOAT32 scalar

$ python -m pytest python/pylibcudf/tests/test_scalar.py -v
118 passed

Conclusion: the fix makes pylibcudf.Scalar.from_py match pyarrow's accept-inf behavior for FLOAT32
(and FLOAT64) while preserving the OverflowError for genuinely out-of-range finite floats.
Both the author's dev checkout and this worktree were left clean (git status) after verification;
the conda env's scalar.abi3.so was restored to the fixed build (md5 verified identical to the
state before this verification began).
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python -m pytest python/pylibcudf/tests/test_scalar.py -v` (118 passed) against pylibcudf built from the target commit</code>
- <code>`python -m pytest python/pylibcudf/tests/test_scalar.py -k &#34;test_from_py_with_dtype and (inf or -inf)&#34;` run against an isolated rebuild of scalar.abi3.so from the base commit (3652e808337c) — reproduced the exact reported bug: FLOAT32 inf/-inf FAILED with OverflowError, FLOAT64 inf/-inf passed</code>
- <code>Manual e2e repro: `plc.Scalar.from_py(float(&#39;inf&#39;), DataType(TypeId.FLOAT32))` — raised OverflowError on base-commit binary, returned `inf` on target-commit binary</code>
- `Manual e2e check that finite out-of-range floats (3.5e40) still raise OverflowError on FLOAT32 after the fix, confirming the guard wasn't broken`
- <code>Cross-checked pyarrow&#39;s own accept-inf behavior (`pa.scalar(float(&#39;inf&#39;), type=pa.float32())` -&gt; inf) as the target behavior being matched</code>
- <code>Restored the dev checkout (~/OpenSource/cudf-issue-23094) and conda env `cudf_dev` pylibcudf build back to the fixed state (md5-verified identical), confirmed `git status` clean in both that checkout and this worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
