### PR TITLE
Optimize `cudf::lists::sort_lists` for fixed-width and `STRING` types

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1003,6 +1003,7 @@ add_library(
   src/sort/is_sorted.cu
   src/sort/rank.cu
   src/sort/segmented_sort.cu
+  src/sort/segmented_sort_strings.cu
   src/sort/segmented_top_k.cu
   src/sort/sort.cu
   src/sort/sort_column.cu

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1003,6 +1003,7 @@ add_library(
   src/sort/is_sorted.cu
   src/sort/rank.cu
   src/sort/segmented_sort.cu
+  src/sort/segmented_sort_fixed_width.cu
   src/sort/segmented_sort_strings.cu
   src/sort/segmented_top_k.cu
   src/sort/sort.cu

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -184,6 +184,8 @@ ConfigureNVBench(
   sort/segmented_top_k.cpp
   sort/segmented_sort.cpp
   sort/sort.cpp
+  sort/sort_list_of_numbers.cpp
+  sort/sort_list_of_strings.cu
   sort/sort_lists.cpp
   sort/sort_strings.cpp
   sort/sort_structs.cpp

--- a/cpp/benchmarks/sort/sort_list_of_numbers.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_numbers.cpp
@@ -202,9 +202,9 @@ NVBENCH_BENCH_TYPES(
   // 4: tiny lists (tiered network/warp tiers); 32: the mid band where no-null routing splits by
   // type between CUB DeviceSegmentedSort and the tiered kernel; 256: past the packed-radix cutoff.
   .add_int64_axis("max_list_size", {4, 16, 32, 64, 128, 256})
-  // Null-bearing ascending / nulls-after cells route to the tiered kernel.
+  // The null-bearing case routes every supported type to the tiered kernel.
   .add_float64_axis("null_frequency", {0, 0.1})
-  // Only explicit ascending / nulls-after engages the fast paths; the rest measure base routing.
+  // The fast path folds (order, null_order) into its keys, so all four combinations exercise it.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});
 

--- a/cpp/benchmarks/sort/sort_list_of_numbers.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_numbers.cpp
@@ -190,8 +190,8 @@ void bench_sort_list_of_numbers(nvbench::state& state, nvbench::type_list<Type>)
 }
 
 // Chrono is omitted: its packed key is byte-identical to the int32/int64 rep it extracts to, so
-// those cells already measure it. decimal128 stays on the comparator fallback and needs its own
-// type-string mapping.
+// those cells already measure it. decimal128 stays on the comparator fallback at this stage and
+// needs its own type-string mapping.
 NVBENCH_DECLARE_TYPE_STRINGS(numeric::decimal128, "decimal128", "decimal128");
 
 NVBENCH_BENCH_TYPES(
@@ -199,13 +199,12 @@ NVBENCH_BENCH_TYPES(
   NVBENCH_TYPE_AXES(nvbench::type_list<std::int32_t, std::int64_t, float, double>))
   .set_name("sort_list_of_numbers")
   .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
-  // 4 and 32 keep no-null cells below the packed-radix average gate (100); 256 (average ~128)
-  // crosses it, routing eligible ascending / nulls-after cells to the packed radix.
+  // 4: tiny lists (tiered network/warp tiers); 32: the mid band the tiered kernel also claims;
+  // 256: past the packed-radix cutoff.
   .add_int64_axis("max_list_size", {4, 16, 32, 64, 128, 256})
-  // The null-bearing case routes eligible ascending / nulls-after cells to the packed radix.
+  // The null-bearing ascending / nulls-after cells route to the tiered kernel.
   .add_float64_axis("null_frequency", {0, 0.1})
-  // The packed-radix gate engages only for explicit ascending / nulls-after; the other combinations
-  // measure the base routing.
+  // The fast path engages only for ascending / nulls-after; the rest measure the base routing.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});
 

--- a/cpp/benchmarks/sort/sort_list_of_numbers.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_numbers.cpp
@@ -1,0 +1,222 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/memory_stats.hpp>
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/lists/sorting.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <nvbench/nvbench.cuh>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+
+// Copies a benchmark column's offsets (INT32 or INT64) to a pinned host int64 vector: `count + 1`
+// entries. The pinned vector makes later H2D copies sourced from it genuinely asynchronous. The
+// offsetalator's device-only iterators are unavailable in this host-only TU, so the width
+// dispatch stays explicit.
+static cudf::detail::host_vector<int64_t> offsets_to_host_int64(cudf::column_view const& offsets_cv,
+                                                                cudf::size_type count,
+                                                                rmm::cuda_stream_view stream)
+{
+  auto offsets =
+    cudf::detail::make_pinned_vector_async<int64_t>(static_cast<std::size_t>(count) + 1, stream);
+  if (offsets_cv.type().id() == cudf::type_id::INT64) {
+    auto const host_offsets = cudf::detail::make_pinned_vector<int64_t>(
+      cudf::device_span<int64_t const>{offsets_cv.data<int64_t>(),
+                                       static_cast<std::size_t>(count) + 1},
+      stream);
+    std::copy(host_offsets.begin(), host_offsets.end(), offsets.begin());
+  } else {
+    auto const host_offsets = cudf::detail::make_pinned_vector<cudf::size_type>(
+      cudf::device_span<cudf::size_type const>{offsets_cv.data<cudf::size_type>(),
+                                               static_cast<std::size_t>(count) + 1},
+      stream);
+    std::copy(host_offsets.begin(), host_offsets.end(), offsets.begin());
+  }
+  return offsets;
+}
+
+// The list generator forces its final offset to the child size, so the last row absorbs every
+// leftover element -- an artifact often far above `max_list_size`. The numeric gates average over
+// the whole column, so routing cannot flip on one row, but the trim (untimed) keeps the timed
+// input inside the declared [0, max_list_size] regime, matching the strings benchmark. Returns
+// nullptr when the last row already fits.
+static std::unique_ptr<cudf::column> trim_forced_last_row(cudf::column_view const& list_col,
+                                                          cudf::size_type max_list_size,
+                                                          rmm::cuda_stream_view stream)
+{
+  auto const mr       = cudf::get_current_device_resource_ref();
+  auto const lists    = cudf::lists_column_view{list_col};
+  auto const num_rows = lists.size();
+
+  auto const offsets_cv = lists.offsets();
+  auto const offsets    = offsets_to_host_int64(offsets_cv, num_rows, stream);
+  if (num_rows == 0 or offsets[num_rows] - offsets[num_rows - 1] <= max_list_size) {
+    return nullptr;
+  }
+
+  auto new_offsets          = offsets;
+  new_offsets[num_rows]     = new_offsets[num_rows - 1] + max_list_size;
+  auto const new_child_size = static_cast<cudf::size_type>(new_offsets[num_rows]);
+
+  // Rebuild offsets at the input's own width to keep the generator's offset type. Both staging
+  // buffers are pinned; `new_offsets` must outlive the trailing synchronize since the INT64
+  // branch's H2D copy reads it asynchronously, while the INT32 branch's buffer does not outlive
+  // this scope and so synchronizes immediately.
+  std::unique_ptr<cudf::column> offsets_col;
+  if (offsets_cv.type().id() == cudf::type_id::INT64) {
+    offsets_col = std::make_unique<cudf::column>(
+      cudf::data_type{cudf::type_id::INT64},
+      num_rows + 1,
+      rmm::device_buffer{new_offsets.data(), new_offsets.size() * sizeof(int64_t), stream, mr},
+      rmm::device_buffer{},
+      0);
+  } else {
+    auto new_offsets_i32 =
+      cudf::detail::make_pinned_vector_async<cudf::size_type>(new_offsets.size(), stream);
+    std::copy(new_offsets.begin(), new_offsets.end(), new_offsets_i32.begin());
+    offsets_col = std::make_unique<cudf::column>(
+      cudf::data_type{cudf::type_id::INT32},
+      num_rows + 1,
+      rmm::device_buffer{
+        new_offsets_i32.data(), new_offsets_i32.size() * sizeof(cudf::size_type), stream, mr},
+      rmm::device_buffer{},
+      0);
+    stream.synchronize();
+  }
+  auto new_leaf =
+    std::make_unique<cudf::column>(cudf::slice(lists.child(), {0, new_child_size})[0], stream, mr);
+  auto result = cudf::make_lists_column(num_rows,
+                                        std::move(offsets_col),
+                                        std::move(new_leaf),
+                                        list_col.null_count(),
+                                        cudf::copy_bitmask(list_col, stream, mr));
+  stream.synchronize();
+  return result;
+}
+
+// Benchmarks cudf::lists::sort_lists on LIST<numeric>, the operation Spark array_sort lowers to.
+// Axis values straddle the CUB fast-path gate; per-axis rationale at the registrations.
+template <typename Type>
+void bench_sort_list_of_numbers(nvbench::state& state, nvbench::type_list<Type>)
+{
+  auto const num_rows       = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const max_list_size  = static_cast<cudf::size_type>(state.get_int64("max_list_size"));
+  auto const null_frequency = state.get_float64("null_frequency");
+  auto const column_order =
+    state.get_string("order") == "DESC" ? cudf::order::DESCENDING : cudf::order::ASCENDING;
+  auto const null_precedence =
+    state.get_string("null_order") == "BEFORE" ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
+
+  // Skip states whose worst-case leaf count overflows int32 offsets.
+  if (static_cast<double>(num_rows) * max_list_size >
+      static_cast<double>(std::numeric_limits<cudf::size_type>::max())) {
+    state.skip("Skip benchmarks greater than size_type limit");
+    return;
+  }
+
+  // Nulls apply at both the list-row and leaf levels; cardinality 0 leaves distinct counts
+  // uncapped. null_frequency == 0 must pass std::nullopt: a literal null_probability(0.0) still
+  // samples per-element validity, and thrust's uniform_real<float> endpoint rounding injects stray
+  // nulls past ~2^24 leaf elements, routing the "no-null" cell through the has-nulls path.
+  auto const null_prob =
+    null_frequency > 0 ? std::optional<double>{null_frequency} : std::optional<double>{};
+  data_profile profile =
+    data_profile_builder()
+      .list_type(cudf::type_to_id<Type>())
+      .list_depth(1)
+      .distribution(cudf::type_id::LIST, distribution_id::UNIFORM, 0, max_list_size)
+      .null_probability(null_prob)
+      .cardinality(0);
+  // The bound type selects the set_distribution_params overload and must match the leaf type -- a
+  // mismatched call is a silent no-op.
+  if constexpr (cudf::is_floating_point<Type>()) {
+    profile.set_distribution_params(
+      cudf::type_to_id<Type>(), distribution_id::UNIFORM, 0., 1'000'000.);
+  } else if constexpr (cudf::is_fixed_point<Type>()) {
+    // dec_regime picks the leaf magnitude regime: u64 (< 2^32), key96 (within int64), twophase
+    // (past int64). __int128 bounds make >2^63 expressible.
+    auto const regime = state.get_string("dec_regime");
+    auto const hi     = regime == "twophase" ? (static_cast<__int128_t>(1) << 64)
+                        : regime == "key96"  ? (static_cast<__int128_t>(1) << 40)
+                                             : static_cast<__int128_t>(1'000'000);
+    profile.set_distribution_params(cudf::type_to_id<Type>(),
+                                    distribution_id::UNIFORM,
+                                    static_cast<__int128_t>(0),
+                                    hi,
+                                    numeric::scale_type{0});
+  } else {
+    profile.set_distribution_params(
+      cudf::type_to_id<Type>(), distribution_id::UNIFORM, 0, 1'000'000);
+  }
+
+  auto const table = create_random_table({cudf::type_id::LIST}, row_count{num_rows}, profile);
+
+  auto const stream = cudf::get_default_stream();
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+
+  auto const trimmed  = trim_forced_last_row(table->view().column(0), max_list_size, stream);
+  auto const base_col = trimmed ? trimmed->view() : table->view().column(0);
+  auto const input    = cudf::lists_column_view{base_col};
+  stream.synchronize();  // Ensure untimed setup completes before timing.
+
+  auto const mem_stats_logger = cudf::memory_stats_logger();
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
+    cudf::lists::sort_lists(
+      input, column_order, null_precedence, stream, cudf::get_current_device_resource_ref());
+  });
+
+  state.add_buffer_size(
+    mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
+}
+
+// Chrono is omitted: neither integral nor fixed-point, so it takes the same comparator sort the
+// float/double cells already measure. decimal128 skips the CUB path (its 128-bit width is
+// unsupported there) and needs its own type-string mapping.
+NVBENCH_DECLARE_TYPE_STRINGS(numeric::decimal128, "decimal128", "decimal128");
+
+NVBENCH_BENCH_TYPES(
+  bench_sort_list_of_numbers,
+  NVBENCH_TYPE_AXES(nvbench::type_list<std::int32_t, std::int64_t, float, double>))
+  .set_name("sort_list_of_numbers")
+  // Row counts measure scaling; on this grid they never change which path runs.
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  // 4, 32, 128: short lists (average < 100) on the CUB path; 256 (average ~128): past the gate at
+  // every row count here, so the comparator sort.
+  .add_int64_axis("max_list_size", {4, 16, 32, 64, 128, 256})
+  // Any null forces the comparator sort.
+  .add_float64_axis("null_frequency", {0, 0.1})
+  // The CUB path applies only order; the comparator sort applies both order and null_order.
+  .add_string_axis("order", {"ASC", "DESC"})
+  .add_string_axis("null_order", {"AFTER", "BEFORE"});
+
+// decimal128 registers separately to carry the dec_regime axis; other axes mirror the bench above.
+NVBENCH_BENCH_TYPES(bench_sort_list_of_numbers,
+                    NVBENCH_TYPE_AXES(nvbench::type_list<numeric::decimal128>))
+  .set_name("sort_list_of_decimal128")
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  .add_int64_axis("max_list_size", {4, 16, 32, 64, 128, 256})
+  // Leaf magnitude classes -- span < 2^32, within int64, past int64 -- bounds set in the body.
+  .add_string_axis("dec_regime", {"u64", "key96", "twophase"})
+  .add_float64_axis("null_frequency", {0, 0.1})
+  .add_string_axis("order", {"ASC", "DESC"})
+  .add_string_axis("null_order", {"AFTER", "BEFORE"});

--- a/cpp/benchmarks/sort/sort_list_of_numbers.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_numbers.cpp
@@ -190,8 +190,8 @@ void bench_sort_list_of_numbers(nvbench::state& state, nvbench::type_list<Type>)
 }
 
 // Chrono is omitted: its packed key is byte-identical to the int32/int64 rep it extracts to, so
-// those cells already measure it. decimal128 stays on the comparator fallback at this stage and
-// needs its own type-string mapping.
+// those cells already measure it. decimal128 exercises the range-gated radix keys (8-byte
+// min-biased / prefix_key96 / two-phase hi64/lo64) and needs its own type-string mapping.
 NVBENCH_DECLARE_TYPE_STRINGS(numeric::decimal128, "decimal128", "decimal128");
 
 NVBENCH_BENCH_TYPES(
@@ -199,12 +199,12 @@ NVBENCH_BENCH_TYPES(
   NVBENCH_TYPE_AXES(nvbench::type_list<std::int32_t, std::int64_t, float, double>))
   .set_name("sort_list_of_numbers")
   .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
-  // 4: tiny lists (tiered network/warp tiers); 32: the mid band the tiered kernel also claims;
-  // 256: past the packed-radix cutoff.
+  // 4: tiny lists (tiered network/warp tiers); 32: the mid band where no-null routing splits by
+  // type between CUB DeviceSegmentedSort and the tiered kernel; 256: past the packed-radix cutoff.
   .add_int64_axis("max_list_size", {4, 16, 32, 64, 128, 256})
-  // The null-bearing ascending / nulls-after cells route to the tiered kernel.
+  // Null-bearing ascending / nulls-after cells route to the tiered kernel.
   .add_float64_axis("null_frequency", {0, 0.1})
-  // The fast path engages only for ascending / nulls-after; the rest measure the base routing.
+  // Only explicit ascending / nulls-after engages the fast paths; the rest measure base routing.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});
 

--- a/cpp/benchmarks/sort/sort_list_of_numbers.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_numbers.cpp
@@ -114,7 +114,7 @@ static std::unique_ptr<cudf::column> trim_forced_last_row(cudf::column_view cons
 }
 
 // Benchmarks cudf::lists::sort_lists on LIST<numeric>, the operation Spark array_sort lowers to.
-// Axis values straddle the CUB fast-path gate; per-axis rationale at the registrations.
+// Axis values straddle the fast-path routing crossovers; per-axis rationale at the registrations.
 template <typename Type>
 void bench_sort_list_of_numbers(nvbench::state& state, nvbench::type_list<Type>)
 {
@@ -189,23 +189,23 @@ void bench_sort_list_of_numbers(nvbench::state& state, nvbench::type_list<Type>)
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }
 
-// Chrono is omitted: neither integral nor fixed-point, so it takes the same comparator sort the
-// float/double cells already measure. decimal128 skips the CUB path (its 128-bit width is
-// unsupported there) and needs its own type-string mapping.
+// Chrono is omitted: its packed key is byte-identical to the int32/int64 rep it extracts to, so
+// those cells already measure it. decimal128 stays on the comparator fallback and needs its own
+// type-string mapping.
 NVBENCH_DECLARE_TYPE_STRINGS(numeric::decimal128, "decimal128", "decimal128");
 
 NVBENCH_BENCH_TYPES(
   bench_sort_list_of_numbers,
   NVBENCH_TYPE_AXES(nvbench::type_list<std::int32_t, std::int64_t, float, double>))
   .set_name("sort_list_of_numbers")
-  // Row counts measure scaling; on this grid they never change which path runs.
   .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
-  // 4, 32, 128: short lists (average < 100) on the CUB path; 256 (average ~128): past the gate at
-  // every row count here, so the comparator sort.
+  // 4 and 32 keep no-null cells below the packed-radix average gate (100); 256 (average ~128)
+  // crosses it, routing eligible ascending / nulls-after cells to the packed radix.
   .add_int64_axis("max_list_size", {4, 16, 32, 64, 128, 256})
-  // Any null forces the comparator sort.
+  // The null-bearing case routes eligible ascending / nulls-after cells to the packed radix.
   .add_float64_axis("null_frequency", {0, 0.1})
-  // The CUB path applies only order; the comparator sort applies both order and null_order.
+  // The packed-radix gate engages only for explicit ascending / nulls-after; the other combinations
+  // measure the base routing.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});
 

--- a/cpp/benchmarks/sort/sort_list_of_strings.cu
+++ b/cpp/benchmarks/sort/sort_list_of_strings.cu
@@ -52,8 +52,8 @@ static cudf::detail::host_vector<int64_t> offsets_to_host_int64(cudf::column_vie
 
 // Overwrites the first `min(plen, byte_length)` bytes of every non-null leaf string with 'A',
 // returning a new LIST<STRING> column: strings stay distinct in their tails but share a
-// `plen`-byte prefix -- the regime where every compare must scan past the shared prefix before it
-// can distinguish two strings. Untimed setup, so a host round-trip is fine.
+// `plen`-byte prefix -- the regime where the packed-prefix key is uninformative and the tie-break
+// does the real work. Untimed setup, so a host round-trip is fine.
 // Assumes an unsliced leaf, which holds for the freshly generated column.
 static std::unique_ptr<cudf::column> apply_shared_prefix(cudf::column_view const& list_col,
                                                          cudf::size_type plen,
@@ -152,13 +152,13 @@ static std::unique_ptr<cudf::column> trim_forced_last_row(cudf::column_view cons
                                         std::move(new_leaf),
                                         list_col.null_count(),
                                         cudf::copy_bitmask(list_col, stream, mr));
+
   stream.synchronize();
   return result;
 }
 
 // Benchmarks cudf::lists::sort_lists on LIST<STRING>, the operation Spark array_sort lowers to and
-// which a plain table sort does not exercise. STRING is never eligible for the CUB fast path, so
-// every cell measures the segment-id + comparator sort; per-axis rationale at the registration.
+// which a plain table sort does not exercise; per-axis rationale at the registration below.
 static void bench_sort_list_of_strings(nvbench::state& state)
 {
   auto const num_rows          = static_cast<cudf::size_type>(state.get_int64("num_rows"));
@@ -180,7 +180,7 @@ static void bench_sort_list_of_strings(nvbench::state& state)
   }
 
   // Leaf strings are all-distinct (cardinality 0) to match the near-unique elements of real
-  // array_sort workloads -- the hardest case for the comparator, stressed by shared_prefix_len --
+  // array_sort workloads -- the hardest tie-break case, stressed further by shared_prefix_len --
   // so leaf cardinality is not a separate axis. Nulls apply at both the list-row and leaf levels.
   // null_frequency == 0 must pass std::nullopt: a literal null_probability(0.0) still samples
   // per-element validity, and thrust's uniform_real<float> endpoint rounding injects stray nulls
@@ -223,15 +223,15 @@ static void bench_sort_list_of_strings(nvbench::state& state)
 NVBENCH_BENCH(bench_sort_list_of_strings)
   .set_name("sort_list_of_strings")
   .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
-  // List length sets the share of compares that stay within a segment and scan string bytes.
+  // Tiny lists stress per-segment overhead; large ones amortize it.
   .add_int64_axis("max_list_size", {4, 16, 32, 64, 128, 256})
-  // Short strings resolve compares in a few bytes; wide ones give the comparator more to scan.
+  // Short strings mostly fit the packed key; wide strings push work into the byte-window tie-break.
   .add_int64_axis("row_width", {16, 64})
-  // 0: control; 8 and 32 force compares through a shared leading prefix before bytes can differ.
+  // 0: control; 8: exactly the packed-key width (first tie-break window); 32: several windows.
   // 96: exceeds both row widths, so bytes never differ and compares resolve by length alone.
   // Shared prefixes are the realistic regime for keyed array_sort data.
   .add_int64_axis("shared_prefix_len", {0, 8, 32, 96})
   .add_float64_axis("null_frequency", {0, 0.1})
-  // Full (order, null_order) matrix: the comparator sort applies both.
+  // The fast path takes only ASC/nulls-last; the other combinations exercise the fallback sort.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});

--- a/cpp/benchmarks/sort/sort_list_of_strings.cu
+++ b/cpp/benchmarks/sort/sort_list_of_strings.cu
@@ -231,7 +231,6 @@ NVBENCH_BENCH(bench_sort_list_of_strings)
   // Shared prefixes are the realistic regime for keyed array_sort data.
   .add_int64_axis("shared_prefix_len", {0, 8, 32, 96})
   .add_float64_axis("null_frequency", {0, 0.1})
-  // The string fast path engages only for explicit ascending / nulls-after; the other combinations
-  // measure the comparator fallback.
+  // The fast path folds (order, null_order) into its keys, so all four combinations exercise it.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});

--- a/cpp/benchmarks/sort/sort_list_of_strings.cu
+++ b/cpp/benchmarks/sort/sort_list_of_strings.cu
@@ -1,0 +1,237 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/memory_stats.hpp>
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/offsets_iterator_factory.cuh>
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/lists/sorting.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/copy.h>
+
+#include <nvbench/nvbench.cuh>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+// Copies a benchmark column's offsets (INT32 or INT64) to host int64 -- `count + 1` entries --
+// through the input offsetalator, cudf's canonical width-erased view of an offsets column. The
+// pinned return vector also makes later H2D copies sourced from it genuinely asynchronous.
+static cudf::detail::host_vector<int64_t> offsets_to_host_int64(cudf::column_view const& offsets_cv,
+                                                                cudf::size_type count,
+                                                                rmm::cuda_stream_view stream)
+{
+  auto const d_offsets = cudf::detail::offsetalator_factory::make_input_iterator(offsets_cv);
+  auto widened         = rmm::device_uvector<int64_t>(static_cast<std::size_t>(count) + 1, stream);
+  thrust::copy(rmm::exec_policy_nosync(stream), d_offsets, d_offsets + count + 1, widened.begin());
+  return cudf::detail::make_pinned_vector(
+    cudf::device_span<int64_t const>{widened.data(), widened.size()}, stream);
+}
+
+// Overwrites the first `min(plen, byte_length)` bytes of every non-null leaf string with 'A',
+// returning a new LIST<STRING> column: strings stay distinct in their tails but share a
+// `plen`-byte prefix -- the regime where every compare must scan past the shared prefix before it
+// can distinguish two strings. Untimed setup, so a host round-trip is fine.
+// Assumes an unsliced leaf, which holds for the freshly generated column.
+static std::unique_ptr<cudf::column> apply_shared_prefix(cudf::column_view const& list_col,
+                                                         cudf::size_type plen,
+                                                         rmm::cuda_stream_view stream)
+{
+  auto const mr = cudf::get_current_device_resource_ref();
+
+  auto const lists    = cudf::lists_column_view{list_col};
+  auto const scv      = cudf::strings_column_view{lists.child()};
+  auto const num_leaf = scv.size();
+
+  auto const chars_bytes = static_cast<std::size_t>(scv.chars_size(stream));
+  auto host_chars        = cudf::detail::make_pinned_vector<char>(
+    cudf::device_span<char const>{scv.chars_begin(stream), chars_bytes}, stream);
+
+  auto const offsets_cv = scv.offsets();
+  auto const offsets    = offsets_to_host_int64(offsets_cv, num_leaf, stream);
+
+  std::vector<cudf::bitmask_type> host_mask;
+  if (scv.null_mask() != nullptr) {
+    auto const host_mask_words = cudf::detail::make_pinned_vector<cudf::bitmask_type>(
+      cudf::device_span<cudf::bitmask_type const>{
+        scv.null_mask(), static_cast<std::size_t>(cudf::num_bitmask_words(num_leaf))},
+      stream);
+    host_mask.assign(host_mask_words.begin(), host_mask_words.end());
+  }
+  auto const* mask_ptr = host_mask.empty() ? nullptr : host_mask.data();
+
+  for (cudf::size_type i = 0; i < num_leaf; ++i) {
+    if (!cudf::bit_value_or(mask_ptr, i, true)) { continue; }  // Skip null elements.
+    auto const len = offsets[i + 1] - offsets[i];
+    auto const k   = std::min<int64_t>(plen, len);
+    std::fill_n(host_chars.begin() + offsets[i], k, 'A');
+  }
+
+  auto new_chars = rmm::device_buffer{host_chars.data(), chars_bytes, stream, mr};
+  auto new_leaf  = cudf::make_strings_column(num_leaf,
+                                            std::make_unique<cudf::column>(offsets_cv, stream, mr),
+                                            std::move(new_chars),
+                                            scv.null_count(),
+                                            cudf::copy_bitmask(scv.parent(), stream, mr));
+
+  auto result = cudf::make_lists_column(lists.size(),
+                                        std::make_unique<cudf::column>(lists.offsets(), stream, mr),
+                                        std::move(new_leaf),
+                                        list_col.null_count(),
+                                        cudf::copy_bitmask(list_col, stream, mr));
+
+  // The async H2D chars copy reads `host_chars`; synchronize before it goes out of scope.
+  stream.synchronize();
+  return result;
+}
+
+// The list generator forces its final offset to the child size, so the last row absorbs every
+// leftover element -- an artifact often far above `max_list_size`, handing the sweep a shape no
+// axis value asked for. Trimming that row (untimed) restores the declared [0, max_list_size]
+// regime. Returns nullptr when the last row already fits. The generator purges nonempty nulls, so
+// the trim cannot create a nonempty null.
+static std::unique_ptr<cudf::column> trim_forced_last_row(cudf::column_view const& list_col,
+                                                          cudf::size_type max_list_size,
+                                                          rmm::cuda_stream_view stream)
+{
+  auto const mr       = cudf::get_current_device_resource_ref();
+  auto const lists    = cudf::lists_column_view{list_col};
+  auto const num_rows = lists.size();
+
+  auto const offsets_cv = lists.offsets();
+  auto const offsets    = offsets_to_host_int64(offsets_cv, num_rows, stream);
+  if (num_rows == 0 or offsets[num_rows] - offsets[num_rows - 1] <= max_list_size) {
+    return nullptr;
+  }
+
+  auto new_offsets      = offsets;
+  new_offsets[num_rows] = new_offsets[num_rows - 1] + max_list_size;
+  // The trim only shrinks the final offset below the existing child size, so the size_type
+  // narrowings here and inside the output offsetalator cannot overflow; the guard makes any
+  // future violation fail loudly instead of wrapping.
+  CUDF_EXPECTS(new_offsets[num_rows] <= std::numeric_limits<cudf::size_type>::max(),
+               "trimmed final offset exceeds size_type range");
+  auto const new_child_size = static_cast<cudf::size_type>(new_offsets[num_rows]);
+
+  // Rebuild offsets at the input's own width: H2D the widened offsets (pinned, so the copy is
+  // async), then store through the output offsetalator, which narrows to the source type on
+  // device. The host and device staging must outlive the trailing synchronize.
+  auto offsets_col = cudf::make_numeric_column(
+    offsets_cv.type(), num_rows + 1, cudf::mask_state::UNALLOCATED, stream, mr);
+  auto const d_new_offsets = cudf::detail::make_device_uvector_async(new_offsets, stream, mr);
+  auto const d_out_offsets =
+    cudf::detail::offsetalator_factory::make_output_iterator(offsets_col->mutable_view());
+  thrust::copy(
+    rmm::exec_policy_nosync(stream), d_new_offsets.begin(), d_new_offsets.end(), d_out_offsets);
+  auto new_leaf =
+    std::make_unique<cudf::column>(cudf::slice(lists.child(), {0, new_child_size})[0], stream, mr);
+  auto result = cudf::make_lists_column(num_rows,
+                                        std::move(offsets_col),
+                                        std::move(new_leaf),
+                                        list_col.null_count(),
+                                        cudf::copy_bitmask(list_col, stream, mr));
+  stream.synchronize();
+  return result;
+}
+
+// Benchmarks cudf::lists::sort_lists on LIST<STRING>, the operation Spark array_sort lowers to and
+// which a plain table sort does not exercise. STRING is never eligible for the CUB fast path, so
+// every cell measures the segment-id + comparator sort; per-axis rationale at the registration.
+static void bench_sort_list_of_strings(nvbench::state& state)
+{
+  auto const num_rows          = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const max_list_size     = static_cast<cudf::size_type>(state.get_int64("max_list_size"));
+  auto const row_width         = static_cast<cudf::size_type>(state.get_int64("row_width"));
+  auto const null_frequency    = state.get_float64("null_frequency");
+  auto const shared_prefix_len = static_cast<cudf::size_type>(state.get_int64("shared_prefix_len"));
+  auto const column_order =
+    state.get_string("order") == "DESC" ? cudf::order::DESCENDING : cudf::order::ASCENDING;
+  auto const null_precedence =
+    state.get_string("null_order") == "BEFORE" ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
+
+  // Skip when estimated leaf chars exceed the int32 char cap.
+  auto const estimated_chars =
+    static_cast<double>(num_rows) * (max_list_size / 2.0) * (row_width / 2.0);
+  if (estimated_chars > static_cast<double>(std::numeric_limits<cudf::size_type>::max())) {
+    state.skip("Skip benchmarks greater than size_type limit");
+    return;
+  }
+
+  // Leaf strings are all-distinct (cardinality 0) to match the near-unique elements of real
+  // array_sort workloads -- the hardest case for the comparator, stressed by shared_prefix_len --
+  // so leaf cardinality is not a separate axis. Nulls apply at both the list-row and leaf levels.
+  // null_frequency == 0 must pass std::nullopt: a literal null_probability(0.0) still samples
+  // per-element validity, and thrust's uniform_real<float> endpoint rounding injects stray nulls
+  // past ~2^24 leaf elements, routing the "no-null" cell through the has-nulls path.
+  auto const null_prob =
+    null_frequency > 0 ? std::optional<double>{null_frequency} : std::optional<double>{};
+  data_profile const profile =
+    data_profile_builder()
+      .list_type(cudf::type_id::STRING)
+      .list_depth(1)
+      .distribution(cudf::type_id::LIST, distribution_id::UNIFORM, 0, max_list_size)
+      .distribution(cudf::type_id::STRING, distribution_id::NORMAL, 0, row_width)
+      .null_probability(null_prob)
+      .cardinality(0);
+
+  auto const table = create_random_table({cudf::type_id::LIST}, row_count{num_rows}, profile);
+
+  auto const stream = cudf::get_default_stream();
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+
+  auto const trimmed  = trim_forced_last_row(table->view().column(0), max_list_size, stream);
+  auto const base_col = trimmed ? trimmed->view() : table->view().column(0);
+
+  auto const prefixed =
+    shared_prefix_len > 0 ? apply_shared_prefix(base_col, shared_prefix_len, stream) : nullptr;
+  auto const input = cudf::lists_column_view{prefixed ? prefixed->view() : base_col};
+  stream.synchronize();  // Ensure untimed setup completes before timing.
+
+  auto const mem_stats_logger = cudf::memory_stats_logger();
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
+    cudf::lists::sort_lists(
+      input, column_order, null_precedence, stream, cudf::get_current_device_resource_ref());
+  });
+
+  state.add_buffer_size(
+    mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
+}
+
+NVBENCH_BENCH(bench_sort_list_of_strings)
+  .set_name("sort_list_of_strings")
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  // List length sets the share of compares that stay within a segment and scan string bytes.
+  .add_int64_axis("max_list_size", {4, 16, 32, 64, 128, 256})
+  // Short strings resolve compares in a few bytes; wide ones give the comparator more to scan.
+  .add_int64_axis("row_width", {16, 64})
+  // 0: control; 8 and 32 force compares through a shared leading prefix before bytes can differ.
+  // 96: exceeds both row widths, so bytes never differ and compares resolve by length alone.
+  // Shared prefixes are the realistic regime for keyed array_sort data.
+  .add_int64_axis("shared_prefix_len", {0, 8, 32, 96})
+  .add_float64_axis("null_frequency", {0, 0.1})
+  // Full (order, null_order) matrix: the comparator sort applies both.
+  .add_string_axis("order", {"ASC", "DESC"})
+  .add_string_axis("null_order", {"AFTER", "BEFORE"});

--- a/cpp/benchmarks/sort/sort_list_of_strings.cu
+++ b/cpp/benchmarks/sort/sort_list_of_strings.cu
@@ -108,10 +108,10 @@ static std::unique_ptr<cudf::column> apply_shared_prefix(cudf::column_view const
 }
 
 // The list generator forces its final offset to the child size, so the last row absorbs every
-// leftover element -- an artifact often far above `max_list_size`, handing the sweep a shape no
-// axis value asked for. Trimming that row (untimed) restores the declared [0, max_list_size]
-// regime. Returns nullptr when the last row already fits. The generator purges nonempty nulls, so
-// the trim cannot create a nonempty null.
+// leftover element -- an artifact often far above `max_list_size` that would disqualify the whole
+// column from the graduated-warp path and silently demote it to the prefix path. Trimming that row
+// (untimed) restores the declared [0, max_list_size] regime. Returns nullptr when the last row
+// already fits. The generator purges nonempty nulls, so the trim cannot create a nonempty null.
 static std::unique_ptr<cudf::column> trim_forced_last_row(cudf::column_view const& list_col,
                                                           cudf::size_type max_list_size,
                                                           rmm::cuda_stream_view stream)
@@ -152,7 +152,6 @@ static std::unique_ptr<cudf::column> trim_forced_last_row(cudf::column_view cons
                                         std::move(new_leaf),
                                         list_col.null_count(),
                                         cudf::copy_bitmask(list_col, stream, mr));
-
   stream.synchronize();
   return result;
 }
@@ -232,6 +231,7 @@ NVBENCH_BENCH(bench_sort_list_of_strings)
   // Shared prefixes are the realistic regime for keyed array_sort data.
   .add_int64_axis("shared_prefix_len", {0, 8, 32, 96})
   .add_float64_axis("null_frequency", {0, 0.1})
-  // The fast path takes only ASC/nulls-last; the other combinations exercise the fallback sort.
+  // The string fast path engages only for explicit ascending / nulls-after; the other combinations
+  // measure the comparator fallback.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});

--- a/cpp/src/lists/segmented_sort.cu
+++ b/cpp/src/lists/segmented_sort.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/transform.h>
@@ -68,11 +69,20 @@ std::unique_ptr<column> sort_lists(lists_column_view const& input,
                                                                       stream,
                                                                       mr);
 
+  // The sort cannot add nulls: release a null-free child's all-valid mask and skip the parent
+  // bitmask copy when it holds no nulls, so the output is nullable only where nulls are present.
+  auto sorted_child = std::move(sorted_child_table->release().front());
+  // Defensive: keeps sort_lists' no-spurious-mask contract independent of the by-key internals --
+  // currently a no-op, since the shared gather already normalizes.
+  if (sorted_child->null_count() == 0) { sorted_child->set_null_mask(rmm::device_buffer{}, 0); }
+
   return make_lists_column(input.size(),
                            std::move(output_offset),
-                           std::move(sorted_child_table->release().front()),
+                           std::move(sorted_child),
                            input.null_count(),
-                           cudf::detail::copy_bitmask(input.parent(), stream, mr));
+                           input.null_count() == 0
+                             ? rmm::device_buffer{}
+                             : cudf::detail::copy_bitmask(input.parent(), stream, mr));
 }
 
 std::unique_ptr<column> stable_sort_lists(lists_column_view const& input,
@@ -94,11 +104,20 @@ std::unique_ptr<column> stable_sort_lists(lists_column_view const& input,
                                                                              stream,
                                                                              mr);
 
+  // The sort cannot add nulls: release a null-free child's all-valid mask and skip the parent
+  // bitmask copy when it holds no nulls, so the output is nullable only where nulls are present.
+  auto sorted_child = std::move(sorted_child_table->release().front());
+  // Defensive: keeps stable_sort_lists' no-spurious-mask contract independent of the by-key
+  // internals -- currently a no-op, since the shared gather already normalizes.
+  if (sorted_child->null_count() == 0) { sorted_child->set_null_mask(rmm::device_buffer{}, 0); }
+
   return make_lists_column(input.size(),
                            std::move(output_offset),
-                           std::move(sorted_child_table->release().front()),
+                           std::move(sorted_child),
                            input.null_count(),
-                           cudf::detail::copy_bitmask(input.parent(), stream, mr));
+                           input.null_count() == 0
+                             ? rmm::device_buffer{}
+                             : cudf::detail::copy_bitmask(input.parent(), stream, mr));
 }
 }  // namespace detail
 

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -55,5 +55,36 @@ namespace detail {
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 
+/**
+ * @brief Whether every segment fits the graduated path's largest warp tile
+ * (`STRINGS_GRAD_WARP_CAP`)
+ *
+ * Synchronizing device probe; the caller runs the cheap scalar gates first and guarantees at
+ * least two offsets, so `segment_offsets.size() - 1` is a valid segment count.
+ */
+bool strings_grad_all_segments_fit(column_view const& segment_offsets,
+                                   rmm::cuda_stream_view stream);
+
+/**
+ * @brief Segmented sorted-order for a STRING column via graduated in-warp sorts
+ *
+ * One virtual warp per segment with `cub::WarpMergeSort` under a string comparator; the warp width
+ * follows the segment-size band (W8/W16/W32, two items per lane except the (0,8] slice at one) so
+ * a tiny segment never occupies a full warp. Every band launches over the full segment list and
+ * self-filters to its size slice; the bands partition [1, 64], so every output slot is written
+ * exactly once. The caller guarantees every segment fits `STRINGS_GRAD_WARP_CAP`
+ * (`strings_grad_all_segments_fit`) and offsets spanning all rows; `polarity` folds order and
+ * null placement into the keys as in `fast_segmented_sorted_order_strings_prefix`.
+ *
+ * The cap precondition is re-verified in debug builds only, so a release-build violation is an
+ * unchecked out-of-bounds hazard.
+ */
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_grad(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -53,21 +53,46 @@ enum class fixed_width_sort_path {
 /**
  * @brief Routes a single fixed-width key column to the fast path measured best for its shape
  *
- * Ineligible types -- whatever the packed key cannot encode losslessly -- keep `comparison`. The
- * rest go packed radix wherever it wins outright: null-bearing at any list size, since validity
- * folds into the packed key with no separate null pass, and no-null past the average-list-size
- * cutoff, where long lists amortize the bandwidth-bound global pass; the short no-null remainder
- * keeps main's CUB-or-comparison decision.
+ * Four engines picked by type x null-presence x average list size, since their costs scale
+ * differently:
+ * - Non-tiered numerics (narrow/unsigned ints, `bool`, `DECIMAL32`/`DECIMAL64`) -> packed radix if
+ *   null-bearing or long, else comparison (resolving to CUB): the tiered key can't encode them.
+ * - `DECIMAL128` -> comparison: out of this stage's scope.
+ * - Null-bearing tiered types -> tiered: validity folds into the key, no separate null pass.
+ * - No-null past the fast cutoff -> packed radix: bandwidth-bound, amortized by long lists.
+ * - Other no-null tiered types -> tiered (register networks make tiny-segment cost
+ *   width-independent; the warp tiers beat CUB), except a small-scale int64 tiny-average pocket
+ *   that stays on CUB.
+ * - Outside the envelope -> comparison sort.
  *
  * @param key The fixed-width key column being routed
  * @param num_rows Element count of `key`, used to compute the average list size
  * @param segment_offsets The segment offsets; the caller guarantees non-empty
- * @param stream Unused; the routing reads only host-side metadata
+ * @param stream Unused until the `DECIMAL128` mid-band shape gate lands
  */
 fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
                                                    size_type num_rows,
                                                    column_view const& segment_offsets,
                                                    rmm::cuda_stream_view stream);
+
+/**
+ * @brief Faster segmented sorted-order for a single fixed-width key column via a tiered sort
+ *
+ * Four size tiers whose cost tracks segment size rather than key width -- the win over packed
+ * radix when segments are tiny but values are wide: one thread with a fixed Batcher network
+ * (<= `TIERED_NETWORK_CAP`), a warp with `cub::WarpMergeSort` (<= `TIERED_WARP_CAP`), a block with
+ * `cub::BlockMergeSort` (<= `TIERED_BLOCK_TIER_CAP`), else a packed radix over just that segment's
+ * elements. `polarity` folds nulls (three-valued class flag) and descending (value complement)
+ * into the key; the result matches the comparison path's order.
+ *
+ * @throw cudf::logic_error If `polarity.nulls_first` is requested on a column with no null mask
+ */
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_tiered(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
 
 /**
  * @brief Faster segmented sorted-order for a single fixed-width key column via one radix sort

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "segmented_sort_keys.cuh"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <memory>
+
+namespace cudf {
+namespace detail {
+
+/**
+ * @brief Faster segmented sorted-order for a single STRING key column via iterative radix sort
+ *
+ * The first pass radixes one `uint64` per element laid out `[segment : S bits][class : 1 bit when
+ * nullable][prefix : P bits]` (see `packed_key_layout`) -- eight byte-passes, not the twelve a
+ * 96-bit key needs. Elements still tied are compacted out and re-sorted by successive eight-byte
+ * windows: each pass radixes a `prefix_key96` whose most-significant field is a dense run rank
+ * encoding the order resolved so far, so a pass only reorders within a tied run; elements that
+ * become singletons freeze at their final positions and drop out, and the loop exits once nothing
+ * stays tied. Runs still tied after the pass cap go to one comparison cleanup. Unlike rank
+ * encoding, distinct strings are never sorted, so per-pass cost does not grow with key
+ * cardinality.
+ *
+ * Ordering equals the lexicographic comparison sort under the requested `polarity`:
+ * - The prefix and the windows pack leading bytes big-endian, so unsigned key compares reproduce
+ *   unsigned-byte order. `P` need not be a byte multiple: a packed-key match proves only
+ *   `floor(P/8)` whole bytes equal, so the windows and the cleanup both begin there and the run
+ *   rank is seeded from the packed keys, leaving `P`-bit ties in one run.
+ * - A string with no byte left in a window packs to zero (the minimum), reproducing the
+ *   shorter-is-less length tie-break; the residual all-zero-tail case is settled by the cleanup's
+ *   length compare.
+ * - The class bit sits above every prefix bit, so nulls land on the requested side with no
+ *   sentinel prefix (no all-0xFF collision) and are position-final after the first pass.
+ * - A descending sort XOR-complements only the byte fields (prefix and windows), leaving segment
+ *   and null placement intact; the complement sends an exhausted window's zero to the maximum, so
+ *   the length tie-break inverts to shorter-is-greater consistently. A zero-null column relaxes to
+ *   nulls-last, keeping its keys bit-identical to the shipped ascending configuration.
+ *
+ * @throw cudf::logic_error If `polarity.nulls_first` is requested on a column with no null mask
+ */
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_prefix(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -27,6 +27,15 @@ constexpr size_type MAX_AVG_LIST_SIZE_FOR_FAST_SORT{100};
 constexpr size_type MAX_LIST_SIZE_FOR_FAST_SORT{1 << 18};
 
 /**
+ * @brief Average list size at or below which a no-null `DECIMAL128` column prefers CUB
+ * `DeviceSegmentedSort`
+ *
+ * Measured band top shared by both fast paths; above it CUB loses several-fold to the comparison
+ * sort.
+ */
+constexpr size_type DECIMAL128_CUB_MAX_AVG_LIST_SIZE{16};
+
+/**
  * @brief Whether a single fixed-width column is small enough to prefer CUB `DeviceSegmentedSort`
  *
  * @param num_rows Total element count; the average-size disjunct divides it by `num_offsets`
@@ -56,10 +65,12 @@ enum class fixed_width_sort_path {
  * Four engines picked by type x null-presence x average list size, since their costs scale
  * differently:
  * - Non-tiered numerics (narrow/unsigned ints, `bool`, `DECIMAL32`/`DECIMAL64`) -> packed radix if
- *   null-bearing or long, else comparison (resolving to CUB): the tiered key can't encode them.
- * - `DECIMAL128` -> comparison: out of this stage's scope.
+ *   null-bearing or long, else CUB/comparison: the tiered key can't encode them.
  * - Null-bearing tiered types -> tiered: validity folds into the key, no separate null pass.
  * - No-null past the fast cutoff -> packed radix: bandwidth-bound, amortized by long lists.
+ * - No-null `DECIMAL128` -> tiered, CUB in a sparse-large mid band, tiered above it: CUB's
+ *   16-byte-pair merge tiles cap at 32 elements, so dense large segments would explode into a
+ *   radix.
  * - Other no-null tiered types -> tiered (register networks make tiny-segment cost
  *   width-independent; the warp tiers beat CUB), except a small-scale int64 tiny-average pocket
  *   that stays on CUB.
@@ -68,7 +79,7 @@ enum class fixed_width_sort_path {
  * @param key The fixed-width key column being routed
  * @param num_rows Element count of `key`, used to compute the average list size
  * @param segment_offsets The segment offsets; the caller guarantees non-empty
- * @param stream Unused until the `DECIMAL128` mid-band shape gate lands
+ * @param stream Used only by the `DECIMAL128` mid-band shape gate
  */
 fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
                                                    size_type num_rows,

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -49,8 +49,8 @@ inline bool prefer_cub_segmented_sort(size_type num_rows, size_type num_offsets)
 }
 
 /**
- * @brief Fixed-width fast path a single key column takes within the explicit ascending /
- * nulls-after, unstable envelope
+ * @brief Fixed-width fast path a single key column takes within the explicit-(order, null_order) /
+ * unstable envelope
  */
 enum class fixed_width_sort_path {
   comparison,     ///< No fast path applies

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -19,6 +19,75 @@ namespace cudf {
 namespace detail {
 
 /**
+ * @brief Average and total element-count bounds below which CUB `DeviceSegmentedSort` is preferred
+ *
+ * Benchmark-chosen; the packed-radix path takes exactly the complement of this gate.
+ */
+constexpr size_type MAX_AVG_LIST_SIZE_FOR_FAST_SORT{100};
+constexpr size_type MAX_LIST_SIZE_FOR_FAST_SORT{1 << 18};
+
+/**
+ * @brief Whether a single fixed-width column is small enough to prefer CUB `DeviceSegmentedSort`
+ *
+ * @param num_rows Total element count; the average-size disjunct divides it by `num_offsets`
+ * @param num_offsets Number of segments plus one, matching the historical average-size heuristic;
+ *        the caller guarantees it is nonzero
+ */
+inline bool prefer_cub_segmented_sort(size_type num_rows, size_type num_offsets)
+{
+  return (num_rows / num_offsets) < MAX_AVG_LIST_SIZE_FOR_FAST_SORT or
+         num_rows < MAX_LIST_SIZE_FOR_FAST_SORT;
+}
+
+/**
+ * @brief Fixed-width fast path a single key column takes within the explicit ascending /
+ * nulls-after, unstable envelope
+ */
+enum class fixed_width_sort_path {
+  comparison,     ///< No fast path applies
+  tiered,         ///< Register / warp / block tiered kernel
+  cub_segmented,  ///< CUB `DeviceSegmentedSort` over the packed rep
+  packed_radix    ///< One global packed-radix sort
+};
+
+/**
+ * @brief Routes a single fixed-width key column to the fast path measured best for its shape
+ *
+ * Ineligible types -- whatever the packed key cannot encode losslessly -- keep `comparison`. The
+ * rest go packed radix wherever it wins outright: null-bearing at any list size, since validity
+ * folds into the packed key with no separate null pass, and no-null past the average-list-size
+ * cutoff, where long lists amortize the bandwidth-bound global pass; the short no-null remainder
+ * keeps main's CUB-or-comparison decision.
+ *
+ * @param key The fixed-width key column being routed
+ * @param num_rows Element count of `key`, used to compute the average list size
+ * @param segment_offsets The segment offsets; the caller guarantees non-empty
+ * @param stream Unused; the routing reads only host-side metadata
+ */
+fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
+                                                   size_type num_rows,
+                                                   column_view const& segment_offsets,
+                                                   rmm::cuda_stream_view stream);
+
+/**
+ * @brief Faster segmented sorted-order for a single fixed-width key column via one radix sort
+ *
+ * One non-segmented radix over a packed [segment | null class | transformed value] key whose
+ * unsigned order equals the requested order (`polarity` complements the value field for descending
+ * and picks the null side). The value is fully encoded, so the radix permutation is final -- no
+ * tie-break, and no null post-pass since null-vs-null order is immaterial under the unstable
+ * contract.
+ *
+ * @throw cudf::logic_error If `polarity.nulls_first` is requested on a column with no null mask
+ */
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_numeric_packed(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+/**
  * @brief Faster segmented sorted-order for a single STRING key column via iterative radix sort
  *
  * The first pass radixes one `uint64` per element laid out `[segment : S bits][class : 1 bit when

--- a/cpp/src/sort/segmented_sort_fixed_width.cu
+++ b/cpp/src/sort/segmented_sort_fixed_width.cu
@@ -5,12 +5,17 @@
 
 #include "segmented_sort_fast.cuh"
 #include "segmented_sort_keys.cuh"
+#include "segmented_sort_warp_kernel.cuh"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/detail/utilities/assert.cuh>
+#include <cudf/detail/utilities/grid_1d.cuh>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -19,7 +24,11 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/block/block_merge_sort.cuh>
+#include <cub/device/device_partition.cuh>
 #include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_select.cuh>
+#include <cub/warp/warp_merge_sort.cuh>
 #include <cuda/iterator>
 #include <cuda/std/algorithm>
 #include <cuda/std/bit>
@@ -27,6 +36,7 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
+#include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
@@ -93,6 +103,18 @@ __device__ inline cuda::std::uint64_t radix_encode_u64(T value)
 }
 
 /**
+ * @brief 128-bit analogue for the `DECIMAL128` rep (`__int128_t`): always signed, so the sign bit
+ * flips unconditionally
+ */
+template <typename T>
+__device__ inline unsigned __int128 radix_encode_u128(T value)
+{
+  auto encoded = static_cast<unsigned __int128>(value);
+  encoded ^= (static_cast<unsigned __int128>(1) << 127);
+  return encoded;
+}
+
+/**
  * @brief Builds the single-`uint64` packed key for a fixed-width element of width four bytes or
  * less
  *
@@ -152,6 +174,24 @@ struct numeric_packed_key_builder64 {
                  key.prefix_lo);
     return key;
   }
+};
+
+/**
+ * @brief Common per-column sort parameters shared by the packed-radix engine
+ *
+ * Bundles the column, its null/segment/polarity metadata, and the stream so the sort entry points
+ * that operate on a whole segmented column share one parameter list instead of repeating the same
+ * six arguments. `tiered_sort_fn` is intentionally excluded: it derives
+ * `d_segment_ids`/`segment_bits` lazily, only inside its radix-spill branch, and forcing that work
+ * eager for struct uniformity would change when it happens on the common path.
+ */
+struct segment_sort_context {
+  size_type const* d_segment_ids;
+  column_device_view const d_input;
+  bool const has_nulls;
+  int const segment_bits;
+  sort_polarity const polarity;
+  rmm::cuda_stream_view const stream;
 };
 
 /**
@@ -261,8 +301,9 @@ void build_and_radix_sort_packed_keys(IndexIteratorT d_indices_in,
  * only the non-fixed-width types, which the caller's gate never dispatches.
  */
 struct numeric_packed_sort_fn {
-  // Compile-time counterpart of `is_numeric_packed_radix_supported` after `dispatch_storage_type`
-  // mapping: widen the two together. The DECIMAL128 rep is enabled here but fenced off at run time.
+  // Compile-time counterpart of the runtime gate `is_numeric_packed_radix_supported`: widen the
+  // two together. `is_integral` also admits the 16-byte `__int128` rep, which the runtime gate
+  // fences off until its engine lands.
   template <typename T>
   static constexpr bool is_supported()
   {
@@ -270,16 +311,18 @@ struct numeric_packed_sort_fn {
   }
 
   template <typename T, CUDF_ENABLE_IF(is_supported<T>())>
-  void operator()(column_device_view const& d_input,
-                  size_type const* d_segment_ids,
-                  bool has_nulls,
-                  sort_polarity polarity,
-                  int segment_bits,
+  void operator()(segment_sort_context const& ctx,
                   size_type num_elements,
-                  size_type* d_indices_out,
-                  rmm::cuda_stream_view stream) const
+                  size_type* d_indices_out) const
   {
-    auto const counting = cuda::counting_iterator<size_type>{0};
+    // Locals preserve the body's original parameter names; only the call boundary changed.
+    auto const& d_input      = ctx.d_input;
+    auto const d_segment_ids = ctx.d_segment_ids;
+    auto const has_nulls     = ctx.has_nulls;
+    auto const polarity      = ctx.polarity;
+    auto const segment_bits  = ctx.segment_bits;
+    auto const stream        = ctx.stream;
+    auto const counting      = cuda::counting_iterator<size_type>{0};
     rmm::device_uvector<size_type> indices_in(num_elements, stream);
     thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      indices_in.begin(),
@@ -320,20 +363,14 @@ struct numeric_packed_sort_fn {
         d_indices_out,
         stream);
     } else {
-      // Unreached fail-safe: the run-time gate excludes the DECIMAL128 (`__int128`) rep.
+      // Unreached fail-safe: `is_numeric_packed_radix_supported` fences off the 16-byte
+      // DECIMAL128 rep until its engine lands.
       CUDF_FAIL("Column type cannot be used with the numeric packed-radix segmented sort");
     }
   }
 
   template <typename T, CUDF_ENABLE_IF(not is_supported<T>())>
-  void operator()(column_device_view const&,
-                  size_type const*,
-                  bool,
-                  sort_polarity,
-                  int,
-                  size_type,
-                  size_type*,
-                  rmm::cuda_stream_view) const
+  void operator()(segment_sort_context const&, size_type, size_type*) const
   {
     CUDF_FAIL("Column type cannot be used with the numeric packed-radix segmented sort");
   }
@@ -342,6 +379,8 @@ struct numeric_packed_sort_fn {
 /**
  * @brief Run-time predicate for the numeric packed-radix fast path: every fixed-width type the
  * packed key encodes losslessly
+ *
+ * `DECIMAL128` (16-byte rep) stays excluded until its engine lands.
  *
  * @param type The key column's data type
  * @return true if the type is eligible for the packed-radix fast path
@@ -352,6 +391,1109 @@ inline bool is_numeric_packed_radix_supported(data_type type)
          (cudf::is_fixed_point(type) and type.id() != type_id::DECIMAL128) or
          cudf::is_floating_point(type) or cudf::is_chrono(type);
 }
+
+// ==========================================================================================
+// Tiered per-segment sort for a single fixed-width key column.
+//
+// The packed-radix path's fixed per-element cost (a global radix over a key as wide as the value)
+// dominates when segments are tiny. This path instead classifies segments by size into four
+// tiers whose cost tracks the segment size: up to `TIERED_NETWORK_CAP` a single thread with a
+// register sorting network, up to `TIERED_WARP_CAP` a full warp with `cub::WarpMergeSort`, up to
+// `TIERED_BLOCK_TIER_CAP` one block with `cub::BlockMergeSort`, and rare larger outliers a packed
+// radix over just their elements. Nulls sort via a class flag folded into the key; descending
+// complements the key's value bits.
+// ==========================================================================================
+
+/**
+ * @brief Ordering key for the 16-byte (`__int128`) rep: a class flag over the hi/lo-split 128-bit
+ * value
+ *
+ * `flag` dominates (the polarity's classes below the pad); within the valid class the sign-flipped
+ * value words -- complemented when descending -- give unsigned-compare == value order. 24 bytes; a
+ * null or pad leaves the value words zero. Unused until the DECIMAL128 tiered engine lands.
+ */
+struct tiered_key128 {
+  cuda::std::uint64_t hi;
+  cuda::std::uint64_t lo;
+  cuda::std::uint32_t flag;
+};
+static_assert(sizeof(tiered_key128) == 24 and alignof(tiered_key128) == 8,
+              "tiered_key128 must stay 24 bytes with 8-byte alignment");
+
+/**
+ * @brief Maps a tiered storage type to its packed ordering key by value width
+ *
+ * The class flag rides the high bits, so a native compare orders valid < null < pad and then by
+ * the `radix_encode_*` value: four bytes or fewer -> `uint64` (flag in bits 32-33), eight ->
+ * `unsigned __int128` (bits 64-65), sixteen -> the 24-byte `tiered_key128`.
+ */
+template <typename T>
+using tiered_key_t = cuda::std::conditional_t<
+  sizeof(T) <= 4,
+  cuda::std::uint64_t,
+  cuda::std::conditional_t<sizeof(T) == 8, unsigned __int128, tiered_key128>>;
+
+/**
+ * @brief The pad key for type `T`: class flag `tier_pad`, value words zero
+ *
+ * Ordered strictly after every valid element and null, so the sorts keep pads beyond a segment's
+ * valid-item boundary. Host-usable because the launch code builds it on the host.
+ */
+template <typename T>
+__host__ __device__ inline tiered_key_t<T> tiered_pad_key()
+{
+  using KeyT = tiered_key_t<T>;
+  if constexpr (cuda::std::is_same_v<KeyT, tiered_key128>) {
+    return tiered_key128{0, 0, static_cast<cuda::std::uint32_t>(tiered_element_class::tier_pad)};
+  } else if constexpr (cuda::std::is_same_v<KeyT, unsigned __int128>) {
+    return static_cast<unsigned __int128>(tiered_element_class::tier_pad) << 64;
+  } else {
+    return static_cast<cuda::std::uint64_t>(tiered_element_class::tier_pad) << 32;
+  }
+}
+
+/// Strict-weak less-than over any tiered key: native `<` or `tiered_key128::operator<`.
+struct tiered_key_less {
+  template <typename KeyT>
+  __device__ bool operator()(KeyT const& a, KeyT const& b) const
+  {
+    return a < b;
+  }
+};
+
+/**
+ * @brief Builds the packed tiered key for one element: class flag then radix-encoded value
+ *
+ * A null (value zero, unread) sorts on the polarity's side regardless of values. A valid value is
+ * complemented within the value bits when descending -- per-word for `tiered_key128`, where the
+ * hi-then-lo compare equals the 128-bit unsigned compare -- never reaching the class flag.
+ */
+template <typename T>
+struct tiered_key_builder {
+  column_device_view d_input;
+  bool has_nulls;
+  sort_polarity polarity;
+  __device__ tiered_key_t<T> operator()(size_type idx) const
+  {
+    using KeyT     = tiered_key_t<T>;
+    bool const nul = has_nulls && d_input.is_null(idx);
+    auto const cls = polarity.element_class(nul);
+    if constexpr (cuda::std::is_same_v<KeyT, tiered_key128>) {
+      if (nul) { return tiered_key128{0, 0, cls}; }
+      auto const encoded = radix_encode_u128<T>(d_input.element<T>(idx));
+      auto const mask    = polarity.value_mask64();
+      return tiered_key128{static_cast<cuda::std::uint64_t>(encoded >> 64) ^ mask,
+                           static_cast<cuda::std::uint64_t>(encoded) ^ mask,
+                           cls};
+    } else if constexpr (cuda::std::is_same_v<KeyT, unsigned __int128>) {
+      if (nul) { return static_cast<unsigned __int128>(cls) << 64; }
+      return (static_cast<unsigned __int128>(cls) << 64) |
+             static_cast<unsigned __int128>(radix_encode_u64<T>(d_input.element<T>(idx)) ^
+                                            polarity.value_mask64());
+    } else {
+      if (nul) { return static_cast<cuda::std::uint64_t>(cls) << 32; }
+      return (static_cast<cuda::std::uint64_t>(cls) << 32) |
+             static_cast<cuda::std::uint64_t>(radix_encode_u32<T>(d_input.element<T>(idx)) ^
+                                              polarity.value_mask32());
+    }
+  }
+};
+
+// Network tier: one thread sorts a whole segment of <= `TIERED_NETWORK_CAP` elements in registers
+// with a fixed Batcher network. The 19-comparator eight-key network sorts all 2^8 binary inputs,
+// so by the zero-one principle it sorts any totally-ordered keys; even at the widest (24-byte)
+// key, eight keys + indices fit in registers without spilling.
+constexpr size_type TIERED_NETWORK_CAP = 8;
+// The kernel hardcodes the eight-slot network: raising the cap would silently mis-sort, lowering
+// it would over-index. Regenerate the network before changing the cap.
+static_assert(TIERED_NETWORK_CAP == 8,
+              "tiered_network_sort_kernel hardcodes the eight-key Batcher network");
+// Warp tier: a full 32-lane warp per segment, `cub::WarpMergeSort` at two items per lane. The
+// 64-slot tile stays within register / shared budget even at the widest key, so the cap is
+// uniform across key widths.
+constexpr int TIERED_WARP_LANES     = 32;
+constexpr int TIERED_WARP_ITEMS     = 2;
+constexpr size_type TIERED_WARP_CAP = TIERED_WARP_LANES * TIERED_WARP_ITEMS;
+// Block tier: one 128-thread block per segment with `cub::BlockMergeSort`, in graduated
+// items-per-thread bands so a segment just over the warp cap pays a 128-slot tile rather than a
+// 1024-slot one. Without this rung mid-band list shapes spilled to the radix tier and regressed
+// below CUB `DeviceSegmentedSort`. The largest band's shared tile is ~16KB at the widest key,
+// inside the 48KB static budget.
+constexpr size_type TIERED_BLOCK_TIER_CAP = 1'024;
+
+/// Selects segments whose size is <= `cap` (the network tier) for `cub::DevicePartition::If`
+struct segment_in_network_tier {
+  size_type const* d_offsets;
+  size_type cap;
+  __device__ bool operator()(size_type seg) const
+  {
+    return (d_offsets[seg + 1] - d_offsets[seg]) <= cap;
+  }
+};
+
+/**
+ * @brief Selects segments whose size is in `(network_cap, warp_cap]` (the warp tier)
+ *
+ * The explicit lower bound keeps the predicate correct whether or not `DevicePartition::If`
+ * evaluates it on items the first selector already selected.
+ */
+struct segment_in_warp_tier {
+  size_type const* d_offsets;
+  size_type network_cap;
+  size_type warp_cap;
+  __device__ bool operator()(size_type seg) const
+  {
+    auto const sz = d_offsets[seg + 1] - d_offsets[seg];
+    return sz > network_cap && sz <= warp_cap;
+  }
+};
+
+/**
+ * @brief Selects segments whose size is <= `block_cap` (the block tier) from the large-segment
+ * list
+ *
+ * Every entry already exceeds the warp cap, so only the upper bound needs testing; the rest stay
+ * radix-spill outliers.
+ */
+struct segment_in_block_tier {
+  size_type const* d_offsets;
+  size_type block_cap;
+  __device__ bool operator()(size_type seg) const
+  {
+    return (d_offsets[seg + 1] - d_offsets[seg]) <= block_cap;
+  }
+};
+
+/**
+ * @brief Selects elements whose segment is in the radix tier (size > `cap`)
+ *
+ * Scanning ascending element indices compacts them grouped by segment then position -- the
+ * arrangement `radix_sort_large_segments` relies on for its scatter.
+ */
+struct element_in_radix_tier {
+  size_type const* d_segment_ids;
+  size_type const* d_offsets;
+  size_type cap;
+  __device__ bool operator()(size_type i) const
+  {
+    auto const seg = d_segment_ids[i];
+    return (d_offsets[seg + 1] - d_offsets[seg]) > cap;
+  }
+};
+
+/// One compare-exchange: orders `keys[a] <= keys[b]` under `cmp`, carrying the paired values.
+template <typename KeyT, typename CompareOp>
+__device__ inline void network_compare_exchange(
+  KeyT* keys, size_type* vals, int a, int b, CompareOp cmp)
+{
+  if (cmp(keys[b], keys[a])) {
+    KeyT const tk      = keys[a];
+    keys[a]            = keys[b];
+    keys[b]            = tk;
+    size_type const tv = vals[a];
+    vals[a]            = vals[b];
+    vals[b]            = tv;
+  }
+}
+
+/**
+ * @brief Sorts one segment per thread with the fixed eight-key Batcher network
+ *
+ * Thread `t` loads segment `d_seg_list[t]`'s keys and global indices into registers, pads the
+ * unused slots (pads sort last and are never written back), applies the network, and writes the
+ * sorted indices back to the segment's slots. Register-only, so a segment's cost is independent
+ * of its neighbours'.
+ */
+template <typename T, int BLOCK_THREADS, typename CompareOp>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_network_sort_kernel(
+  column_device_view const d_input,
+  size_type const* d_offsets,
+  size_type const* d_seg_list,
+  size_type num_class_segments,
+  bool has_nulls,
+  sort_polarity polarity,
+  size_type* d_out,
+  CompareOp compare_op,
+  tiered_key_t<T> pad_key)
+{
+  using KeyT     = tiered_key_t<T>;
+  auto const tid = cudf::detail::grid_1d::global_thread_id<BLOCK_THREADS>();
+  if (tid >= static_cast<thread_index_type>(num_class_segments)) { return; }
+
+  auto const seg       = d_seg_list[tid];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+
+  tiered_key_builder<T> const build_key{d_input, has_nulls, polarity};
+  KeyT keys[TIERED_NETWORK_CAP];
+  size_type vals[TIERED_NETWORK_CAP];
+#pragma unroll
+  for (int i = 0; i < TIERED_NETWORK_CAP; ++i) {
+    if (i < seg_size) {
+      auto const gidx = seg_start + i;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = pad_key;
+      vals[i] = size_type{0};
+    }
+  }
+
+  // Eight-key Batcher network (19 compare-exchanges); pads settle above every real element.
+  network_compare_exchange(keys, vals, 0, 1, compare_op);
+  network_compare_exchange(keys, vals, 2, 3, compare_op);
+  network_compare_exchange(keys, vals, 4, 5, compare_op);
+  network_compare_exchange(keys, vals, 6, 7, compare_op);
+  network_compare_exchange(keys, vals, 0, 2, compare_op);
+  network_compare_exchange(keys, vals, 1, 3, compare_op);
+  network_compare_exchange(keys, vals, 4, 6, compare_op);
+  network_compare_exchange(keys, vals, 5, 7, compare_op);
+  network_compare_exchange(keys, vals, 1, 2, compare_op);
+  network_compare_exchange(keys, vals, 5, 6, compare_op);
+  network_compare_exchange(keys, vals, 0, 4, compare_op);
+  network_compare_exchange(keys, vals, 3, 7, compare_op);
+  network_compare_exchange(keys, vals, 1, 5, compare_op);
+  network_compare_exchange(keys, vals, 2, 6, compare_op);
+  network_compare_exchange(keys, vals, 1, 4, compare_op);
+  network_compare_exchange(keys, vals, 3, 6, compare_op);
+  network_compare_exchange(keys, vals, 2, 4, compare_op);
+  network_compare_exchange(keys, vals, 3, 5, compare_op);
+  network_compare_exchange(keys, vals, 3, 4, compare_op);
+
+#pragma unroll
+  for (int i = 0; i < TIERED_NETWORK_CAP; ++i) {
+    if (i < seg_size) { d_out[seg_start + i] = vals[i]; }
+  }
+}
+
+/**
+ * @brief Sorts one segment per virtual warp with `cub::WarpMergeSort` under a null-aware
+ * comparator
+ *
+ * Lane `l` holds items `[l*IPT, l*IPT+IPT)` in blocked order, padded past the segment size; the
+ * pad key plus `valid_items = seg_size` keep the real elements in `[0, seg_size)`, so only those
+ * slots are written back (global indices, straight into the output gather map). `W*IPT` >= the
+ * class's maximum segment size is guaranteed by the caps the caller partitions on.
+ */
+template <typename T, int W, int IPT, int BLOCK_THREADS, typename CompareOp>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_warp_sort_kernel(
+  column_device_view const d_input,
+  size_type const* d_offsets,
+  size_type const* d_seg_list,
+  size_type num_class_segments,
+  bool has_nulls,
+  sort_polarity polarity,
+  size_type* d_out,
+  CompareOp compare_op,
+  tiered_key_t<T> pad_key)
+{
+  using KeyT                     = tiered_key_t<T>;
+  using WarpMergeSortT           = cub::WarpMergeSort<KeyT, IPT, W, size_type>;
+  constexpr int VWARPS_PER_BLOCK = BLOCK_THREADS / W;
+  __shared__ typename WarpMergeSortT::TempStorage temp_storage[VWARPS_PER_BLOCK];
+
+  auto const global_tid = cudf::detail::grid_1d::global_thread_id<BLOCK_THREADS>();
+  auto const vwarp_id   = static_cast<size_type>(global_tid / W);  // the class segment to sort
+  auto const lane       = static_cast<int>(threadIdx.x % W);  // logical lane in the virtual warp
+  auto const vwarp_slot = static_cast<int>(threadIdx.x / W);  // virtual warp's shared-mem slot
+  // Uniform across the virtual warp's lanes, so the whole warp returns together and never
+  // desynchronizes the `__syncwarp` inside `Sort`.
+  if (vwarp_id >= num_class_segments) { return; }
+
+  auto const seg       = d_seg_list[vwarp_id];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+
+  tiered_key_builder<T> const build_key{d_input, has_nulls, polarity};
+  KeyT keys[IPT];
+  size_type vals[IPT];
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) {
+      auto const gidx = seg_start + local;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = pad_key;
+      vals[i] = size_type{0};
+    }
+  }
+
+  WarpMergeSortT(temp_storage[vwarp_slot])
+    .Sort(keys, vals, compare_op, static_cast<int>(seg_size), pad_key);
+
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) { d_out[seg_start + local] = vals[i]; }
+  }
+}
+
+/**
+ * @brief Sorts one segment per thread block with `cub::BlockMergeSort` over a segment-size band
+ *
+ * A block whose segment size falls outside `(band_lo, band_hi]` returns before sorting, so
+ * graduated `IPT` bands share one list without re-partitioning. `seg_size` is uniform across the
+ * block, so every arriving thread reaches the `__syncthreads` inside `Sort`. Blocked layout with
+ * pads past the segment size, as in the warp kernel; only `[0, seg_size)` is written back.
+ */
+template <typename T, int BLOCK_THREADS, int IPT, typename CompareOp>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_block_band_kernel(
+  column_device_view const d_input,
+  size_type const* d_offsets,
+  size_type const* d_seg_list,
+  size_type num_class_segments,
+  size_type band_lo,
+  size_type band_hi,
+  bool has_nulls,
+  sort_polarity polarity,
+  size_type* d_out,
+  CompareOp compare_op,
+  tiered_key_t<T> pad_key)
+{
+  using KeyT            = tiered_key_t<T>;
+  using BlockMergeSortT = cub::BlockMergeSort<KeyT, BLOCK_THREADS, IPT, size_type>;
+  __shared__ typename BlockMergeSortT::TempStorage temp_storage;
+
+  auto const block_id = static_cast<size_type>(blockIdx.x);
+  if (block_id >= num_class_segments) { return; }
+
+  auto const seg       = d_seg_list[block_id];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+  if (seg_size <= band_lo || seg_size > band_hi) { return; }
+  // A band_hi above the BLOCK_THREADS*IPT tile would silently drop elements.
+  cudf_assert(seg_size <= BLOCK_THREADS * IPT &&
+              "band segment exceeds the block tile (band_hi > BLOCK_THREADS*IPT)");
+
+  tiered_key_builder<T> const build_key{d_input, has_nulls, polarity};
+  KeyT keys[IPT];
+  size_type vals[IPT];
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = static_cast<int>(threadIdx.x) * IPT + i;
+    if (local < seg_size) {
+      auto const gidx = seg_start + local;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = pad_key;
+      vals[i] = size_type{0};
+    }
+  }
+
+  BlockMergeSortT(temp_storage).Sort(keys, vals, compare_op, static_cast<int>(seg_size), pad_key);
+
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = static_cast<int>(threadIdx.x) * IPT + i;
+    if (local < seg_size) { d_out[seg_start + local] = vals[i]; }
+  }
+}
+
+// No-null INT32 / INT64 warp segments route to kernels measured faster than the packed
+// `WarpMergeSort`: a raw key (no null field) at half the packed width cuts the sort's data
+// traffic. Only when `has_nulls` is false -- a raw key cannot express null ordering.
+
+/**
+ * @brief Raw ordering key for the no-null warp tier: the encoded value alone, half the packed
+ * key's width
+ */
+template <typename T>
+using tiered_raw_key_t =
+  cuda::std::conditional_t<sizeof(T) <= 4, cuda::std::uint32_t, cuda::std::uint64_t>;
+
+/**
+ * @brief Builds the raw no-null key for one element: its order-preserving encoded value,
+ * complemented when descending
+ */
+template <typename T>
+struct tiered_raw_key_builder {
+  column_device_view d_input;
+  sort_polarity polarity;
+  __device__ tiered_raw_key_t<T> operator()(size_type idx) const
+  {
+    if constexpr (sizeof(T) <= 4) {
+      return radix_encode_u32<T>(d_input.element<T>(idx)) ^ polarity.value_mask32();
+    } else {
+      return radix_encode_u64<T>(d_input.element<T>(idx)) ^ polarity.value_mask64();
+    }
+  }
+};
+
+/**
+ * @brief The pad key for the raw no-null path: the maximum unsigned value
+ *
+ * A real element can encode to the same maximum (`INT*_MAX` ascending, the minimum descending), so
+ * the warp band uses `StableSort`: reals precede pads in tile order, and stability keeps an
+ * equal-valued real inside the valid range.
+ */
+template <typename T>
+__host__ __device__ inline tiered_raw_key_t<T> tiered_raw_pad_key()
+{
+  return cuda::std::numeric_limits<tiered_raw_key_t<T>>::max();
+}
+
+/// Plain ascending less-than for the raw key -- the raw path is no-null, so no class flag.
+struct tiered_raw_less {
+  template <typename KeyT>
+  __device__ bool operator()(KeyT const& a, KeyT const& b) const
+  {
+    return a < b;
+  }
+};
+
+/**
+ * @brief Ascending compare of a raw-key/index pair with a pad tie-break for the register bitonic
+ *
+ * Compares `(key, is_pad)` with `is_pad == (val < 0)` (a pad carries `val = -1`). Ordering a real
+ * before an equal-keyed pad keeps every real inside `[0, seg_size)` even when a real key encodes
+ * to the all-ones pad sentinel, so the write-back never drops one.
+ */
+template <typename KeyT>
+__device__ inline bool bitonic_pad_less(KeyT ka, size_type va, KeyT kb, size_type vb)
+{
+  if (ka != kb) { return ka < kb; }
+  return (va >= 0) && (vb < 0);
+}
+
+/**
+ * @brief Register shuffle-bitonic sort of `W * IPT` elements across a logical warp
+ *
+ * Standard Batcher bitonic network, blocked layout `e = lane * IPT + item`: intra-lane exchanges
+ * (`j < IPT`) run in registers, inter-lane ones swap with lane `lane ^ (j / IPT)` via
+ * `__shfl_xor_sync` confined by `mask` and width `W`. Stage direction is `(e & k) == 0` and the
+ * `j`-bit-clear index is the low element, keeping partners consistent. Validated exhaustively on
+ * the host (zero-one principle) for the instantiated shapes.
+ */
+template <int W, int IPT, typename KeyT>
+__device__ inline void bitonic_warp_sort(KeyT (&keys)[IPT],
+                                         size_type (&vals)[IPT],
+                                         int lane,
+                                         unsigned mask)
+{
+  constexpr int n = W * IPT;
+  for (int k = 2; k <= n; k <<= 1) {
+    for (int j = k >> 1; j > 0; j >>= 1) {
+      if (j >= IPT) {
+        int const jl = j / IPT;
+#pragma unroll
+        for (int m = 0; m < IPT; ++m) {
+          int const e          = lane * IPT + m;
+          KeyT const pk        = __shfl_xor_sync(mask, keys[m], jl, W);
+          size_type const pv   = __shfl_xor_sync(mask, vals[m], jl, W);
+          bool const ascending = ((e & k) == 0);
+          bool const keep_min  = (((e & j) == 0) == ascending);
+          bool const take      = keep_min ? bitonic_pad_less(pk, pv, keys[m], vals[m])
+                                          : bitonic_pad_less(keys[m], vals[m], pk, pv);
+          if (take) {
+            keys[m] = pk;
+            vals[m] = pv;
+          }
+        }
+      } else {
+#pragma unroll
+        for (int m = 0; m < IPT; ++m) {
+          int const m2 = m ^ j;
+          if (m2 > m) {
+            int const e          = lane * IPT + m;
+            bool const ascending = ((e & k) == 0);
+            bool const inverted  = ascending
+                                     ? bitonic_pad_less(keys[m2], vals[m2], keys[m], vals[m])
+                                     : bitonic_pad_less(keys[m], vals[m], keys[m2], vals[m2]);
+            if (inverted) {
+              KeyT const tk      = keys[m];
+              keys[m]            = keys[m2];
+              keys[m2]           = tk;
+              size_type const tv = vals[m];
+              vals[m]            = vals[m2];
+              vals[m2]           = tv;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief Register shuffle-bitonic warp kernel over a segment-size band (raw keys, no-null)
+ *
+ * One logical `W`-lane warp per segment of size in `(band_lo, band_hi]`; pads (max key, index -1)
+ * stay beyond `[0, seg_size)` via the tie-break.
+ */
+template <typename T, int W, int IPT, int BLOCK_THREADS>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_bitonic_band_kernel(
+  column_device_view const d_input,
+  size_type const* d_offsets,
+  size_type const* d_seg_list,
+  size_type num_class_segments,
+  size_type band_lo,
+  size_type band_hi,
+  sort_polarity polarity,
+  size_type* d_out)
+{
+  using KeyT            = tiered_raw_key_t<T>;
+  auto const global_tid = cudf::detail::grid_1d::global_thread_id<BLOCK_THREADS>();
+  auto const vwarp_id   = static_cast<size_type>(global_tid / W);
+  auto const lane       = static_cast<int>(threadIdx.x % W);
+  if (vwarp_id >= num_class_segments) { return; }
+
+  auto const seg       = d_seg_list[vwarp_id];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+  if (seg_size <= band_lo || seg_size > band_hi) { return; }
+  // The register tile holds W*IPT elements; a band_hi above that would silently drop elements.
+  cudf_assert(seg_size <= W * IPT && "band segment exceeds the register tile (band_hi > W*IPT)");
+
+  tiered_raw_key_builder<T> const build_key{d_input, polarity};
+  KeyT keys[IPT];
+  size_type vals[IPT];
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) {
+      auto const gidx = seg_start + local;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = tiered_raw_pad_key<T>();
+      vals[i] = size_type{-1};
+    }
+  }
+  // Member mask of this virtual warp's W lanes (W <= 16, so the shift is well-defined).
+  unsigned const mask = ((1u << W) - 1u) << ((static_cast<unsigned>(threadIdx.x) % 32u / W) * W);
+  bitonic_warp_sort<W, IPT>(keys, vals, lane, mask);
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) { d_out[seg_start + local] = vals[i]; }
+  }
+}
+
+/**
+ * @brief Common per-helper launch parameters shared by all four tiered band launchers
+ *
+ * Bundles the column, its offsets/polarity, the output map, and the stream: the fields that stay
+ * fixed across every launcher call one tier helper makes, so it constructs one instance and reuses
+ * it. `band_lo`/`band_hi` stay explicit despite appearing in all four launchers' own signatures
+ * too -- they change on every call within a helper, so bundling them would force a fresh struct
+ * per call instead of one shared instance. `has_nulls` and the segment-list pointer (with its
+ * paired count) also stay explicit: only two of the four launchers use `has_nulls`, and the
+ * segment-list differs by name and meaning (`d_warp_segs` vs `d_block_segs`).
+ */
+struct band_launch_ctx {
+  column_device_view const d_input;
+  size_type const* d_offsets;
+  sort_polarity const polarity;
+  size_type* d_out;
+  rmm::cuda_stream_view const stream;
+};
+
+/// Launches one packed-key `WarpMergeSort` band over the warp-segment list (all tiered types)
+template <typename T, int W, int IPT>
+void launch_packed_warp_band(band_launch_ctx const& ctx,
+                             size_type const* d_warp_segs,
+                             size_type num_warp,
+                             bool has_nulls,
+                             size_type band_lo,
+                             size_type band_hi)
+{
+  if (num_warp == 0) { return; }
+  using KeyT = tiered_key_t<T>;
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_warp) * W, TIERED_BLOCK_THREADS);
+  tiered_warp_band_kernel<KeyT,
+                          tiered_key_builder<T>,
+                          W,
+                          IPT,
+                          TIERED_BLOCK_THREADS,
+                          tiered_key_less>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, ctx.stream.value()>>>(
+      ctx.d_offsets,
+      d_warp_segs,
+      num_warp,
+      band_lo,
+      band_hi,
+      tiered_key_builder<T>{ctx.d_input, has_nulls, ctx.polarity},
+      ctx.d_out,
+      tiered_key_less{},
+      tiered_pad_key<T>());
+  CUDF_CHECK_CUDA(ctx.stream.value());
+}
+
+/// Launches one raw-key `WarpMergeSort` band over the warp-segment list (no-null only)
+template <typename T, int W, int IPT>
+void launch_raw_warp_band(band_launch_ctx const& ctx,
+                          size_type const* d_warp_segs,
+                          size_type num_warp,
+                          size_type band_lo,
+                          size_type band_hi)
+{
+  if (num_warp == 0) { return; }
+  using KeyT = tiered_raw_key_t<T>;
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_warp) * W, TIERED_BLOCK_THREADS);
+  tiered_warp_band_kernel<KeyT,
+                          tiered_raw_key_builder<T>,
+                          W,
+                          IPT,
+                          TIERED_BLOCK_THREADS,
+                          tiered_raw_less>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, ctx.stream.value()>>>(
+      ctx.d_offsets,
+      d_warp_segs,
+      num_warp,
+      band_lo,
+      band_hi,
+      tiered_raw_key_builder<T>{ctx.d_input, ctx.polarity},
+      ctx.d_out,
+      tiered_raw_less{},
+      tiered_raw_pad_key<T>());
+  CUDF_CHECK_CUDA(ctx.stream.value());
+}
+
+/// Launches one register-bitonic band over the warp-segment list (raw keys, no-null only)
+template <typename T, int W, int IPT>
+void launch_bitonic_band(band_launch_ctx const& ctx,
+                         size_type const* d_warp_segs,
+                         size_type num_warp,
+                         size_type band_lo,
+                         size_type band_hi)
+{
+  if (num_warp == 0) { return; }
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_warp) * W, TIERED_BLOCK_THREADS);
+  tiered_bitonic_band_kernel<T, W, IPT, TIERED_BLOCK_THREADS>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, ctx.stream.value()>>>(
+      ctx.d_input, ctx.d_offsets, d_warp_segs, num_warp, band_lo, band_hi, ctx.polarity, ctx.d_out);
+  CUDF_CHECK_CUDA(ctx.stream.value());
+}
+
+/// Launches one packed-key `BlockMergeSort` band over the block-segment list (all tiered types)
+template <typename T, int IPT>
+void launch_block_band(band_launch_ctx const& ctx,
+                       size_type const* d_block_segs,
+                       size_type num_block,
+                       bool has_nulls,
+                       size_type band_lo,
+                       size_type band_hi)
+{
+  if (num_block == 0) { return; }
+  auto const grid = cudf::detail::grid_1d(
+    static_cast<thread_index_type>(num_block) * TIERED_BLOCK_THREADS, TIERED_BLOCK_THREADS);
+  tiered_block_band_kernel<T, TIERED_BLOCK_THREADS, IPT, tiered_key_less>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, ctx.stream.value()>>>(ctx.d_input,
+                                                                             ctx.d_offsets,
+                                                                             d_block_segs,
+                                                                             num_block,
+                                                                             band_lo,
+                                                                             band_hi,
+                                                                             has_nulls,
+                                                                             ctx.polarity,
+                                                                             ctx.d_out,
+                                                                             tiered_key_less{},
+                                                                             tiered_pad_key<T>());
+  CUDF_CHECK_CUDA(ctx.stream.value());
+}
+
+/**
+ * @brief Run-time predicate for the tiered fast path on a key column's type
+ *
+ * Timestamps / durations flow through the same width-keyed path via their integer reps.
+ * DECIMAL128, DECIMAL32/64, the narrower integrals, and non-fixed-width types fall through to the
+ * paths below.
+ *
+ * @param type The key column's data type
+ * @return true if the type is eligible for the tiered fast path
+ */
+inline bool is_tiered_sort_supported(data_type type)
+{
+  return type.id() == type_id::INT32 or type.id() == type_id::INT64 or
+         cudf::is_floating_point(type) or cudf::is_chrono(type);
+}
+
+/**
+ * @brief Sorts only the radix-tier segments' elements via the packed-radix key, scattering the
+ * result into the output gather map
+ *
+ * Keys just the compacted radix-tier element indices rather than paying a full-column radix for a
+ * rare tier. `d_large_gidx` is ascending, so its entries are exactly the radix-tier output slots
+ * in order: `d_out[d_large_gidx[j]] = sorted_gidx[j]` writes each segment's k-th smallest element
+ * to its k-th slot. `d_large_gidx` is read-only throughout, so it doubles as the scatter map.
+ */
+template <typename T>
+void radix_sort_large_segments(segment_sort_context const& ctx,
+                               size_type const* d_large_gidx,
+                               size_type num_large_elems,
+                               size_type* d_out)
+{
+  // Locals preserve the body's original parameter names; only the call boundary changed.
+  auto const& d_input      = ctx.d_input;
+  auto const d_segment_ids = ctx.d_segment_ids;
+  auto const has_nulls     = ctx.has_nulls;
+  auto const polarity      = ctx.polarity;
+  auto const segment_bits  = ctx.segment_bits;
+  auto const stream        = ctx.stream;
+  auto const alloc         = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<size_type> sorted_gidx(num_large_elems, stream);
+
+  // Each branch mirrors the packed-radix path's width-specific key, restricted to the subset.
+  if constexpr (sizeof(T) <= 4) {
+    build_and_radix_sort_packed_keys<cuda::std::uint64_t>(
+      d_large_gidx,
+      num_large_elems,
+      numeric_packed_key_builder<T>{d_segment_ids, d_input, has_nulls, segment_bits, polarity},
+      static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+      d_large_gidx,
+      sorted_gidx.data(),
+      stream);
+  } else if constexpr (sizeof(T) == 8) {
+    // Same seg_null end-bit trim as the full-column eight-byte branch.
+    auto const key_bits = cuda::std::min(static_cast<int>(sizeof(prefix_key96) * 8),
+                                         64 + cuda::std::min(32, segment_bits + 1));
+    build_and_radix_sort_packed_keys<prefix_key96>(
+      d_large_gidx,
+      num_large_elems,
+      numeric_packed_key_builder64<T>{d_segment_ids, d_input, has_nulls, polarity},
+      prefix_decomposer{},
+      key_bits,
+      d_large_gidx,
+      sorted_gidx.data(),
+      stream);
+  } else {
+    // Unreached fail-safe: `is_tiered_sort_supported` fences off the 16-byte DECIMAL128 rep
+    // until its engine lands.
+    CUDF_FAIL("Column type cannot be used with the tiered segmented sort");
+  }
+
+  thrust::scatter(rmm::exec_policy_nosync(stream, alloc),
+                  sorted_gidx.begin(),
+                  sorted_gidx.end(),
+                  d_large_gidx,
+                  d_out);
+}
+
+/**
+ * @brief Per-call tier sizes and the shared out-of-segment pad key for one `tiered_sort_fn`
+ * dispatch
+ *
+ * Bundles what segment classification hands to all three tier handlers below, even though each
+ * handler reads only its own count: one shared type keeps the three call sites uniform instead of
+ * three bespoke parameter lists. `pad_key` depends only on `T`, so computing it once here, right
+ * after classification, is equivalent to each tier computing it independently at its old site.
+ */
+template <typename T>
+struct tiered_tier_counts {
+  size_type num_network;
+  size_type num_warp;
+  size_type num_large;
+  tiered_key_t<T> pad_key;
+};
+
+/**
+ * @brief Handles the large-segment tier: splits it into the block sub-tier and the rare
+ * radix-spill outliers, sorting each
+ *
+ * `segment_offsets` (not just `d_offsets`) is needed to re-derive `segment_ids` for the
+ * radix-spill branch's `label_segments` call.
+ */
+template <typename T>
+void handle_large_tier(column_view const& segment_offsets,
+                       column_device_view const& d_input,
+                       size_type num_elements,
+                       size_type num_segments,
+                       bool has_nulls,
+                       sort_polarity polarity,
+                       size_type const* large_segs,
+                       tiered_tier_counts<T> const& counts,
+                       size_type* d_out,
+                       rmm::cuda_stream_view stream)
+{
+  auto const num_large = counts.num_large;
+  if (num_large == 0) { return; }
+  auto const d_offsets = segment_offsets.begin<size_type>();
+  auto const seg_iter  = cuda::counting_iterator<size_type>{0};
+
+  // The partition writes the rejected (radix-spill) ids reversed to the rear of `block_segs`;
+  // the spill is driven off element size below, so the rear is never read.
+  rmm::device_uvector<size_type> block_segs(num_large, stream);
+  rmm::device_uvector<size_type> d_num_block(1, stream);
+  auto const select_block = segment_in_block_tier{d_offsets, TIERED_BLOCK_TIER_CAP};
+  {
+    rmm::device_buffer d_temp_storage;
+    size_t temp_storage_bytes = 0;
+    cub::DevicePartition::If(d_temp_storage.data(),
+                             temp_storage_bytes,
+                             large_segs,
+                             block_segs.data(),
+                             d_num_block.data(),
+                             num_large,
+                             select_block,
+                             stream.value());
+    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+    cub::DevicePartition::If(d_temp_storage.data(),
+                             temp_storage_bytes,
+                             large_segs,
+                             block_segs.data(),
+                             d_num_block.data(),
+                             num_large,
+                             select_block,
+                             stream.value());
+  }
+  auto const h_num_block =
+    cudf::detail::make_pinned_vector(device_span<size_type const>{d_num_block.data(), 1}, stream);
+  auto const num_block = h_num_block[0];
+  auto const num_radix = num_large - num_block;
+
+  // Radix-spill outliers: sort only their elements and scatter into their disjoint slots.
+  if (num_radix > 0) {
+    rmm::device_uvector<size_type> segment_ids(num_elements, stream);
+    label_segments(segment_offsets.begin<size_type>(),
+                   segment_offsets.end<size_type>(),
+                   segment_ids.begin(),
+                   segment_ids.end(),
+                   stream);
+    auto const segment_bits =
+      static_cast<int>(cuda::std::bit_width(static_cast<cuda::std::uint64_t>(num_segments)));
+
+    // Compact the radix-tier elements' global indices (ascending), then read their count
+    // back -- the radix tier's one extra sync.
+    rmm::device_uvector<size_type> large_gidx(num_elements, stream);
+    rmm::device_uvector<size_type> d_num_large_elems(1, stream);
+    {
+      rmm::device_buffer d_temp_storage;
+      size_t temp_storage_bytes = 0;
+      auto const is_large =
+        element_in_radix_tier{segment_ids.data(), d_offsets, TIERED_BLOCK_TIER_CAP};
+      cub::DeviceSelect::If(d_temp_storage.data(),
+                            temp_storage_bytes,
+                            seg_iter,
+                            large_gidx.data(),
+                            d_num_large_elems.data(),
+                            num_elements,
+                            is_large,
+                            stream.value());
+      d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+      cub::DeviceSelect::If(d_temp_storage.data(),
+                            temp_storage_bytes,
+                            seg_iter,
+                            large_gidx.data(),
+                            d_num_large_elems.data(),
+                            num_elements,
+                            is_large,
+                            stream.value());
+    }
+    auto const h_num_large_elems = cudf::detail::make_pinned_vector(
+      device_span<size_type const>{d_num_large_elems.data(), 1}, stream);
+    radix_sort_large_segments<T>(
+      segment_sort_context{segment_ids.data(), d_input, has_nulls, segment_bits, polarity, stream},
+      large_gidx.data(),
+      h_num_large_elems[0],
+      d_out);
+  }
+
+  // Block tier: graduated items-per-thread bands over the one block-segment list; each band
+  // self-filters to its size slice, so the bands need no re-partition.
+  if (num_block > 0) {
+    auto const* bl = block_segs.data();
+    band_launch_ctx const launch_ctx{d_input, d_offsets, polarity, d_out, stream};
+    launch_block_band<T, 1>(launch_ctx, bl, num_block, has_nulls, TIERED_WARP_CAP, 128);
+    launch_block_band<T, 2>(launch_ctx, bl, num_block, has_nulls, 128, 256);
+    launch_block_band<T, 4>(launch_ctx, bl, num_block, has_nulls, 256, 512);
+    launch_block_band<T, 8>(launch_ctx, bl, num_block, has_nulls, 512, TIERED_BLOCK_TIER_CAP);
+  }
+}
+
+/// Handles the network tier: one warp-network sort kernel launch over the small-segment list.
+template <typename T>
+void handle_network_tier(column_device_view const& d_input,
+                         size_type const* d_offsets,
+                         bool has_nulls,
+                         sort_polarity polarity,
+                         size_type const* network_segs,
+                         tiered_tier_counts<T> const& counts,
+                         size_type* d_out,
+                         rmm::cuda_stream_view stream)
+{
+  auto const num_network = counts.num_network;
+  if (num_network == 0) { return; }
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_network), TIERED_BLOCK_THREADS);
+  tiered_network_sort_kernel<T, TIERED_BLOCK_THREADS>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(d_input,
+                                                                         d_offsets,
+                                                                         network_segs,
+                                                                         num_network,
+                                                                         has_nulls,
+                                                                         polarity,
+                                                                         d_out,
+                                                                         tiered_key_less{},
+                                                                         counts.pad_key);
+  CUDF_CHECK_CUDA(stream.value());
+}
+
+/**
+ * @brief Handles the warp tier: routes each size sub-band to the kernel measured best per (type,
+ * null-presence)
+ *
+ * No-null INT32: register bitonic throughout; no-null INT64: bitonic to 32, then a raw-key
+ * WarpMergeSort at half the key traffic; nullable INT32 / INT64: packed-key WarpMergeSort bands.
+ * Every other tiered type keeps the whole-band packed WarpMergeSort -- the raw-key / bitonic
+ * kernels are unmeasured there.
+ */
+template <typename T>
+void handle_warp_tier(column_device_view const& d_input,
+                      size_type const* d_offsets,
+                      bool has_nulls,
+                      sort_polarity polarity,
+                      size_type const* warp_segs,
+                      tiered_tier_counts<T> const& counts,
+                      size_type* d_out,
+                      rmm::cuda_stream_view stream)
+{
+  auto const num_warp = counts.num_warp;
+  if (num_warp == 0) { return; }
+  auto const* wl = warp_segs;
+  if constexpr (cuda::std::is_same_v<T, int32_t> or cuda::std::is_same_v<T, int64_t>) {
+    band_launch_ctx const launch_ctx{d_input, d_offsets, polarity, d_out, stream};
+    if (has_nulls) {
+      launch_packed_warp_band<T, TIERED_WARP_LANES, 1>(
+        launch_ctx, wl, num_warp, has_nulls, TIERED_NETWORK_CAP, 32);
+      launch_packed_warp_band<T, TIERED_WARP_LANES, TIERED_WARP_ITEMS>(
+        launch_ctx, wl, num_warp, has_nulls, 32, TIERED_WARP_CAP);
+    } else {
+      launch_bitonic_band<T, 4, 4>(launch_ctx, wl, num_warp, TIERED_NETWORK_CAP, 16);
+      launch_bitonic_band<T, 8, 4>(launch_ctx, wl, num_warp, 16, 32);
+      if constexpr (cuda::std::is_same_v<T, int32_t>) {
+        launch_bitonic_band<T, 16, 4>(launch_ctx, wl, num_warp, 32, TIERED_WARP_CAP);
+      } else {
+        launch_raw_warp_band<T, TIERED_WARP_LANES, TIERED_WARP_ITEMS>(
+          launch_ctx, wl, num_warp, 32, TIERED_WARP_CAP);
+      }
+    }
+  } else {
+    auto const grid = cudf::detail::grid_1d(
+      static_cast<thread_index_type>(num_warp) * TIERED_WARP_LANES, TIERED_BLOCK_THREADS);
+    tiered_warp_sort_kernel<T, TIERED_WARP_LANES, TIERED_WARP_ITEMS, TIERED_BLOCK_THREADS>
+      <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(d_input,
+                                                                           d_offsets,
+                                                                           wl,
+                                                                           num_warp,
+                                                                           has_nulls,
+                                                                           polarity,
+                                                                           d_out,
+                                                                           tiered_key_less{},
+                                                                           counts.pad_key);
+    CUDF_CHECK_CUDA(stream.value());
+  }
+}
+
+/**
+ * @brief Type-dispatched worker for `fast_segmented_sorted_order_tiered`
+ *
+ * One three-way `cub::DevicePartition::If` classifies segments (network / warp / large); the
+ * large class is split again into the block tier and the radix-spill outliers. Each stage adds
+ * its host sync only when its class exists.
+ */
+struct tiered_sort_fn {
+  template <typename T>
+  static constexpr bool is_supported()
+  {
+    return cuda::std::is_same_v<T, int32_t> or cuda::std::is_same_v<T, int64_t> or
+           cudf::is_floating_point<T>() or cudf::is_chrono<T>();
+  }
+
+  template <typename T, CUDF_ENABLE_IF(is_supported<T>())>
+  void operator()(column_view const& segment_offsets,
+                  column_device_view const& d_input,
+                  size_type num_elements,
+                  size_type num_segments,
+                  bool has_nulls,
+                  sort_polarity polarity,
+                  size_type* d_out,
+                  rmm::cuda_stream_view stream) const
+  {
+    auto const d_offsets = segment_offsets.begin<size_type>();
+
+    // Three-way classify the segment indices by size; `large_segs` feeds the second-stage
+    // partition below.
+    rmm::device_uvector<size_type> network_segs(num_segments, stream);
+    rmm::device_uvector<size_type> warp_segs(num_segments, stream);
+    rmm::device_uvector<size_type> large_segs(num_segments, stream);
+    rmm::device_uvector<size_type> d_counts(2, stream);
+    auto const seg_iter       = cuda::counting_iterator<size_type>{0};
+    auto const select_network = segment_in_network_tier{d_offsets, TIERED_NETWORK_CAP};
+    auto const select_warp = segment_in_warp_tier{d_offsets, TIERED_NETWORK_CAP, TIERED_WARP_CAP};
+    {
+      rmm::device_buffer d_temp_storage;
+      size_t temp_storage_bytes = 0;
+      cub::DevicePartition::If(d_temp_storage.data(),
+                               temp_storage_bytes,
+                               seg_iter,
+                               network_segs.data(),
+                               warp_segs.data(),
+                               large_segs.data(),
+                               d_counts.data(),
+                               num_segments,
+                               select_network,
+                               select_warp,
+                               stream.value());
+      d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+      cub::DevicePartition::If(d_temp_storage.data(),
+                               temp_storage_bytes,
+                               seg_iter,
+                               network_segs.data(),
+                               warp_segs.data(),
+                               large_segs.data(),
+                               d_counts.data(),
+                               num_segments,
+                               select_network,
+                               select_warp,
+                               stream.value());
+    }
+    auto const h_counts =
+      cudf::detail::make_pinned_vector(device_span<size_type const>{d_counts.data(), 2}, stream);
+    tiered_tier_counts<T> const counts{
+      h_counts[0], h_counts[1], num_segments - h_counts[0] - h_counts[1], tiered_pad_key<T>()};
+
+    // Each handler is a no-op -- with its host sync -- when its tier is empty, so the
+    // tiny-segment common case pays nothing for unused rungs; every output slot is written
+    // exactly once across the tiers.
+    handle_large_tier<T>(segment_offsets,
+                         d_input,
+                         num_elements,
+                         num_segments,
+                         has_nulls,
+                         polarity,
+                         large_segs.data(),
+                         counts,
+                         d_out,
+                         stream);
+    handle_network_tier<T>(
+      d_input, d_offsets, has_nulls, polarity, network_segs.data(), counts, d_out, stream);
+    handle_warp_tier<T>(
+      d_input, d_offsets, has_nulls, polarity, warp_segs.data(), counts, d_out, stream);
+  }
+
+  template <typename T, CUDF_ENABLE_IF(not is_supported<T>())>
+  void operator()(column_view const&,
+                  column_device_view const&,
+                  size_type,
+                  size_type,
+                  bool,
+                  sort_polarity,
+                  size_type*,
+                  rmm::cuda_stream_view) const
+  {
+    CUDF_FAIL("Column type cannot be used with the tiered segmented sort");
+  }
+};
+
+// Segment-count ceiling for the eight-byte tiny-average pocket: below it CUB `DeviceSegmentedSort`
+// beats the tiered network tier, whose fixed per-launch setup has not yet amortized.
+constexpr size_type EIGHT_BYTE_TINY_CUB_MAX_NUM_OFFSETS{1 << 17};
 
 }  // namespace
 
@@ -390,14 +1532,45 @@ inline bool is_numeric_packed_radix_supported(data_type type)
     data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
 
   // Storage-type dispatch: DECIMAL32/64 sort by their int32/int64 rep.
+  cudf::type_dispatcher<dispatch_storage_type>(
+    input.type(),
+    numeric_packed_sort_fn{},
+    segment_sort_context{segment_ids.data(), *d_input, has_nulls, segment_bits, polarity, stream},
+    num_elements,
+    sorted_indices->mutable_view().begin<size_type>());
+  return sorted_indices;
+}
+
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_tiered(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_elements = input.size();
+  auto const num_segments = segment_offsets.size() - 1;
+  CUDF_EXPECTS(num_segments >= 1, "the tiered key layout requires at least one segment");
+  auto const d_input   = column_device_view::create(input, stream);
+  auto const has_nulls = input.has_nulls();
+
+  // The tiered key reserves a null class only when nullable; pin the caller-side coupling the
+  // strings path also asserts, so a null-free column can never arrive with `nulls_first` set.
+  CUDF_EXPECTS(has_nulls or not polarity.nulls_first,
+               "nulls_first requires a nullable column for the tiered key layout");
+
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
+
+  // `dispatch_storage_type` readies the decimal reps for when their tiered routing lands.
   cudf::type_dispatcher<dispatch_storage_type>(input.type(),
-                                               numeric_packed_sort_fn{},
+                                               tiered_sort_fn{},
+                                               segment_offsets,
                                                *d_input,
-                                               segment_ids.data(),
+                                               num_elements,
+                                               num_segments,
                                                has_nulls,
                                                polarity,
-                                               segment_bits,
-                                               num_elements,
                                                sorted_indices->mutable_view().begin<size_type>(),
                                                stream);
   return sorted_indices;
@@ -416,14 +1589,37 @@ fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
   auto const num_offsets   = segment_offsets.size();
   auto const avg_list_size = num_rows / num_offsets;
 
-  // Packed radix folds validity into the key, so nulls need no separate pass, at any list size.
-  if (key.has_nulls()) { return fixed_width_sort_path::packed_radix; }
+  // Types the tiered key can't encode: keep main's packed-radix-or-CUB decision.
+  if (not is_tiered_sort_supported(type)) {
+    return (key.has_nulls() or not prefer_cub_segmented_sort(num_rows, num_offsets))
+             ? fixed_width_sort_path::packed_radix
+             : fixed_width_sort_path::comparison;
+  }
+  // Tiered sort folds validity into the key, so nulls need no separate pass, at any list size.
+  if (key.has_nulls()) { return fixed_width_sort_path::tiered; }
   // Long lists amortize the global packed-key radix's bandwidth-bound pass.
   if (avg_list_size >= MAX_AVG_LIST_SIZE_FOR_FAST_SORT) {
     return fixed_width_sort_path::packed_radix;
   }
-  // The short no-null remainder keeps main's CUB-or-comparison decision.
-  return fixed_width_sort_path::comparison;
+  // Floating point no-null short: tiered across the range.
+  if (cudf::is_floating_point(type)) { return fixed_width_sort_path::tiered; }
+  // Eight-byte no-null: in the tiny-average pocket at a small offset count, CUB (via comparison)
+  // beats the tiered network tier until the offset count amortizes its launch setup
+  // (`EIGHT_BYTE_TINY_CUB_MAX_NUM_OFFSETS`); `num_offsets >= 2` matches the coverage probe's
+  // precondition. Above the pocket, tiered: the warp kernels beat CUB for INT64 mid-band lists.
+  // Chrono must stay off `cub_segmented` -- the CUB engine sorts only integral reps and would
+  // `CUDF_FAIL`.
+  if (cudf::size_of(type) == 8) {
+    // Chrono skips the pocket: the CUB engine sorts only integral reps, so the pocket's
+    // comparison route would strand a timestamp/duration on the plain comparison sort.
+    if (cudf::is_integral(type) and avg_list_size <= TIERED_NETWORK_CAP and num_offsets >= 2 and
+        num_offsets < EIGHT_BYTE_TINY_CUB_MAX_NUM_OFFSETS) {
+      return fixed_width_sort_path::comparison;
+    }
+    return fixed_width_sort_path::tiered;
+  }
+  // Four-byte no-null short: tiered; the block tier covers the mid band, so no CUB escape.
+  return fixed_width_sort_path::tiered;
 }
 
 }  // namespace detail

--- a/cpp/src/sort/segmented_sort_fixed_width.cu
+++ b/cpp/src/sort/segmented_sort_fixed_width.cu
@@ -1,0 +1,430 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "segmented_sort_fast.cuh"
+#include "segmented_sort_keys.cuh"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cub/device/device_radix_sort.cuh>
+#include <cuda/iterator>
+#include <cuda/std/algorithm>
+#include <cuda/std/bit>
+#include <cuda/std/cmath>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+#include <thrust/sequence.h>
+#include <thrust/transform.h>
+
+namespace cudf {
+namespace detail {
+namespace {
+
+/**
+ * @brief Maps a fixed-width value to the unsigned key whose ascending order equals value order
+ *
+ * Signed integrals flip the sign bit; chrono types encode their integer rep; floating point takes
+ * the order-preserving IEEE-754 flip with every NaN mapped to all-ones (NaNs tie, sorting after
+ * +Inf). The transform runs at the input width; the caller's zero-extension adds equal high bits
+ * that cannot reorder. Non-integral branches resolve first: `make_unsigned_t` is ill-formed for
+ * floating-point and chrono types.
+ */
+template <typename T>
+__device__ inline cuda::std::uint32_t radix_encode_u32(T value)
+{
+  if constexpr (cuda::std::is_same_v<T, bool>) {
+    return value ? cuda::std::uint32_t{1} : cuda::std::uint32_t{0};
+  } else if constexpr (cudf::is_timestamp<T>()) {
+    return radix_encode_u32(value.time_since_epoch().count());
+  } else if constexpr (cudf::is_duration<T>()) {
+    return radix_encode_u32(value.count());
+  } else if constexpr (cuda::std::is_floating_point_v<T>) {
+    if (cuda::std::isnan(value)) { return ~cuda::std::uint32_t{0}; }
+    auto const bits          = cuda::std::bit_cast<cuda::std::uint32_t>(value);
+    auto constexpr sign_mask = cuda::std::uint32_t{1} << (sizeof(cuda::std::uint32_t) * 8 - 1);
+    return (bits & sign_mask) ? ~bits : (bits | sign_mask);
+  } else {
+    using U      = cuda::std::make_unsigned_t<T>;
+    auto encoded = static_cast<U>(value);
+    if constexpr (cuda::std::is_signed_v<T>) {
+      encoded ^= static_cast<U>(U{1} << (sizeof(U) * 8 - 1));
+    }
+    return static_cast<cuda::std::uint32_t>(encoded);
+  }
+}
+
+/**
+ * @brief Eight-byte analogue of `radix_encode_u32`: the same transforms at 64 bits
+ */
+template <typename T>
+__device__ inline cuda::std::uint64_t radix_encode_u64(T value)
+{
+  if constexpr (cudf::is_timestamp<T>()) {
+    return radix_encode_u64(value.time_since_epoch().count());
+  } else if constexpr (cudf::is_duration<T>()) {
+    return radix_encode_u64(value.count());
+  } else if constexpr (cuda::std::is_floating_point_v<T>) {
+    if (cuda::std::isnan(value)) { return ~cuda::std::uint64_t{0}; }
+    auto const bits          = cuda::std::bit_cast<cuda::std::uint64_t>(value);
+    auto constexpr sign_mask = cuda::std::uint64_t{1} << (sizeof(cuda::std::uint64_t) * 8 - 1);
+    return (bits & sign_mask) ? ~bits : (bits | sign_mask);
+  } else {
+    using U      = cuda::std::make_unsigned_t<T>;
+    auto encoded = static_cast<U>(value);
+    if constexpr (cuda::std::is_signed_v<T>) {
+      encoded ^= static_cast<U>(U{1} << (sizeof(U) * 8 - 1));
+    }
+    return static_cast<cuda::std::uint64_t>(encoded);
+  }
+}
+
+/**
+ * @brief Builds the single-`uint64` packed key for a fixed-width element of width four bytes or
+ * less
+ *
+ * Layout, most- to least-significant: `[segment : S bits][class : 1 bit][value : 32 bits]` with
+ * `S = bit_width(num_segments)`, so an unsigned compare orders by segment, then the polarity's
+ * null placement, then the radix-encoded value (complemented within its field when descending).
+ * The class bit sits above the value field and (since `S <= 31`) below the segment field, so a
+ * null -- value zero, unread -- sorts on its configured side of every valid element; the gap bits
+ * are zero for all elements.
+ */
+template <typename T>
+struct numeric_packed_key_builder {
+  size_type const* d_segment_ids;
+  column_device_view const d_input;
+  bool const has_nulls;
+  int const segment_bits;
+  sort_polarity const polarity;
+  __device__ cuda::std::uint64_t operator()(size_type idx) const
+  {
+    auto const segment_part = static_cast<cuda::std::uint64_t>(d_segment_ids[idx])
+                              << (64 - segment_bits);
+    if (has_nulls && d_input.is_null(idx)) {
+      return segment_part | (static_cast<cuda::std::uint64_t>(polarity.element_class(true))
+                             << (sizeof(cuda::std::uint32_t) * 8));
+    }
+    return segment_part |
+           (static_cast<cuda::std::uint64_t>(polarity.element_class(false))
+            << (sizeof(cuda::std::uint32_t) * 8)) |
+           static_cast<cuda::std::uint64_t>(radix_encode_u32<T>(d_input.element<T>(idx)) ^
+                                            polarity.value_mask32());
+  }
+};
+
+/**
+ * @brief Builds the `prefix_key96` packed key for an eight-byte fixed-width element
+ *
+ * Reuses the strings path's key: `seg_null` packs the segment ordinal and the polarity's class bit
+ * (via `pack_seg_null`), so the segment dominates and a null sorts on its configured side; the
+ * window words carry the encoded 64-bit value split hi/lo -- complemented when descending, which
+ * distributes over the split. A null leaves the value words zero.
+ */
+template <typename T>
+struct numeric_packed_key_builder64 {
+  size_type const* d_segment_ids;
+  column_device_view const d_input;
+  bool const has_nulls;
+  sort_polarity const polarity;
+  __device__ prefix_key96 operator()(size_type idx) const
+  {
+    auto const segment = static_cast<cuda::std::uint32_t>(d_segment_ids[idx]);
+    if (has_nulls && d_input.is_null(idx)) {
+      return prefix_key96{pack_seg_null(segment, polarity.element_class(true)), 0u, 0u};
+    }
+    prefix_key96 key{pack_seg_null(segment, polarity.element_class(false)), 0u, 0u};
+    split_prefix(radix_encode_u64<T>(d_input.element<T>(idx)) ^ polarity.value_mask64(),
+                 key.prefix_hi,
+                 key.prefix_lo);
+    return key;
+  }
+};
+
+/**
+ * @brief Builds a radix key for each input index via `build_key`, then two-call
+ * `cub::DeviceRadixSort::SortPairs` orders the paired index array by it
+ *
+ * Shared by every packed-radix branch that builds a key column then radix-sorts an index array by
+ * it: only the key type, key builder, optional decomposer, and end bit differ per call site. This
+ * overload covers a directly radix-sortable unsigned integer key (no decomposer); the sibling
+ * overload below covers a struct key (`prefix_key96`) CUB needs help decomposing.
+ */
+template <typename KeyT, typename IndexIteratorT, typename KeyBuilder>
+void build_and_radix_sort_packed_keys(IndexIteratorT d_indices_in,
+                                      size_type count,
+                                      KeyBuilder const& build_key,
+                                      int end_bit,
+                                      size_type const* d_values_in,
+                                      size_type* d_values_out,
+                                      rmm::cuda_stream_view stream)
+{
+  auto const alloc = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<KeyT> keys_in(count, stream);
+  rmm::device_uvector<KeyT> keys_out(count, stream);
+  thrust::transform(rmm::exec_policy_nosync(stream, alloc),
+                    d_indices_in,
+                    d_indices_in + count,
+                    keys_in.begin(),
+                    build_key);
+  rmm::device_buffer d_temp_storage;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                  temp_storage_bytes,
+                                  keys_in.data(),
+                                  keys_out.data(),
+                                  d_values_in,
+                                  d_values_out,
+                                  count,
+                                  0,
+                                  end_bit,
+                                  stream.value());
+  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                  temp_storage_bytes,
+                                  keys_in.data(),
+                                  keys_out.data(),
+                                  d_values_in,
+                                  d_values_out,
+                                  count,
+                                  0,
+                                  end_bit,
+                                  stream.value());
+}
+
+/// Decomposer overload of `build_and_radix_sort_packed_keys` for a struct key (e.g.
+/// `prefix_key96`).
+template <typename KeyT, typename IndexIteratorT, typename KeyBuilder, typename DecomposerT>
+void build_and_radix_sort_packed_keys(IndexIteratorT d_indices_in,
+                                      size_type count,
+                                      KeyBuilder const& build_key,
+                                      DecomposerT const& decomposer,
+                                      int end_bit,
+                                      size_type const* d_values_in,
+                                      size_type* d_values_out,
+                                      rmm::cuda_stream_view stream)
+{
+  auto const alloc = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<KeyT> keys_in(count, stream);
+  rmm::device_uvector<KeyT> keys_out(count, stream);
+  thrust::transform(rmm::exec_policy_nosync(stream, alloc),
+                    d_indices_in,
+                    d_indices_in + count,
+                    keys_in.begin(),
+                    build_key);
+  rmm::device_buffer d_temp_storage;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                  temp_storage_bytes,
+                                  keys_in.data(),
+                                  keys_out.data(),
+                                  d_values_in,
+                                  d_values_out,
+                                  count,
+                                  decomposer,
+                                  0,
+                                  end_bit,
+                                  stream.value());
+  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                  temp_storage_bytes,
+                                  keys_in.data(),
+                                  keys_out.data(),
+                                  d_values_in,
+                                  d_values_out,
+                                  count,
+                                  decomposer,
+                                  0,
+                                  end_bit,
+                                  stream.value());
+}
+
+/**
+ * @brief Sorts a single fixed-width key column within its segments by one global radix sort
+ *
+ * The whole value is encoded into the key, so the radix order is final: elements of four bytes or
+ * less use one `uint64` key, eight-byte elements the `prefix_key96`. The paired sort value is the
+ * element index, so the sorted values are the segmented sorted order. The failing overload covers
+ * only the non-fixed-width types, which the caller's gate never dispatches.
+ */
+struct numeric_packed_sort_fn {
+  // Compile-time counterpart of `is_numeric_packed_radix_supported` after `dispatch_storage_type`
+  // mapping: widen the two together. The DECIMAL128 rep is enabled here but fenced off at run time.
+  template <typename T>
+  static constexpr bool is_supported()
+  {
+    return cudf::is_integral<T>() or cudf::is_floating_point<T>() or cudf::is_chrono<T>();
+  }
+
+  template <typename T, CUDF_ENABLE_IF(is_supported<T>())>
+  void operator()(column_device_view const& d_input,
+                  size_type const* d_segment_ids,
+                  bool has_nulls,
+                  sort_polarity polarity,
+                  int segment_bits,
+                  size_type num_elements,
+                  size_type* d_indices_out,
+                  rmm::cuda_stream_view stream) const
+  {
+    auto const counting = cuda::counting_iterator<size_type>{0};
+    rmm::device_uvector<size_type> indices_in(num_elements, stream);
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     indices_in.begin(),
+                     indices_in.end(),
+                     0);
+
+    if constexpr (sizeof(T) <= 4) {
+      // S = bit_width(num_segments) <= 31, so S + 1 + 32 <= 64: the three fields always fit.
+      static_assert(cuda::std::bit_width(static_cast<cuda::std::uint64_t>(
+                      cuda::std::numeric_limits<size_type>::max())) +
+                        1 + 32 <=
+                      64,
+                    "packed numeric key fields exceed the 64-bit key for some segment count");
+      // The segment rides the key's high bits, so the end bit cannot be tightened.
+      build_and_radix_sort_packed_keys<cuda::std::uint64_t>(
+        counting,
+        num_elements,
+        numeric_packed_key_builder<T>{d_segment_ids, d_input, has_nulls, segment_bits, polarity},
+        static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+        indices_in.data(),
+        d_indices_out,
+        stream);
+    } else if constexpr (sizeof(T) == 8) {
+      // seg_null packs (segment << 1) | flag, so the shift must fit a uint32.
+      static_assert(2ull * cuda::std::numeric_limits<size_type>::max() + 1ull <=
+                      cuda::std::numeric_limits<cuda::std::uint32_t>::max(),
+                    "size_type segment label does not fit prefix_key96::seg_null after the shift");
+      // seg_null needs only segment_bits + 1 bits; the constant-zero high bits skip radix passes.
+      auto const key_bits = cuda::std::min(static_cast<int>(sizeof(prefix_key96) * 8),
+                                           64 + cuda::std::min(32, segment_bits + 1));
+      build_and_radix_sort_packed_keys<prefix_key96>(
+        counting,
+        num_elements,
+        numeric_packed_key_builder64<T>{d_segment_ids, d_input, has_nulls, polarity},
+        prefix_decomposer{},
+        key_bits,
+        indices_in.data(),
+        d_indices_out,
+        stream);
+    } else {
+      // Unreached fail-safe: the run-time gate excludes the DECIMAL128 (`__int128`) rep.
+      CUDF_FAIL("Column type cannot be used with the numeric packed-radix segmented sort");
+    }
+  }
+
+  template <typename T, CUDF_ENABLE_IF(not is_supported<T>())>
+  void operator()(column_device_view const&,
+                  size_type const*,
+                  bool,
+                  sort_polarity,
+                  int,
+                  size_type,
+                  size_type*,
+                  rmm::cuda_stream_view) const
+  {
+    CUDF_FAIL("Column type cannot be used with the numeric packed-radix segmented sort");
+  }
+};
+
+/**
+ * @brief Run-time predicate for the numeric packed-radix fast path: every fixed-width type the
+ * packed key encodes losslessly
+ *
+ * @param type The key column's data type
+ * @return true if the type is eligible for the packed-radix fast path
+ */
+inline bool is_numeric_packed_radix_supported(data_type type)
+{
+  return cudf::is_integral(type) or
+         (cudf::is_fixed_point(type) and type.id() != type_id::DECIMAL128) or
+         cudf::is_floating_point(type) or cudf::is_chrono(type);
+}
+
+}  // namespace
+
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_numeric_packed(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_elements = input.size();
+  auto const num_segments = segment_offsets.size() - 1;
+  CUDF_EXPECTS(num_segments >= 1, "the packed key layout requires at least one segment");
+
+  // Dense segment ordinals: the key's segment field needs only bit_width(num_segments) bits; an
+  // empty segment skips a label, preserving cross-segment order.
+  rmm::device_uvector<size_type> segment_ids(num_elements, stream);
+  label_segments(segment_offsets.begin<size_type>(),
+                 segment_offsets.end<size_type>(),
+                 segment_ids.begin(),
+                 segment_ids.end(),
+                 stream);
+
+  auto const d_input   = column_device_view::create(input, stream);
+  auto const has_nulls = input.has_nulls();
+
+  // The packed key reserves a null class only when nullable; pin the caller-side coupling the
+  // strings path also asserts, so a null-free column can never arrive with `nulls_first` set.
+  CUDF_EXPECTS(has_nulls or not polarity.nulls_first,
+               "nulls_first requires a nullable column for the packed key layout");
+
+  auto const segment_bits =
+    static_cast<int>(cuda::std::bit_width(static_cast<cuda::std::uint64_t>(num_segments)));
+
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
+
+  // Storage-type dispatch: DECIMAL32/64 sort by their int32/int64 rep.
+  cudf::type_dispatcher<dispatch_storage_type>(input.type(),
+                                               numeric_packed_sort_fn{},
+                                               *d_input,
+                                               segment_ids.data(),
+                                               has_nulls,
+                                               polarity,
+                                               segment_bits,
+                                               num_elements,
+                                               sorted_indices->mutable_view().begin<size_type>(),
+                                               stream);
+  return sorted_indices;
+}
+
+fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
+                                                   size_type num_rows,
+                                                   column_view const& segment_offsets,
+                                                   [[maybe_unused]] rmm::cuda_stream_view stream)
+{
+  auto const type = key.type();
+  // String / nested keys have no fixed-width fast path.
+  if (not is_numeric_packed_radix_supported(type)) { return fixed_width_sort_path::comparison; }
+
+  // avg_list_size uses num_rows / num_offsets, the heuristic prefer_cub_segmented_sort also uses.
+  auto const num_offsets   = segment_offsets.size();
+  auto const avg_list_size = num_rows / num_offsets;
+
+  // Packed radix folds validity into the key, so nulls need no separate pass, at any list size.
+  if (key.has_nulls()) { return fixed_width_sort_path::packed_radix; }
+  // Long lists amortize the global packed-key radix's bandwidth-bound pass.
+  if (avg_list_size >= MAX_AVG_LIST_SIZE_FOR_FAST_SORT) {
+    return fixed_width_sort_path::packed_radix;
+  }
+  // The short no-null remainder keeps main's CUB-or-comparison decision.
+  return fixed_width_sort_path::comparison;
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/sort/segmented_sort_fixed_width.cu
+++ b/cpp/src/sort/segmented_sort_fixed_width.cu
@@ -9,6 +9,7 @@
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/device_scalar.hpp>
 #include <cudf/detail/labeling/label_segments.cuh>
 #include <cudf/detail/utilities/assert.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
@@ -27,6 +28,7 @@
 #include <cub/block/block_merge_sort.cuh>
 #include <cub/device/device_partition.cuh>
 #include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_scan.cuh>
 #include <cub/device/device_select.cuh>
 #include <cub/warp/warp_merge_sort.cuh>
 #include <cuda/iterator>
@@ -36,9 +38,14 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
+#include <thrust/copy.h>
+#include <thrust/count.h>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
+#include <thrust/transform_reduce.h>
+
+#include <utility>
 
 namespace cudf {
 namespace detail {
@@ -176,12 +183,183 @@ struct numeric_packed_key_builder64 {
   }
 };
 
+// A DECIMAL128 segment set sorts by the narrowest lossless radix key its value range admits,
+// rather than an unconditional twenty-pass 160-bit key: a min-biased `uint64` (range < 2^32, eight
+// passes), a `prefix_key96` (fits int64, twelve passes), or a two-phase hi64-then-lo64 sort.
+// Shared by the full-column and compact-large-segment DECIMAL128 radix sites.
+
 /**
- * @brief Common per-column sort parameters shared by the packed-radix engine
+ * @brief Inclusive value range [min, max] over the `__int128` elements a radix site is about to
+ * sort
  *
- * Bundles the column, its null/segment/polarity metadata, and the stream so the sort entry points
- * that operate on a whole segmented column share one parameter list instead of repeating the same
- * six arguments. `tiered_sort_fn` is intentionally excluded: it derives
+ * Drives the key-width gate. Nulls contribute the identity: placed by key class alone, their
+ * values are never compared.
+ */
+struct dec128_value_range {
+  __int128_t min_val;
+  __int128_t max_val;
+};
+
+// Identity: min = largest, max = smallest `__int128`; a null-only/empty set leaves min > max.
+__host__ __device__ inline dec128_value_range dec128_value_range_identity()
+{
+  auto constexpr i128_max = static_cast<__int128_t>((static_cast<unsigned __int128>(1) << 127) - 1);
+  return dec128_value_range{i128_max, static_cast<__int128_t>(-i128_max - 1)};
+}
+
+/// Min of minima, max of maxima; associative and commutative as `transform_reduce` requires.
+struct dec128_value_range_combine {
+  __device__ dec128_value_range operator()(dec128_value_range const& a,
+                                           dec128_value_range const& b) const
+  {
+    return dec128_value_range{a.min_val < b.min_val ? a.min_val : b.min_val,
+                              a.max_val > b.max_val ? a.max_val : b.max_val};
+  }
+};
+
+/// Maps a global element index to its single-value range; a null contributes the identity
+struct dec128_value_range_fn {
+  column_device_view d_input;
+  bool has_nulls;
+  __device__ dec128_value_range operator()(size_type idx) const
+  {
+    if (has_nulls && d_input.is_null(idx)) { return dec128_value_range_identity(); }
+    auto const value = d_input.element<__int128_t>(idx);
+    return dec128_value_range{value, value};
+  }
+};
+
+/**
+ * @brief Builds the single-`uint64` gate key for a DECIMAL128 element when the column-wide value
+ * range spans fewer than 2^32 (the min-biased path)
+ *
+ * `numeric_packed_key_builder`'s layout with the value `v - min_val`: monotonic in `v` and inside
+ * 32 bits, so the same segment/class/value order at eight byte-passes instead of twenty.
+ */
+struct dec128_biased_u64_key_builder {
+  size_type const* d_segment_ids;
+  column_device_view const d_input;
+  bool const has_nulls;
+  int const segment_bits;
+  __int128_t const min_val;
+  sort_polarity const polarity;
+  __device__ cuda::std::uint64_t operator()(size_type idx) const
+  {
+    auto const segment_part = static_cast<cuda::std::uint64_t>(d_segment_ids[idx])
+                              << (64 - segment_bits);
+    if (has_nulls && d_input.is_null(idx)) {
+      return segment_part | (static_cast<cuda::std::uint64_t>(polarity.element_class(true))
+                             << (sizeof(cuda::std::uint32_t) * 8));
+    }
+    auto const biased = static_cast<cuda::std::uint32_t>(
+      static_cast<unsigned __int128>(d_input.element<__int128_t>(idx)) -
+      static_cast<unsigned __int128>(min_val));
+    return segment_part |
+           (static_cast<cuda::std::uint64_t>(polarity.element_class(false))
+            << (sizeof(cuda::std::uint32_t) * 8)) |
+           static_cast<cuda::std::uint64_t>(biased ^ polarity.value_mask32());
+  }
+};
+
+/**
+ * @brief Builds the `prefix_key96` gate key for a DECIMAL128 element whose value fits `int64`
+ *
+ * `numeric_packed_key_builder64`'s layout with the rep narrowed to `int64` -- lossless, the caller
+ * guarantees representability -- at twelve byte-passes instead of twenty.
+ */
+struct dec128_int64_key_builder {
+  size_type const* d_segment_ids;
+  column_device_view const d_input;
+  bool const has_nulls;
+  sort_polarity const polarity;
+  __device__ prefix_key96 operator()(size_type idx) const
+  {
+    auto const segment = static_cast<cuda::std::uint32_t>(d_segment_ids[idx]);
+    if (has_nulls && d_input.is_null(idx)) {
+      return prefix_key96{pack_seg_null(segment, polarity.element_class(true)), 0u, 0u};
+    }
+    prefix_key96 key{pack_seg_null(segment, polarity.element_class(false)), 0u, 0u};
+    split_prefix(radix_encode_u64<int64_t>(static_cast<int64_t>(d_input.element<__int128_t>(idx))) ^
+                   polarity.value_mask64(),
+                 key.prefix_hi,
+                 key.prefix_lo);
+    return key;
+  }
+};
+
+/**
+ * @brief Phase-one key of the two-phase DECIMAL128 sort: `prefix_key96` {seg_null, high 64 bits}
+ *
+ * The value words carry the high 64 bits of the sign-flipped encoding, complemented when
+ * descending -- equal high words stay equal, so the phase-two tie set is polarity-independent. A
+ * null sets its class bit and leaves the words zero.
+ */
+struct dec128_hi64_key_builder {
+  size_type const* d_segment_ids;
+  column_device_view const d_input;
+  bool const has_nulls;
+  sort_polarity const polarity;
+  __device__ prefix_key96 operator()(size_type idx) const
+  {
+    auto const segment = static_cast<cuda::std::uint32_t>(d_segment_ids[idx]);
+    if (has_nulls && d_input.is_null(idx)) {
+      return prefix_key96{pack_seg_null(segment, polarity.element_class(true)), 0u, 0u};
+    }
+    prefix_key96 key{pack_seg_null(segment, polarity.element_class(false)), 0u, 0u};
+    auto const encoded = radix_encode_u128<__int128_t>(d_input.element<__int128_t>(idx));
+    split_prefix(static_cast<cuda::std::uint64_t>(encoded >> 64) ^ polarity.value_mask64(),
+                 key.prefix_hi,
+                 key.prefix_lo);
+    return key;
+  }
+};
+
+/**
+ * @brief Phase-two key of the two-phase DECIMAL128 sort: `prefix_key96` {run rank, low 64 bits}
+ *
+ * Applied to the (all non-null) elements still tied after phase one. The dense one-based run rank
+ * keeps distinct (segment, hi64) runs apart; the low word -- untouched by the bit-127 flip,
+ * complemented when descending -- orders within a run. `d_child` maps each tied slot to its
+ * element's global index.
+ */
+struct dec128_lo64_key_builder {
+  cuda::std::uint32_t const* d_run_ids;
+  size_type const* d_child;
+  column_device_view const d_input;
+  sort_polarity const polarity;
+  __device__ prefix_key96 operator()(size_type i) const
+  {
+    prefix_key96 key{pack_seg_null(d_run_ids[i], 0u), 0u, 0u};
+    auto const value = static_cast<unsigned __int128>(d_input.element<__int128_t>(d_child[i]));
+    split_prefix(static_cast<cuda::std::uint64_t>(value) ^ polarity.value_mask64(),
+                 key.prefix_hi,
+                 key.prefix_lo);
+    return key;
+  }
+};
+
+/**
+ * @brief Run-head flag over the tied subset, reading the sorted phase-one keys through `d_pos`
+ *
+ * The indirection spares materializing the compacted keys -- a dominant peak-memory term when most
+ * elements tie.
+ */
+struct gathered_key_head_flag {
+  prefix_key96 const* d_keys;
+  size_type const* d_pos;
+  __device__ cuda::std::uint32_t operator()(size_type i) const
+  {
+    if (i == 0) { return 1u; }
+    return keys_equal(d_keys[d_pos[i - 1]], d_keys[d_pos[i]]) ? 0u : 1u;
+  }
+};
+
+/**
+ * @brief Common per-column sort parameters shared by the packed-radix and DECIMAL128 engines
+ *
+ * Bundles the column, its null/segment/polarity metadata, and the stream so the four sort entry
+ * points that operate on a whole segmented column share one parameter list instead of repeating
+ * the same six arguments. `tiered_sort_fn` is intentionally excluded: it derives
  * `d_segment_ids`/`segment_bits` lazily, only inside its radix-spill branch, and forcing that work
  * eager for struct uniformity would change when it happens on the common path.
  */
@@ -195,13 +373,214 @@ struct segment_sort_context {
 };
 
 /**
+ * @brief Two-phase DECIMAL128 sort: order by the high 64 value bits, then resolve exact hi64 ties
+ * by the low 64 bits
+ *
+ * `d_order[j]` receives the global index of the j-th smallest element. Correct because the
+ * sign-flipped 128-bit encoding compares lexicographically hi64 then lo64: phase one orders every
+ * element whose (segment, hi64) differs, and only exact ties -- nulls excluded, being
+ * position-final -- are re-sorted by {dense run rank, lo64} and scattered back into their
+ * (ascending) slots. Each phase trims the radix end bit to its leading field's significant width.
+ *
+ * Tie density can reach every element, so the working set is held to the live minimum: both radix
+ * sorts run ping-pong in caller-owned `cub::DoubleBuffer`s (CUB then keeps no key/value copies in
+ * its temp storage), phase-one scratch is released before phase two allocates, and the tied keys
+ * are read through the compacted positions instead of re-materialized.
+ */
+inline void dec128_two_phase_sort(segment_sort_context const& ctx,
+                                  size_type const* global_indices,
+                                  size_type num_elements,
+                                  size_type* d_order)
+{
+  // Locals preserve the body's original parameter names; only the call boundary changed.
+  auto const& d_input      = ctx.d_input;
+  auto const d_segment_ids = ctx.d_segment_ids;
+  auto const has_nulls     = ctx.has_nulls;
+  auto const polarity      = ctx.polarity;
+  auto const segment_bits  = ctx.segment_bits;
+  auto const stream        = ctx.stream;
+  // seg_null packs (rank << 1) | flag, so the shift must fit a uint32.
+  static_assert(2ull * cuda::std::numeric_limits<size_type>::max() + 1ull <=
+                  cuda::std::numeric_limits<cuda::std::uint32_t>::max(),
+                "size_type run rank does not fit prefix_key96::seg_null after the shift");
+  auto const alloc      = cudf::get_current_device_resource_ref();
+  auto const counting   = cuda::counting_iterator<size_type>{0};
+  auto const decomposer = prefix_decomposer{};
+  // seg_null needs only segment_bits + 1 bits; the constant-zero high bits skip radix passes.
+  auto const phase1_end = cuda::std::min(static_cast<int>(sizeof(prefix_key96) * 8),
+                                         64 + cuda::std::min(32, segment_bits + 1));
+
+  // Phase one: sort by (segment, null, hi64), ping-pong in `cub::DoubleBuffer`s. Either half of a
+  // pair may hold the result, so the sorted halves are routed back to `k1` / `d_order` afterward.
+  rmm::device_uvector<prefix_key96> k1(num_elements, stream);
+  {
+    rmm::device_uvector<prefix_key96> keys_in(num_elements, stream);
+    thrust::transform(rmm::exec_policy_nosync(stream, alloc),
+                      global_indices,
+                      global_indices + num_elements,
+                      keys_in.begin(),
+                      dec128_hi64_key_builder{d_segment_ids, d_input, has_nulls, polarity});
+    // The sort scribbles on both value halves and the radix-tier caller reads `global_indices`
+    // again as its scatter map, so the indices are staged into `d_order` + a scratch alternate.
+    rmm::device_uvector<size_type> vals_alt(num_elements, stream);
+    thrust::copy(rmm::exec_policy_nosync(stream, alloc),
+                 global_indices,
+                 global_indices + num_elements,
+                 d_order);
+    cub::DoubleBuffer<prefix_key96> d_keys(keys_in.data(), k1.data());
+    cub::DoubleBuffer<size_type> d_values(d_order, vals_alt.data());
+    {
+      rmm::device_buffer d_temp_storage;
+      size_t temp_storage_bytes = 0;
+      cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                      temp_storage_bytes,
+                                      d_keys,
+                                      d_values,
+                                      num_elements,
+                                      decomposer,
+                                      0,
+                                      phase1_end,
+                                      stream.value());
+      d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+      cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                      temp_storage_bytes,
+                                      d_keys,
+                                      d_values,
+                                      num_elements,
+                                      decomposer,
+                                      0,
+                                      phase1_end,
+                                      stream.value());
+    }
+    // Swap so `k1` owns the current key buffer (the stale half dies with this scope); copy the
+    // values back only if they landed in the scratch half.
+    if (d_keys.Current() != k1.data()) { std::swap(k1, keys_in); }
+    if (d_values.Current() != d_order) {
+      thrust::copy(rmm::exec_policy_nosync(stream, alloc),
+                   d_values.Current(),
+                   d_values.Current() + num_elements,
+                   d_order);
+    }
+  }
+
+  // Zero-tie gate: on distinct-hi64 data nothing ties and phase one is the order.
+  auto const any_tied =
+    thrust::count_if(rmm::exec_policy_nosync(stream, alloc),
+                     counting,
+                     counting + num_elements,
+                     key_tied_flag{k1.data(), num_elements, polarity.element_class(true)}) > 0;
+  if (not any_tied) { return; }
+
+  // Compact the tied slots' output positions and global indices; the keys stay uncompacted and
+  // are read through `comp_pos` instead.
+  rmm::device_uvector<bool> tied_flags(num_elements, stream);
+  thrust::transform(rmm::exec_policy_nosync(stream, alloc),
+                    counting,
+                    counting + num_elements,
+                    tied_flags.begin(),
+                    key_tied_flag{k1.data(), num_elements, polarity.element_class(true)});
+  auto const num_tied = static_cast<size_type>(thrust::count(
+    rmm::exec_policy_nosync(stream, alloc), tied_flags.begin(), tied_flags.end(), true));
+
+  rmm::device_uvector<size_type> comp_pos(num_tied, stream);
+  rmm::device_uvector<size_type> child(num_tied, stream);
+  cudf::detail::device_scalar<size_type> d_num_tied(stream);
+  cub_select_flagged(
+    counting, tied_flags.data(), comp_pos.data(), d_num_tied.data(), num_elements, stream);
+  cub_select_flagged(
+    d_order, tied_flags.data(), child.data(), d_num_tied.data(), num_elements, stream);
+  // Release phase-one-only scratch before the phase-two buffers stack on it: on tie-dense data
+  // the live buffers, not any single sort, set the peak.
+  tied_flags.resize(0, stream);
+  tied_flags.shrink_to_fit(stream);
+
+  // Dense one-based run rank over the tied subset: one rank per (segment, hi64) run.
+  rmm::device_uvector<cuda::std::uint32_t> run_ids(num_tied, stream);
+  thrust::transform(rmm::exec_policy_nosync(stream, alloc),
+                    counting,
+                    counting + num_tied,
+                    run_ids.begin(),
+                    gathered_key_head_flag{k1.data(), comp_pos.data()});
+  {
+    rmm::device_buffer d_temp_storage;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                  temp_storage_bytes,
+                                  run_ids.data(),
+                                  run_ids.data(),
+                                  num_tied,
+                                  stream.value());
+    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+    cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                  temp_storage_bytes,
+                                  run_ids.data(),
+                                  run_ids.data(),
+                                  num_tied,
+                                  stream.value());
+  }
+  // The sorted keys are dead once the run heads exist; release before phase two allocates.
+  k1.resize(0, stream);
+  k1.shrink_to_fit(stream);
+
+  // Phase two: sort the tied subset by {run rank, lo64}; the end bit trims to the rank field's
+  // bit_width(num_tied) + 1 significant bits.
+  auto const run_field_bits = cuda::std::min(
+    32, static_cast<int>(cuda::std::bit_width(static_cast<cuda::std::uint64_t>(num_tied))) + 1);
+  auto const phase2_end =
+    cuda::std::min(static_cast<int>(sizeof(prefix_key96) * 8), 64 + run_field_bits);
+  rmm::device_uvector<prefix_key96> p2_in(num_tied, stream);
+  rmm::device_uvector<prefix_key96> p2_out(num_tied, stream);
+  thrust::transform(rmm::exec_policy_nosync(stream, alloc),
+                    counting,
+                    counting + num_tied,
+                    p2_in.begin(),
+                    dec128_lo64_key_builder{run_ids.data(), child.data(), d_input, polarity});
+  // The ranks are baked into the keys; release before the alternate value buffer allocates.
+  run_ids.resize(0, stream);
+  run_ids.shrink_to_fit(stream);
+  // Ping-pong again: either value half may end up current, so the scatter reads Current().
+  rmm::device_uvector<size_type> child_sorted(num_tied, stream);
+  cub::DoubleBuffer<prefix_key96> p2_keys(p2_in.data(), p2_out.data());
+  cub::DoubleBuffer<size_type> p2_values(child.data(), child_sorted.data());
+  {
+    rmm::device_buffer d_temp_storage;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    p2_keys,
+                                    p2_values,
+                                    num_tied,
+                                    decomposer,
+                                    0,
+                                    phase2_end,
+                                    stream.value());
+    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    p2_keys,
+                                    p2_values,
+                                    num_tied,
+                                    decomposer,
+                                    0,
+                                    phase2_end,
+                                    stream.value());
+  }
+  auto const* d_refined = p2_values.Current();
+  thrust::scatter(rmm::exec_policy_nosync(stream, alloc),
+                  d_refined,
+                  d_refined + num_tied,
+                  comp_pos.begin(),
+                  d_order);
+}
+
+/**
  * @brief Builds a radix key for each input index via `build_key`, then two-call
  * `cub::DeviceRadixSort::SortPairs` orders the paired index array by it
  *
- * Shared by every packed-radix branch that builds a key column then radix-sorts an index array by
- * it: only the key type, key builder, optional decomposer, and end bit differ per call site. This
- * overload covers a directly radix-sortable unsigned integer key (no decomposer); the sibling
- * overload below covers a struct key (`prefix_key96`) CUB needs help decomposing.
+ * Shared by every packed-radix / DECIMAL128 branch that builds a key column then radix-sorts an
+ * index array by it: only the key type, key builder, optional decomposer, and end bit differ per
+ * call site. This overload covers a directly radix-sortable unsigned integer key (no decomposer);
+ * the sibling overload below covers a struct key (`prefix_key96`) CUB needs help decomposing.
  */
 template <typename KeyT, typename IndexIteratorT, typename KeyBuilder>
 void build_and_radix_sort_packed_keys(IndexIteratorT d_indices_in,
@@ -293,21 +672,108 @@ void build_and_radix_sort_packed_keys(IndexIteratorT d_indices_in,
 }
 
 /**
+ * @brief Sorts a DECIMAL128 element set within its segments, picking the narrowest lossless radix
+ * key from the value range
+ *
+ * `global_indices` doubles as the paired sort value, so `d_order[j]` receives the global index of
+ * the j-th smallest element. One range reduction (nulls skipped, one D->H sync) picks the key:
+ * range < 2^32 -> min-biased `uint64` (eight passes), fits `int64` -> `prefix_key96` (twelve),
+ * else the two-phase hi64-then-lo64 sort -- never the twenty-pass 160-bit key.
+ */
+inline void dec128_segmented_radix_sort(segment_sort_context const& ctx,
+                                        size_type const* global_indices,
+                                        size_type num_elements,
+                                        size_type* d_order)
+{
+  // Locals preserve the body's original parameter names; only the call boundary changed.
+  auto const& d_input      = ctx.d_input;
+  auto const d_segment_ids = ctx.d_segment_ids;
+  auto const has_nulls     = ctx.has_nulls;
+  auto const polarity      = ctx.polarity;
+  auto const segment_bits  = ctx.segment_bits;
+  auto const stream        = ctx.stream;
+  // seg_null packs (segment << 1) | flag, so the shift must fit a uint32.
+  static_assert(2ull * cuda::std::numeric_limits<size_type>::max() + 1ull <=
+                  cuda::std::numeric_limits<cuda::std::uint32_t>::max(),
+                "size_type segment label does not fit the packed key's seg_null after the shift");
+  auto const alloc = cudf::get_current_device_resource_ref();
+
+  auto const range = thrust::transform_reduce(rmm::exec_policy_nosync(stream, alloc),
+                                              global_indices,
+                                              global_indices + num_elements,
+                                              dec128_value_range_fn{d_input, has_nulls},
+                                              dec128_value_range_identity(),
+                                              dec128_value_range_combine{});
+
+  enum class key_width { u64_biased, key96, twophase };
+  auto width         = key_width::twophase;
+  __int128_t min_val = 0;
+  if (range.max_val < range.min_val) {
+    // Null-only set: the order is width-independent, so take the cheapest.
+    width = key_width::u64_biased;
+  } else {
+    auto const span =
+      static_cast<unsigned __int128>(range.max_val) - static_cast<unsigned __int128>(range.min_val);
+    auto constexpr i64_min = static_cast<__int128_t>(cuda::std::numeric_limits<int64_t>::min());
+    auto constexpr i64_max = static_cast<__int128_t>(cuda::std::numeric_limits<int64_t>::max());
+    if ((span >> 32) == 0) {
+      width   = key_width::u64_biased;
+      min_val = range.min_val;
+    } else if (range.min_val >= i64_min and range.max_val <= i64_max) {
+      width = key_width::key96;
+    } else {
+      width = key_width::twophase;
+    }
+  }
+
+  if (width == key_width::u64_biased) {
+    // Min-biased uint64 key, eight byte-passes; the segment rides the high bits, so the end bit
+    // cannot be tightened.
+    build_and_radix_sort_packed_keys<cuda::std::uint64_t>(
+      global_indices,
+      num_elements,
+      dec128_biased_u64_key_builder{
+        d_segment_ids, d_input, has_nulls, segment_bits, min_val, polarity},
+      static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+      global_indices,
+      d_order,
+      stream);
+  } else if (width == key_width::key96) {
+    // Value fits int64: prefix_key96, twelve byte-passes, end bit trimmed to seg_null's width.
+    auto const key96_end = cuda::std::min(static_cast<int>(sizeof(prefix_key96) * 8),
+                                          64 + cuda::std::min(32, segment_bits + 1));
+    build_and_radix_sort_packed_keys<prefix_key96>(
+      global_indices,
+      num_elements,
+      dec128_int64_key_builder{d_segment_ids, d_input, has_nulls, polarity},
+      prefix_decomposer{},
+      key96_end,
+      global_indices,
+      d_order,
+      stream);
+  } else {
+    // Genuine 128-bit range: two-phase hi64-then-lo64.
+    dec128_two_phase_sort(ctx, global_indices, num_elements, d_order);
+  }
+}
+
+/**
  * @brief Sorts a single fixed-width key column within its segments by one global radix sort
  *
  * The whole value is encoded into the key, so the radix order is final: elements of four bytes or
- * less use one `uint64` key, eight-byte elements the `prefix_key96`. The paired sort value is the
- * element index, so the sorted values are the segmented sorted order. The failing overload covers
- * only the non-fixed-width types, which the caller's gate never dispatches.
+ * less use one `uint64` key, eight-byte elements the `prefix_key96`, and the `DECIMAL128` rep the
+ * narrowest key its value range admits. The paired sort value is the element index, so the sorted
+ * values are the segmented sorted order. The failing overload covers only the non-fixed-width
+ * types, which the caller's gate never dispatches.
  */
 struct numeric_packed_sort_fn {
-  // Compile-time counterpart of the runtime gate `is_numeric_packed_radix_supported`: widen the
-  // two together. `is_integral` also admits the 16-byte `__int128` rep, which the runtime gate
-  // fences off until its engine lands.
+  // Compile-time counterpart of `is_numeric_packed_radix_supported` after `dispatch_storage_type`
+  // mapping: the two must accept exactly the same types, so widen them together.
   template <typename T>
   static constexpr bool is_supported()
   {
-    return cudf::is_integral<T>() or cudf::is_floating_point<T>() or cudf::is_chrono<T>();
+    return cudf::is_integral<T>() or cudf::is_floating_point<T>() or cudf::is_chrono<T>() or
+           cuda::std::is_same_v<__int128, T>;
   }
 
   template <typename T, CUDF_ENABLE_IF(is_supported<T>())>
@@ -363,9 +829,9 @@ struct numeric_packed_sort_fn {
         d_indices_out,
         stream);
     } else {
-      // Unreached fail-safe: `is_numeric_packed_radix_supported` fences off the 16-byte
-      // DECIMAL128 rep until its engine lands.
-      CUDF_FAIL("Column type cannot be used with the numeric packed-radix segmented sort");
+      // DECIMAL128: the narrowest lossless key from the value range; `indices_in` is the key-build
+      // source and the paired sort value.
+      dec128_segmented_radix_sort(ctx, indices_in.data(), num_elements, d_indices_out);
     }
   }
 
@@ -380,16 +846,13 @@ struct numeric_packed_sort_fn {
  * @brief Run-time predicate for the numeric packed-radix fast path: every fixed-width type the
  * packed key encodes losslessly
  *
- * `DECIMAL128` (16-byte rep) stays excluded until its engine lands.
- *
  * @param type The key column's data type
  * @return true if the type is eligible for the packed-radix fast path
  */
 inline bool is_numeric_packed_radix_supported(data_type type)
 {
-  return cudf::is_integral(type) or
-         (cudf::is_fixed_point(type) and type.id() != type_id::DECIMAL128) or
-         cudf::is_floating_point(type) or cudf::is_chrono(type);
+  return cudf::is_integral(type) or cudf::is_fixed_point(type) or cudf::is_floating_point(type) or
+         cudf::is_chrono(type);
 }
 
 // ==========================================================================================
@@ -405,17 +868,24 @@ inline bool is_numeric_packed_radix_supported(data_type type)
 // ==========================================================================================
 
 /**
- * @brief Ordering key for the 16-byte (`__int128`) rep: a class flag over the hi/lo-split 128-bit
+ * @brief Ordering key for the DECIMAL128 tiered path: a class flag over the hi/lo-split 128-bit
  * value
  *
  * `flag` dominates (the polarity's classes below the pad); within the valid class the sign-flipped
- * value words -- complemented when descending -- give unsigned-compare == value order. 24 bytes; a
- * null or pad leaves the value words zero. Unused until the DECIMAL128 tiered engine lands.
+ * value words -- complemented when descending -- give unsigned-compare == value order. 24 bytes,
+ * the width the warp tier's register / shared budget is sized against; a null or pad leaves the
+ * value words zero.
  */
 struct tiered_key128 {
   cuda::std::uint64_t hi;
   cuda::std::uint64_t lo;
   cuda::std::uint32_t flag;
+  __device__ bool operator<(tiered_key128 const& o) const
+  {
+    if (flag != o.flag) { return flag < o.flag; }
+    if (hi != o.hi) { return hi < o.hi; }
+    return lo < o.lo;
+  }
 };
 static_assert(sizeof(tiered_key128) == 24 and alignof(tiered_key128) == 8,
               "tiered_key128 must stay 24 bytes with 8-byte alignment");
@@ -517,7 +987,7 @@ constexpr size_type TIERED_WARP_CAP = TIERED_WARP_LANES * TIERED_WARP_ITEMS;
 // Block tier: one 128-thread block per segment with `cub::BlockMergeSort`, in graduated
 // items-per-thread bands so a segment just over the warp cap pays a 128-slot tile rather than a
 // 1024-slot one. Without this rung mid-band list shapes spilled to the radix tier and regressed
-// below CUB `DeviceSegmentedSort`. The largest band's shared tile is ~16KB at the widest key,
+// below CUB `DeviceSegmentedSort`. The largest band's shared tile is ~25KB at the widest key,
 // inside the 48KB static budget.
 constexpr size_type TIERED_BLOCK_TIER_CAP = 1'024;
 
@@ -1102,8 +1572,7 @@ void launch_block_band(band_launch_ctx const& ctx,
  * @brief Run-time predicate for the tiered fast path on a key column's type
  *
  * Timestamps / durations flow through the same width-keyed path via their integer reps.
- * DECIMAL128, DECIMAL32/64, the narrower integrals, and non-fixed-width types fall through to the
- * paths below.
+ * DECIMAL32/64, the narrower integrals, and non-fixed-width types fall through to the paths below.
  *
  * @param type The key column's data type
  * @return true if the type is eligible for the tiered fast path
@@ -1111,7 +1580,7 @@ void launch_block_band(band_launch_ctx const& ctx,
 inline bool is_tiered_sort_supported(data_type type)
 {
   return type.id() == type_id::INT32 or type.id() == type_id::INT64 or
-         cudf::is_floating_point(type) or cudf::is_chrono(type);
+         type.id() == type_id::DECIMAL128 or cudf::is_floating_point(type) or cudf::is_chrono(type);
 }
 
 /**
@@ -1163,9 +1632,9 @@ void radix_sort_large_segments(segment_sort_context const& ctx,
       sorted_gidx.data(),
       stream);
   } else {
-    // Unreached fail-safe: `is_tiered_sort_supported` fences off the 16-byte DECIMAL128 rep
-    // until its engine lands.
-    CUDF_FAIL("Column type cannot be used with the tiered segmented sort");
+    // DECIMAL128: the narrowest lossless key from the subset's value range; `sorted_gidx`
+    // receives the subset's sorted order for the scatter below.
+    dec128_segmented_radix_sort(ctx, d_large_gidx, num_large_elems, sorted_gidx.data());
   }
 
   thrust::scatter(rmm::exec_policy_nosync(stream, alloc),
@@ -1402,7 +1871,8 @@ struct tiered_sort_fn {
   static constexpr bool is_supported()
   {
     return cuda::std::is_same_v<T, int32_t> or cuda::std::is_same_v<T, int64_t> or
-           cudf::is_floating_point<T>() or cudf::is_chrono<T>();
+           cuda::std::is_same_v<T, __int128_t> or cudf::is_floating_point<T>() or
+           cudf::is_chrono<T>();
   }
 
   template <typename T, CUDF_ENABLE_IF(is_supported<T>())>
@@ -1491,9 +1961,39 @@ struct tiered_sort_fn {
   }
 };
 
+// Measured crossover below which the tiered kernel beats CUB and the packed radix for every type.
+constexpr size_type TIERED_MAX_TINY_AVG_LIST_SIZE{4};
+
 // Segment-count ceiling for the eight-byte tiny-average pocket: below it CUB `DeviceSegmentedSort`
 // beats the tiered network tier, whose fixed per-launch setup has not yet amortized.
 constexpr size_type EIGHT_BYTE_TINY_CUB_MAX_NUM_OFFSETS{1 << 17};
+
+// Measured cap of CUB's 16-byte-pair merge tile; longer segments fall to a costly per-block radix.
+constexpr size_type DECIMAL128_CUB_MAX_SEGMENT_SIZE{32};
+
+/**
+ * @brief Whether a `DECIMAL128` mid-band column's segment shape favors CUB `DeviceSegmentedSort`
+ *
+ * CUB degrades on long segments, so the mid band takes it only when they are sparse: the oversized
+ * count scaled by the cap must stay within the segment count (a 64-bit product, against overflow).
+ * Costs one device count and host sync, paid only on the branch that calls it.
+ *
+ * @param segment_offsets The segment offsets (segment count plus one)
+ * @param stream CUDA stream used for the device count
+ * @return true if the segment shape favors CUB `DeviceSegmentedSort`
+ */
+inline bool decimal128_cub_segment_shape_ok(column_view const& segment_offsets,
+                                            rmm::cuda_stream_view stream)
+{
+  auto const num_segments = segment_offsets.size() - 1;
+  auto const d_offsets    = segment_offsets.begin<size_type>();
+  auto const oversized =
+    thrust::count_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     cuda::counting_iterator<size_type>{0},
+                     cuda::counting_iterator<size_type>{num_segments},
+                     segment_exceeds_size{d_offsets, DECIMAL128_CUB_MAX_SEGMENT_SIZE});
+  return static_cast<int64_t>(oversized) * DECIMAL128_CUB_MAX_SEGMENT_SIZE <= num_segments;
+}
 
 }  // namespace
 
@@ -1562,7 +2062,8 @@ constexpr size_type EIGHT_BYTE_TINY_CUB_MAX_NUM_OFFSETS{1 << 17};
   auto sorted_indices = cudf::make_numeric_column(
     data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
 
-  // `dispatch_storage_type` readies the decimal reps for when their tiered routing lands.
+  // Storage-type dispatch: DECIMAL128 sorts by its __int128 rep; DECIMAL32/64 and chrono types
+  // by their integer reps.
   cudf::type_dispatcher<dispatch_storage_type>(input.type(),
                                                tiered_sort_fn{},
                                                segment_offsets,
@@ -1579,7 +2080,7 @@ constexpr size_type EIGHT_BYTE_TINY_CUB_MAX_NUM_OFFSETS{1 << 17};
 fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
                                                    size_type num_rows,
                                                    column_view const& segment_offsets,
-                                                   [[maybe_unused]] rmm::cuda_stream_view stream)
+                                                   rmm::cuda_stream_view stream)
 {
   auto const type = key.type();
   // String / nested keys have no fixed-width fast path.
@@ -1600,6 +2101,16 @@ fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
   // Long lists amortize the global packed-key radix's bandwidth-bound pass.
   if (avg_list_size >= MAX_AVG_LIST_SIZE_FOR_FAST_SORT) {
     return fixed_width_sort_path::packed_radix;
+  }
+
+  // DECIMAL128 no-null: tiny -> tiered, sparse-large mid band -> lifted CUB, longer -> tiered.
+  if (type.id() == type_id::DECIMAL128) {
+    if (avg_list_size <= TIERED_MAX_TINY_AVG_LIST_SIZE) { return fixed_width_sort_path::tiered; }
+    if (avg_list_size <= DECIMAL128_CUB_MAX_AVG_LIST_SIZE and
+        decimal128_cub_segment_shape_ok(segment_offsets, stream)) {
+      return fixed_width_sort_path::cub_segmented;
+    }
+    return fixed_width_sort_path::tiered;
   }
   // Floating point no-null short: tiered across the range.
   if (cudf::is_floating_point(type)) { return fixed_width_sort_path::tiered; }

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -1,20 +1,27 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
+#include "segmented_sort_fast.cuh"
+#include "segmented_sort_keys.cuh"
 #include "sort.hpp"
 
+#include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/sequence.hpp>
 #include <cudf/detail/sorting.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cub/device/device_segmented_sort.cuh>
@@ -180,19 +187,19 @@ std::unique_ptr<column> fast_segmented_sorted_order(column_view const& input,
  * The segments are added to the input table-view keys so they
  * are lexicographically sorted within the segmented groups.
  *
- * ```
+ * @code{.pseudo}
  * Example 1:
  * num_rows = 10
  * offsets = {0, 3, 7, 10}
  * segment-indices -> { 3,3,3, 7,7,7,7, 10,10,10 }
- * ```
+ * @endcode
  *
- * ```
+ * @code{.pseudo}
  * Example 2: (offsets do not cover all indices)
  * num_rows = 10
  * offsets = {3, 7}
  * segment-indices -> { 0,1,2, 7,7,7,7, 8,9,10 }
- * ```
+ * @endcode
  *
  * @param num_rows Total number of rows in the input keys to sort
  * @param offsets The offsets identifying the segments
@@ -201,6 +208,34 @@ std::unique_ptr<column> fast_segmented_sorted_order(column_view const& input,
 rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
                                                    column_view const& offsets,
                                                    rmm::cuda_stream_view stream);
+
+/**
+ * @brief Whether the segment offsets span every row `[0, num_rows]`
+ *
+ * The fast paths label elements by dense segment ordinal and index the output by raw offset, so
+ * partial-coverage offsets -- allowed by the public contract -- must take the comparison path.
+ * Requiring at least two offsets also excludes `num_segments == 0`, whose zero-width segment field
+ * would shift a 64-bit packed key by 64 (undefined behavior).
+ *
+ * @param segment_offsets The segment offsets (segment count plus one)
+ * @param num_rows Element count the offsets must span
+ * @param stream CUDA stream used for the boundary reads
+ * @return true when there are at least two offsets spanning `[0, num_rows]`
+ */
+inline bool fast_path_offsets_cover_all_rows(column_view const& segment_offsets,
+                                             size_type num_rows,
+                                             rmm::cuda_stream_view stream)
+{
+  auto const num_offsets = segment_offsets.size();
+  if (num_offsets < 2) { return false; }
+  auto const first = cudf::detail::make_pinned_vector_async(
+    device_span<size_type const>{segment_offsets.begin<size_type>(), 1}, stream);
+  auto const last = cudf::detail::make_pinned_vector_async(
+    device_span<size_type const>{segment_offsets.begin<size_type>() + (num_offsets - 1), 1},
+    stream);
+  stream.synchronize();
+  return first[0] == 0 and last[0] == num_rows;
+}
 
 /**
  * @brief Segmented sorted-order utility
@@ -262,6 +297,20 @@ std::unique_ptr<column> segmented_sorted_order_common(
       keys.column(0), segment_offsets, col_order, stream, mr);
   }
 
+  // Unstable-only fast path for a single STRING key column sorted ascending with nulls last: a
+  // radix sort over packed leading-byte prefixes with byte-window tie-breaking. The order and null
+  // precedence must be explicit; any other configuration falls through to the comparison path.
+  if constexpr (method == sort_method::UNSTABLE) {
+    if (keys.num_columns() == 1 and keys.column(0).type().id() == type_id::STRING and
+        (segment_offsets.size() > 0) and column_order.size() == 1 and
+        column_order.front() == order::ASCENDING and null_precedence.size() == 1 and
+        null_precedence.front() == null_order::AFTER and
+        fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
+      return fast_segmented_sorted_order_strings_prefix(
+        keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+    }
+  }
+
   // Get segment id of each element in all segments.
   auto segment_ids = get_segment_indices(keys.num_rows(), segment_offsets, stream);
 
@@ -312,12 +361,19 @@ std::unique_ptr<table> segmented_sort_by_key_common(table_view const& values,
                                           stream,
                                           cudf::get_current_device_resource_ref());
   // Gather segmented sort of child value columns
-  return detail::gather(values,
-                        sorted_order->view(),
-                        out_of_bounds_policy::DONT_CHECK,
-                        negative_index_policy::NOT_ALLOWED,
-                        stream,
-                        mr);
+  auto result = detail::gather(values,
+                               sorted_order->view(),
+                               out_of_bounds_policy::DONT_CHECK,
+                               negative_index_policy::NOT_ALLOWED,
+                               stream,
+                               mr);
+  // A nullable but null-free input still yields a gather-allocated all-valid mask; release it so
+  // output columns are nullable only when they contain nulls.
+  for (auto i = size_type{0}; i < result->num_columns(); ++i) {
+    auto& col = result->get_column(i);
+    if (col.null_count() == 0) { col.set_null_mask(rmm::device_buffer{}, 0); }
+  }
+  return result;
 }
 
 }  // namespace detail

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -13,7 +13,6 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/gather.hpp>
-#include <cudf/detail/sequence.hpp>
 #include <cudf/detail/sorting.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/table/table_view.hpp>
@@ -23,11 +22,30 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_segmented_sort.cuh>
+#include <cuda/iterator>
+#include <thrust/for_each.h>
 
 namespace cudf {
 namespace detail {
+
+/**
+ * @brief Seeds the segmented sort's paired index buffers with the identity permutation
+ *
+ * `d_values_out` must start as the identity: the segmented sort leaves rows outside every segment
+ * unwritten, and the contract keeps such rows mapped to themselves.
+ */
+struct identity_seed_pair {
+  size_type* d_values_in;
+  size_type* d_values_out;
+  __device__ void operator()(size_type idx) const
+  {
+    d_values_in[idx]  = idx;
+    d_values_out[idx] = idx;
+  }
+};
 
 /**
  * @brief Functor performs faster segmented sort on eligible columns
@@ -77,10 +95,12 @@ struct column_fast_sort_fn {
                                                 stream,
                                                 cudf::get_current_device_resource_ref());
     mutable_column_view output_view = temp_col->mutable_view();
-    auto temp_indices =
-      cudf::column(cudf::column_view(indices.type(), indices.size(), indices.head(), nullptr, 0),
-                   stream,
-                   cudf::get_current_device_resource_ref());
+    // One pass seeds CUB's value-input buffer and identity-prefills the output `indices`.
+    rmm::device_uvector<size_type> temp_indices(input.size(), stream);
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       cuda::counting_iterator<size_type>{0},
+                       input.size(),
+                       identity_seed_pair{temp_indices.data(), indices.begin<size_type>()});
 
     // DeviceSegmentedSort is faster than DeviceSegmentedRadixSort at this time
     auto fast_sort_impl = [stream](bool ascending, [[maybe_unused]] auto&&... args) {
@@ -120,7 +140,7 @@ struct column_fast_sort_fn {
     fast_sort_impl(ascending,
                    input.begin<T>(),
                    output_view.begin<T>(),
-                   temp_indices.view().begin<size_type>(),
+                   temp_indices.data(),
                    indices.begin<size_type>(),
                    input.size(),
                    segment_offsets.size() - 1,
@@ -165,13 +185,9 @@ std::unique_ptr<column> fast_segmented_sorted_order(column_view const& input,
                                                     rmm::cuda_stream_view stream,
                                                     rmm::device_async_resource_ref mr)
 {
-  // Unfortunately, CUB's segmented sort functions cannot accept iterators.
-  // We have to build a pre-filled sequence of indices as input.
-  auto sorted_indices = cudf::detail::sequence(
-    input.size(),
-    numeric_scalar<size_type>{0, true, stream, cudf::get_current_device_resource_ref()},
-    stream,
-    mr);
+  // Allocated unfilled: the sort functor identity-seeds it along with CUB's value-input buffer.
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, input.size(), mask_state::UNALLOCATED, stream, mr);
   auto indices_view = sorted_indices->mutable_view();
 
   cudf::type_dispatcher<dispatch_storage_type>(input.type(),
@@ -281,23 +297,24 @@ std::unique_ptr<column> segmented_sorted_order_common(
   }
 
   // Unstable-only fast paths for a single fixed-width key column, routed by type class and list
-  // shape; accepted only for an explicit ascending / nulls-last request.
+  // shape; any explicit (order, null_order) is folded into the fast-path sort keys.
   if constexpr (method == sort_method::UNSTABLE) {
-    // Routing runs first so a column routed to `comparison` skips the probe's stream sync.
     if (keys.num_columns() == 1 and segment_offsets.size() > 0 and column_order.size() == 1 and
-        column_order.front() == order::ASCENDING and null_precedence.size() == 1 and
-        null_precedence.front() == null_order::AFTER) {
+        null_precedence.size() == 1) {
+      // Routing runs first so a column routed to `comparison` skips the probe's stream sync.
       auto const path =
         choose_fixed_width_sort_path(keys.column(0), keys.num_rows(), segment_offsets, stream);
       if (path != fixed_width_sort_path::comparison and
           fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
+        auto const polarity = resolve_sort_polarity(
+          keys.column(0).has_nulls(), column_order.front(), null_precedence.front());
         switch (path) {
           case fixed_width_sort_path::tiered:  // short lists, or any nulls
             return fast_segmented_sorted_order_tiered(
-              keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+              keys.column(0), segment_offsets, polarity, stream, mr);
           case fixed_width_sort_path::packed_radix:  // long no-null lists
             return fast_segmented_sorted_order_numeric_packed(
-              keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+              keys.column(0), segment_offsets, polarity, stream, mr);
           case fixed_width_sort_path::cub_segmented:  // wider-rep no-null mid band
             return fast_segmented_sorted_order<method>(
               keys.column(0), segment_offsets, column_order.front(), stream, mr);
@@ -325,22 +342,23 @@ std::unique_ptr<column> segmented_sorted_order_common(
       keys.column(0), segment_offsets, col_order, stream, mr);
   }
 
-  // Unstable-only fast paths for a single STRING key column, accepted only for an explicit
-  // ascending / nulls-last request. Segments that all fit the warp tile take the graduated in-warp
-  // merge sort, which beats the prefix-radix engine there; otherwise a radix sort over packed
-  // leading-byte prefixes with byte-window tie-breaking.
+  // Unstable-only fast paths for a single STRING key column. Segments that all fit the warp tile
+  // take the graduated in-warp merge sort, which beats the prefix-radix engine there; otherwise a
+  // radix sort over packed leading-byte prefixes with byte-window tie-breaking. Any explicit
+  // (order, null_order) is folded into both engines' keys.
   if constexpr (method == sort_method::UNSTABLE) {
     if (keys.num_columns() == 1 and keys.column(0).type().id() == type_id::STRING and
         (segment_offsets.size() > 0) and column_order.size() == 1 and
-        column_order.front() == order::ASCENDING and null_precedence.size() == 1 and
-        null_precedence.front() == null_order::AFTER and
+        null_precedence.size() == 1 and
         fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
+      auto const polarity = resolve_sort_polarity(
+        keys.column(0).has_nulls(), column_order.front(), null_precedence.front());
       if (strings_grad_all_segments_fit(segment_offsets, stream)) {
         return fast_segmented_sorted_order_strings_grad(
-          keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+          keys.column(0), segment_offsets, polarity, stream, mr);
       }
       return fast_segmented_sorted_order_strings_prefix(
-        keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+        keys.column(0), segment_offsets, polarity, stream, mr);
     }
   }
 

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -212,7 +212,7 @@ rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
 /**
  * @brief Whether the segment offsets span every row `[0, num_rows]`
  *
- * The packed-radix and strings fast paths label elements by dense segment ordinal and index the
+ * The packed, tiered, and strings fast paths label elements by dense segment ordinal and index the
  * output by raw offset, so partial-coverage offsets -- allowed by the public contract -- must take
  * the comparison path. Requiring at least two offsets also excludes `num_segments == 0`, whose
  * zero-width segment field would shift a 64-bit packed key by 64 (undefined behavior).
@@ -277,9 +277,8 @@ std::unique_ptr<column> segmented_sorted_order_common(
                  "Mismatch between number of columns and null_precedence size.");
   }
 
-  // Unstable-only packed-radix fast path for a single fixed-width key column sorted ascending
-  // with nulls last: null-bearing at any list size, or no-null with long lists. The order and
-  // null precedence must be explicit, so the defaulted-argument cases fall through unchanged.
+  // Unstable-only fast paths for a single fixed-width key column sorted ascending / nulls-last,
+  // routed by type class and list shape; any other configuration falls through unchanged.
   if constexpr (method == sort_method::UNSTABLE) {
     // Routing runs first so a column routed to `comparison` skips the probe's stream sync.
     if (keys.num_columns() == 1 and segment_offsets.size() > 0 and column_order.size() == 1 and
@@ -287,10 +286,16 @@ std::unique_ptr<column> segmented_sorted_order_common(
         null_precedence.front() == null_order::AFTER) {
       auto const path =
         choose_fixed_width_sort_path(keys.column(0), keys.num_rows(), segment_offsets, stream);
-      if (path == fixed_width_sort_path::packed_radix and
+      if (path != fixed_width_sort_path::comparison and
           fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
-        return fast_segmented_sorted_order_numeric_packed(
-          keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+        if (path == fixed_width_sort_path::tiered) {
+          return fast_segmented_sorted_order_tiered(
+            keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+        }
+        if (path == fixed_width_sort_path::packed_radix) {
+          return fast_segmented_sorted_order_numeric_packed(
+            keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+        }
       }
     }
   }
@@ -309,11 +314,10 @@ std::unique_ptr<column> segmented_sorted_order_common(
       keys.column(0), segment_offsets, col_order, stream, mr);
   }
 
-  // Unstable-only fast paths for a single STRING key column sorted ascending with nulls last.
+  // Unstable-only fast paths for a single STRING key column sorted ascending / nulls-last.
   // Segments that all fit the warp tile take the graduated in-warp merge sort, which beats the
   // prefix-radix engine there; otherwise a radix sort over packed leading-byte prefixes with
-  // byte-window tie-breaking. The order and null precedence must be stated explicitly; the
-  // defaulted-argument cases fall through to the comparison path below.
+  // byte-window tie-breaking. Any other configuration falls through unchanged.
   if constexpr (method == sort_method::UNSTABLE) {
     if (keys.num_columns() == 1 and keys.column(0).type().id() == type_id::STRING and
         (segment_offsets.size() > 0) and column_order.size() == 1 and

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -212,10 +212,10 @@ rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
 /**
  * @brief Whether the segment offsets span every row `[0, num_rows]`
  *
- * The fast paths label elements by dense segment ordinal and index the output by raw offset, so
- * partial-coverage offsets -- allowed by the public contract -- must take the comparison path.
- * Requiring at least two offsets also excludes `num_segments == 0`, whose zero-width segment field
- * would shift a 64-bit packed key by 64 (undefined behavior).
+ * The packed-radix and strings fast paths label elements by dense segment ordinal and index the
+ * output by raw offset, so partial-coverage offsets -- allowed by the public contract -- must take
+ * the comparison path. Requiring at least two offsets also excludes `num_segments == 0`, whose
+ * zero-width segment field would shift a 64-bit packed key by 64 (undefined behavior).
  *
  * @param segment_offsets The segment offsets (segment count plus one)
  * @param num_rows Element count the offsets must span
@@ -277,30 +277,43 @@ std::unique_ptr<column> segmented_sorted_order_common(
                  "Mismatch between number of columns and null_precedence size.");
   }
 
-  // the average row size for which to prefer fast sort
-  constexpr cudf::size_type MAX_AVG_LIST_SIZE_FOR_FAST_SORT{100};
-  // the maximum row count for which to prefer fast sort
-  constexpr cudf::size_type MAX_LIST_SIZE_FOR_FAST_SORT{1 << 18};
+  // Unstable-only packed-radix fast path for a single fixed-width key column sorted ascending
+  // with nulls last: null-bearing at any list size, or no-null with long lists. The order and
+  // null precedence must be explicit, so the defaulted-argument cases fall through unchanged.
+  if constexpr (method == sort_method::UNSTABLE) {
+    // Routing runs first so a column routed to `comparison` skips the probe's stream sync.
+    if (keys.num_columns() == 1 and segment_offsets.size() > 0 and column_order.size() == 1 and
+        column_order.front() == order::ASCENDING and null_precedence.size() == 1 and
+        null_precedence.front() == null_order::AFTER) {
+      auto const path =
+        choose_fixed_width_sort_path(keys.column(0), keys.num_rows(), segment_offsets, stream);
+      if (path == fixed_width_sort_path::packed_radix and
+          fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
+        return fast_segmented_sorted_order_numeric_packed(
+          keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+      }
+    }
+  }
 
   // fast-path for single column sort:
   // - single-column table
-  // - not stable-sort
+  // - both stable and unstable sort
   // - no nulls and allowable fixed-width type
   // - size and width are limited -- based on benchmark results
   if (keys.num_columns() == 1 and
       column_fast_sort_fn<method>::is_fast_sort_supported(keys.column(0)) and
       (segment_offsets.size() > 0) and
-      (((keys.num_rows() / segment_offsets.size()) < MAX_AVG_LIST_SIZE_FOR_FAST_SORT) or
-       (keys.num_rows() < MAX_LIST_SIZE_FOR_FAST_SORT))) {
+      prefer_cub_segmented_sort(keys.num_rows(), segment_offsets.size())) {
     auto const col_order = column_order.empty() ? order::ASCENDING : column_order.front();
     return fast_segmented_sorted_order<method>(
       keys.column(0), segment_offsets, col_order, stream, mr);
   }
 
-  // Unstable-only fast paths for a single STRING key column. Segments that all fit the warp tile
-  // take the graduated in-warp merge sort, which beats the prefix-radix engine there; otherwise a
-  // radix sort over packed leading-byte prefixes with byte-window tie-breaking. Only an explicit
-  // ascending / nulls-last request qualifies; anything else falls through to the comparison path.
+  // Unstable-only fast paths for a single STRING key column sorted ascending with nulls last.
+  // Segments that all fit the warp tile take the graduated in-warp merge sort, which beats the
+  // prefix-radix engine there; otherwise a radix sort over packed leading-byte prefixes with
+  // byte-window tie-breaking. The order and null precedence must be stated explicitly; the
+  // defaulted-argument cases fall through to the comparison path below.
   if constexpr (method == sort_method::UNSTABLE) {
     if (keys.num_columns() == 1 and keys.column(0).type().id() == type_id::STRING and
         (segment_offsets.size() > 0) and column_order.size() == 1 and

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -37,26 +37,29 @@ struct column_fast_sort_fn {
   /**
    * @brief Run-time check for faster segmented sort on an eligible column
    *
-   * Fast segmented sort can handle integral types including
-   * decimal types if dispatch_storage_type is used but it does not support int128.
+   * Integral types and the fixed-point reps (via `dispatch_storage_type`) are supported; the
+   * `__int128` DECIMAL128 rep is admitted for the unstable sort only.
    */
   static bool is_fast_sort_supported(column_view const& col)
   {
-    return !col.has_nulls() and
-           (cudf::is_integral(col.type()) ||
-            (cudf::is_fixed_point(col.type()) and (col.type().id() != type_id::DECIMAL128)));
+    auto const decimal128_ok =
+      col.type().id() == type_id::DECIMAL128 and method == sort_method::UNSTABLE;
+    return !col.has_nulls() and (cudf::is_integral(col.type()) ||
+                                 (cudf::is_fixed_point(col.type()) and
+                                  (col.type().id() != type_id::DECIMAL128 or decimal128_ok)));
   }
 
   /**
    * @brief Compile-time check for supporting fast segmented sort for a specific type
    *
-   * The dispatch_storage_type means we can check for integral types to
-   * include fixed-point types but the CUB limitation means we need to exclude int128.
+   * The `dispatch_storage_type` lets the integral check cover the fixed-point reps; `__int128` is
+   * admitted for the unstable sort only, matching the run-time gate.
    */
   template <typename T>
   static constexpr bool is_fast_sort_supported()
   {
-    return cudf::is_integral<T>() and !std::is_same_v<__int128, T>;
+    return (cudf::is_integral<T>() and !std::is_same_v<__int128, T>) or
+           (std::is_same_v<__int128, T> and method == sort_method::UNSTABLE);
   }
 
   template <typename T>
@@ -277,8 +280,8 @@ std::unique_ptr<column> segmented_sorted_order_common(
                  "Mismatch between number of columns and null_precedence size.");
   }
 
-  // Unstable-only fast paths for a single fixed-width key column sorted ascending / nulls-last,
-  // routed by type class and list shape; any other configuration falls through unchanged.
+  // Unstable-only fast paths for a single fixed-width key column, routed by type class and list
+  // shape; accepted only for an explicit ascending / nulls-last request.
   if constexpr (method == sort_method::UNSTABLE) {
     // Routing runs first so a column routed to `comparison` skips the probe's stream sync.
     if (keys.num_columns() == 1 and segment_offsets.size() > 0 and column_order.size() == 1 and
@@ -288,13 +291,17 @@ std::unique_ptr<column> segmented_sorted_order_common(
         choose_fixed_width_sort_path(keys.column(0), keys.num_rows(), segment_offsets, stream);
       if (path != fixed_width_sort_path::comparison and
           fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
-        if (path == fixed_width_sort_path::tiered) {
-          return fast_segmented_sorted_order_tiered(
-            keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
-        }
-        if (path == fixed_width_sort_path::packed_radix) {
-          return fast_segmented_sorted_order_numeric_packed(
-            keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+        switch (path) {
+          case fixed_width_sort_path::tiered:  // short lists, or any nulls
+            return fast_segmented_sorted_order_tiered(
+              keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+          case fixed_width_sort_path::packed_radix:  // long no-null lists
+            return fast_segmented_sorted_order_numeric_packed(
+              keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+          case fixed_width_sort_path::cub_segmented:  // wider-rep no-null mid band
+            return fast_segmented_sorted_order<method>(
+              keys.column(0), segment_offsets, column_order.front(), stream, mr);
+          case fixed_width_sort_path::comparison: break;  // excluded by the guard above
         }
       }
     }
@@ -308,16 +315,20 @@ std::unique_ptr<column> segmented_sorted_order_common(
   if (keys.num_columns() == 1 and
       column_fast_sort_fn<method>::is_fast_sort_supported(keys.column(0)) and
       (segment_offsets.size() > 0) and
-      prefer_cub_segmented_sort(keys.num_rows(), segment_offsets.size())) {
+      prefer_cub_segmented_sort(keys.num_rows(), segment_offsets.size()) and
+      // DECIMAL128 wins with CUB only in its measured short-list band; above it CUB loses
+      // several-fold to the comparison sort.
+      (keys.column(0).type().id() != type_id::DECIMAL128 or
+       keys.num_rows() / segment_offsets.size() <= DECIMAL128_CUB_MAX_AVG_LIST_SIZE)) {
     auto const col_order = column_order.empty() ? order::ASCENDING : column_order.front();
     return fast_segmented_sorted_order<method>(
       keys.column(0), segment_offsets, col_order, stream, mr);
   }
 
-  // Unstable-only fast paths for a single STRING key column sorted ascending / nulls-last.
-  // Segments that all fit the warp tile take the graduated in-warp merge sort, which beats the
-  // prefix-radix engine there; otherwise a radix sort over packed leading-byte prefixes with
-  // byte-window tie-breaking. Any other configuration falls through unchanged.
+  // Unstable-only fast paths for a single STRING key column, accepted only for an explicit
+  // ascending / nulls-last request. Segments that all fit the warp tile take the graduated in-warp
+  // merge sort, which beats the prefix-radix engine there; otherwise a radix sort over packed
+  // leading-byte prefixes with byte-window tie-breaking.
   if constexpr (method == sort_method::UNSTABLE) {
     if (keys.num_columns() == 1 and keys.column(0).type().id() == type_id::STRING and
         (segment_offsets.size() > 0) and column_order.size() == 1 and

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -297,15 +297,20 @@ std::unique_ptr<column> segmented_sorted_order_common(
       keys.column(0), segment_offsets, col_order, stream, mr);
   }
 
-  // Unstable-only fast path for a single STRING key column sorted ascending with nulls last: a
-  // radix sort over packed leading-byte prefixes with byte-window tie-breaking. The order and null
-  // precedence must be explicit; any other configuration falls through to the comparison path.
+  // Unstable-only fast paths for a single STRING key column. Segments that all fit the warp tile
+  // take the graduated in-warp merge sort, which beats the prefix-radix engine there; otherwise a
+  // radix sort over packed leading-byte prefixes with byte-window tie-breaking. Only an explicit
+  // ascending / nulls-last request qualifies; anything else falls through to the comparison path.
   if constexpr (method == sort_method::UNSTABLE) {
     if (keys.num_columns() == 1 and keys.column(0).type().id() == type_id::STRING and
         (segment_offsets.size() > 0) and column_order.size() == 1 and
         column_order.front() == order::ASCENDING and null_precedence.size() == 1 and
         null_precedence.front() == null_order::AFTER and
         fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
+      if (strings_grad_all_segments_fit(segment_offsets, stream)) {
+        return fast_segmented_sorted_order_strings_grad(
+          keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+      }
       return fast_segmented_sorted_order_strings_prefix(
         keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
     }

--- a/cpp/src/sort/segmented_sort_keys.cuh
+++ b/cpp/src/sort/segmented_sort_keys.cuh
@@ -40,8 +40,8 @@ constexpr int TIERED_BLOCK_THREADS = 128;
  * comparators, which would multiply kernel instantiations. `descending` complements the encoded
  * value field: an order-reversing bijection confined to the field's exact width, leaving the
  * class/segment bits above it untouched. `nulls_first` picks the null class bit. Callers currently
- * construct only the default `{false, false}` -- the engines are gated to explicit ascending /
- * nulls-after requests -- which reproduces the shipped ascending / nulls-last keys bit for bit.
+ * construct only the default `{false, false}`, which reproduces the shipped ascending / nulls-last
+ * keys bit for bit.
  */
 struct sort_polarity {
   bool descending  = false;
@@ -142,12 +142,36 @@ struct key_head_flag {
 };
 
 /**
+ * @brief Flags positions whose key equals a neighbor, i.e. those in a run of two or more
+ *
+ * Used to compact the sorted order to just the still-tied positions later windows must re-sort;
+ * singletons are already final. A null-classed position never counts as tied: nulls are
+ * position-final after the first pass. `null_flag` is the `seg_null` bit-0 value marking a null --
+ * 1 for the strings path and the numeric nulls-last polarity, 0 under numeric nulls-first, whose
+ * valid elements carry bit 1 and must stay tie-detectable.
+ */
+struct key_tied_flag {
+  prefix_key96 const* d_keys;
+  size_type const num_elements;
+  cuda::std::uint32_t const null_flag = 1u;
+  __device__ bool operator()(size_type i) const
+  {
+    auto const cur = d_keys[i];
+    if ((cur.seg_null & 1u) == null_flag) { return false; }
+    auto const eq_prev = i > 0 && keys_equal(d_keys[i - 1], cur);
+    auto const eq_next = i + 1 < num_elements && keys_equal(d_keys[i + 1], cur);
+    return eq_prev || eq_next;
+  }
+};
+
+/**
  * @brief Runs `cub::DeviceSelect::Flagged` to completion: the temp-storage query pass, then the
  * execute pass
  *
- * Shared by every call site that compacts positions down to their `tied_flags`-true subset -- the
- * strings prefix-radix setup and its per-pass loop repeat this exact two-call CUB idiom (size the
- * scratch buffer, then execute) with only the iterator types and the element count differing.
+ * Shared by every call site that compacts positions down to their `tied_flags`-true subset --
+ * both the numeric two-phase DECIMAL128 sort and the strings prefix-radix loop repeat this exact
+ * two-call CUB idiom (size the scratch buffer, then execute) with only the iterator types and the
+ * element count differing.
  */
 template <typename InputIteratorT, typename OutputIteratorT>
 void cub_select_flagged(InputIteratorT d_in,

--- a/cpp/src/sort/segmented_sort_keys.cuh
+++ b/cpp/src/sort/segmented_sort_keys.cuh
@@ -1,0 +1,168 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+
+#include <cub/device/device_select.cuh>
+#include <cuda/std/cstdint>
+#include <cuda/std/tuple>
+
+namespace cudf {
+namespace detail {
+
+/**
+ * @brief Runtime key polarity realizing one explicit (order, null_order) on the segmented-sort
+ * fast paths
+ *
+ * Every engine orders by an unsigned comparison of a packed key, so the requested configuration is
+ * folded into the key bits -- one XOR/class operation per element -- rather than into per-engine
+ * comparators, which would multiply kernel instantiations. `descending` complements the encoded
+ * value field: an order-reversing bijection confined to the field's exact width, leaving the
+ * class/segment bits above it untouched. `nulls_first` picks the null class bit. The only current
+ * caller constructs the default `{false, false}` state, which reproduces the shipped ascending /
+ * nulls-last keys bit for bit; the other states engage once the gate widens to the full matrix.
+ */
+struct sort_polarity {
+  bool descending  = false;
+  bool nulls_first = false;
+
+  /// Class bit for a valid (0/1) or null (1/0) element: unsigned key order then places nulls on
+  /// the requested side of every valid element.
+  __host__ __device__ cuda::std::uint32_t element_class(bool is_null) const
+  {
+    return static_cast<cuda::std::uint32_t>(is_null != nulls_first);
+  }
+  /// XOR mask reversing a 32-bit encoded value's unsigned order when descending.
+  __host__ __device__ cuda::std::uint32_t value_mask32() const
+  {
+    return descending ? ~cuda::std::uint32_t{0} : cuda::std::uint32_t{0};
+  }
+  /// XOR mask reversing a 64-bit encoded value's unsigned order when descending.
+  __host__ __device__ cuda::std::uint64_t value_mask64() const
+  {
+    return descending ? ~cuda::std::uint64_t{0} : cuda::std::uint64_t{0};
+  }
+};
+
+/**
+ * @brief Fixed-width radix key ordering runs still tied after the single-`uint64` first pass
+ *
+ * Twelve bytes with no padding decompose to exactly 96 radix bits (12 passes) while carrying a
+ * full eight-byte window; key bytes drive this sort's cost, so shedding a 16-byte key's four pad
+ * bytes is a direct data-movement win. Fields are most- to least-significant. `seg_null` holds
+ * `(rank << 1) | is_null` -- the dense run rank dominates, so a pass preserves every order an
+ * earlier pass resolved and reorders only within a tied run, and within a rank a null sorts after
+ * every non-null. `prefix_hi`/`prefix_lo` hold the element's next eight window bytes packed
+ * big-endian (byte 0 most significant, exhausted bytes zero-filled), so comparing them in order
+ * reproduces unsigned-byte lexicographic order; a null's window words are zero, never its string
+ * bytes.
+ */
+struct prefix_key96 {
+  cuda::std::uint32_t seg_null;
+  cuda::std::uint32_t prefix_hi;
+  cuda::std::uint32_t prefix_lo;
+};
+
+static_assert(sizeof(prefix_key96) == 12 and alignof(prefix_key96) == 4,
+              "prefix_key96 must stay 12 bytes with 4-byte alignment");
+
+/// Decomposes a `prefix_key96` for `cub::DeviceRadixSort`; the leftmost tuple element is the most
+/// significant, ordering by run rank and null flag, then the window words.
+struct prefix_decomposer {
+  __device__ cuda::std::tuple<cuda::std::uint32_t&, cuda::std::uint32_t&, cuda::std::uint32_t&>
+  operator()(prefix_key96& key) const
+  {
+    return {key.seg_null, key.prefix_hi, key.prefix_lo};
+  }
+};
+
+/// True when two keys are bit-for-bit equal, i.e. in the same run of an unresolved tie.
+__device__ inline bool keys_equal(prefix_key96 const& a, prefix_key96 const& b)
+{
+  return a.seg_null == b.seg_null && a.prefix_hi == b.prefix_hi && a.prefix_lo == b.prefix_lo;
+}
+
+/**
+ * @brief Packs a dense run rank (bits 1..31) and a null flag (bit 0) into one 32-bit field
+ *
+ * The rank comes from an inclusive scan over run-head flags, so it is bounded by the element count
+ * (a `size_type`, <= 2^31 - 1) and `(rank << 1) | flag` never overflows; a `static_assert` in the
+ * caller proves it.
+ */
+__device__ inline cuda::std::uint32_t pack_seg_null(cuda::std::uint32_t label,
+                                                    cuda::std::uint32_t flag)
+{
+  return (label << 1) | flag;
+}
+
+/// Splits a big-endian-packed eight-byte window into a `prefix_key96`'s two window words.
+__device__ inline void split_prefix(cuda::std::uint64_t packed,
+                                    cuda::std::uint32_t& prefix_hi,
+                                    cuda::std::uint32_t& prefix_lo)
+{
+  prefix_hi = static_cast<cuda::std::uint32_t>(packed >> 32);
+  prefix_lo = static_cast<cuda::std::uint32_t>(packed & 0xFFFF'FFFFu);
+}
+
+/**
+ * @brief Flags the first position of each maximal run of equal keys (1 = head, 0 = continuation)
+ *
+ * An inclusive sum over these flags yields a dense one-based run rank shared exactly by equal
+ * keys; window keys carry the prior pass's rank in their leading field, so each new rank refines
+ * the old grouping without merging elements an earlier pass separated.
+ */
+struct key_head_flag {
+  prefix_key96 const* d_keys;
+  __device__ cuda::std::uint32_t operator()(size_type i) const
+  {
+    if (i == 0) { return 1u; }
+    return keys_equal(d_keys[i - 1], d_keys[i]) ? 0u : 1u;
+  }
+};
+
+/**
+ * @brief Runs `cub::DeviceSelect::Flagged` to completion: the temp-storage query pass, then the
+ * execute pass
+ *
+ * Shared by every call site that compacts positions down to their `tied_flags`-true subset -- the
+ * strings prefix-radix setup and its per-pass loop repeat this exact two-call CUB idiom (size the
+ * scratch buffer, then execute) with only the iterator types and the element count differing.
+ */
+template <typename InputIteratorT, typename OutputIteratorT>
+void cub_select_flagged(InputIteratorT d_in,
+                        bool const* tied_flags,
+                        OutputIteratorT d_out,
+                        size_type* d_num_selected,
+                        size_type count,
+                        rmm::cuda_stream_view stream)
+{
+  rmm::device_buffer d_temp_storage;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSelect::Flagged(d_temp_storage.data(),
+                             temp_storage_bytes,
+                             d_in,
+                             tied_flags,
+                             d_out,
+                             d_num_selected,
+                             count,
+                             stream.value());
+  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  cub::DeviceSelect::Flagged(d_temp_storage.data(),
+                             temp_storage_bytes,
+                             d_in,
+                             tied_flags,
+                             d_out,
+                             d_num_selected,
+                             count,
+                             stream.value());
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/sort/segmented_sort_keys.cuh
+++ b/cpp/src/sort/segmented_sort_keys.cuh
@@ -39,9 +39,8 @@ constexpr int TIERED_BLOCK_THREADS = 128;
  * folded into the key bits -- one XOR/class operation per element -- rather than into per-engine
  * comparators, which would multiply kernel instantiations. `descending` complements the encoded
  * value field: an order-reversing bijection confined to the field's exact width, leaving the
- * class/segment bits above it untouched. `nulls_first` picks the null class bit. Callers currently
- * construct only the default `{false, false}`, which reproduces the shipped ascending / nulls-last
- * keys bit for bit.
+ * class/segment bits above it untouched. `nulls_first` picks the null class bit. The default
+ * `{false, false}` reproduces the shipped ascending / nulls-last keys bit for bit.
  */
 struct sort_polarity {
   bool descending  = false;
@@ -64,6 +63,18 @@ struct sort_polarity {
     return descending ? ~cuda::std::uint64_t{0} : cuda::std::uint64_t{0};
   }
 };
+
+/// null_order is comparator-level -- a descending sort swaps the comparison operands, inverting
+/// null placement -- so nulls land first exactly when (BEFORE) != (DESCENDING); a zero-null column
+/// relaxes to nulls-last, keeping its keys bit-identical to the shipped configuration.
+inline sort_polarity resolve_sort_polarity(bool has_nulls,
+                                           order column_order,
+                                           null_order null_precedence)
+{
+  auto const descending  = column_order == order::DESCENDING;
+  auto const nulls_first = has_nulls and ((null_precedence == null_order::BEFORE) != descending);
+  return sort_polarity{descending, nulls_first};
+}
 
 /**
  * @brief Fixed-width radix key ordering runs still tied after the single-`uint64` first pass

--- a/cpp/src/sort/segmented_sort_keys.cuh
+++ b/cpp/src/sort/segmented_sort_keys.cuh
@@ -17,6 +17,20 @@
 namespace cudf {
 namespace detail {
 
+// Element class within the tiered ordering key. The ranks are load-bearing: `element_class` maps
+// valid/null to 0/1 per the polarity, and `tier_pad` MUST rank strictly above both --
+// `cub::BlockMergeSortStrategy::Sort` fills the slots past a segment's real elements with the pad
+// key and requires it ordered after every valid item, so a tie could let the merge displace a real
+// element past the valid-item boundary and drop it.
+enum class tiered_element_class : cuda::std::uint32_t {
+  tier_valid = 0,
+  tier_null  = 1,
+  tier_pad   = 2
+};
+
+/// Block size hosting the register/warp tiered virtual warps and the graduated-string warp bands.
+constexpr int TIERED_BLOCK_THREADS = 128;
+
 /**
  * @brief Runtime key polarity realizing one explicit (order, null_order) on the segmented-sort
  * fast paths
@@ -25,16 +39,16 @@ namespace detail {
  * folded into the key bits -- one XOR/class operation per element -- rather than into per-engine
  * comparators, which would multiply kernel instantiations. `descending` complements the encoded
  * value field: an order-reversing bijection confined to the field's exact width, leaving the
- * class/segment bits above it untouched. `nulls_first` picks the null class bit. The only current
- * caller constructs the default `{false, false}` state, which reproduces the shipped ascending /
- * nulls-last keys bit for bit; the other states engage once the gate widens to the full matrix.
+ * class/segment bits above it untouched. `nulls_first` picks the null class bit. Callers currently
+ * construct only the default `{false, false}` -- the engines are gated to explicit ascending /
+ * nulls-after requests -- which reproduces the shipped ascending / nulls-last keys bit for bit.
  */
 struct sort_polarity {
   bool descending  = false;
   bool nulls_first = false;
 
   /// Class bit for a valid (0/1) or null (1/0) element: unsigned key order then places nulls on
-  /// the requested side of every valid element.
+  /// the requested side of every valid element; the tiered pad class (2) stays strictly above both.
   __host__ __device__ cuda::std::uint32_t element_class(bool is_null) const
   {
     return static_cast<cuda::std::uint32_t>(is_null != nulls_first);
@@ -163,6 +177,15 @@ void cub_select_flagged(InputIteratorT d_in,
                              count,
                              stream.value());
 }
+
+struct segment_exceeds_size {
+  size_type const* d_offsets;
+  size_type limit;
+  __device__ bool operator()(size_type i) const
+  {
+    return (d_offsets[i + 1] - d_offsets[i]) > limit;
+  }
+};
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/sort/segmented_sort_strings.cu
+++ b/cpp/src/sort/segmented_sort_strings.cu
@@ -1,0 +1,968 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "segmented_sort_fast.cuh"
+#include "segmented_sort_keys.cuh"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/device_scalar.hpp>
+#include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/hashing/detail/hash_functions.cuh>
+#include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_scan.cuh>
+#include <cub/device/device_select.cuh>
+#include <cuda/iterator>
+#include <cuda/std/algorithm>
+#include <cuda/std/bit>
+#include <cuda/std/cstdint>
+#include <cuda/std/cstring>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+#include <cuda/std/utility>
+#include <thrust/count.h>
+#include <thrust/for_each.h>
+#include <thrust/logical.h>
+#include <thrust/reduce.h>
+#include <thrust/scatter.h>
+#include <thrust/sequence.h>
+#include <thrust/transform.h>
+
+namespace cudf {
+namespace detail {
+namespace {
+
+/// Leading string bytes packed per big-endian window (the `uint64` byte capacity).
+constexpr size_type PREFIX_BYTES = sizeof(cuda::std::uint64_t);
+
+/**
+ * @brief Bit layout of the single-`uint64` first-pass radix key
+ *
+ * Most- to least-significant: `[segment_id : S][is_null : 1, only when nullable][prefix : P]`; an
+ * unsigned compare reproduces the `prefix_key96` ordering (segment, non-nulls before nulls, packed
+ * leading bytes) in eight radix byte-passes instead of twelve. `is_null` sits just above the
+ * prefix, a bit no non-null prefix can reach, so an all-0xFF prefix cannot collide with a null and
+ * no sentinel is needed.
+ *
+ * A key match proves only `floor(P/8)` *whole* equal bytes -- the partial trailing bits of `P` say
+ * nothing about the next byte -- so the windows and comparison cleanup start there, not at a fixed
+ * eight.
+ */
+struct packed_key_layout {
+  int segment_bits;  // S: bit_width of the maximum segment label.
+  int null_bits;     // 1 when the column has nulls, else 0.
+  int prefix_bits;   // P = 64 - S - null_bits.
+};
+
+/**
+ * @brief Computes the `uint64` key layout for `num_segment_labels` distinct segment-label values
+ *
+ * The caller labels elements with dense segment ordinals, so the bound is `num_segments` rather
+ * than the row count; the tighter `S` widens `P`, packing more leading bytes per key.
+ */
+inline packed_key_layout make_packed_key_layout(size_type num_segment_labels, bool has_nulls)
+{
+  auto const max_label    = static_cast<cuda::std::uint64_t>(num_segment_labels);
+  auto const segment_bits = cuda::std::bit_width(max_label);
+  auto const null_bits    = has_nulls ? 1 : 0;
+  return packed_key_layout{segment_bits, null_bits, 64 - segment_bits - null_bits};
+}
+
+/**
+ * @brief Big-endian packs a string's eight bytes starting at `window_start` into a `uint64`
+ *
+ * Trailing bytes are zero-filled, so an unsigned compare reproduces unsigned-byte order over the
+ * window and an exhausted string packs to zero -- the minimum -- reproducing the shorter-is-less
+ * tie-break. Descending complements the window at the call site, sending that zero to the maximum
+ * so the shorter string orders last instead. Nulls are never inspected here.
+ */
+__device__ inline cuda::std::uint64_t pack_window(string_view const& d_str, size_type window_start)
+{
+  auto const bytes = d_str.size_bytes();
+  if (window_start >= bytes) { return 0; }
+  auto const* ptr = reinterpret_cast<unsigned char const*>(d_str.data());
+  // Value copy: ODR-using the PREFIX_BYTES constexpr by reference is ill-formed in device code.
+  auto const window_bytes    = cuda::std::min(bytes - window_start, size_type{PREFIX_BYTES});
+  cuda::std::uint64_t window = 0;
+  if (window_bytes == PREFIX_BYTES) {
+    // One wide load and a byte-perm endian swap replace eight dependent single-byte loads; the
+    // full-width branch guarantees eight in-range bytes, so the load never overreads.
+    cuda::std::uint64_t raw;
+    cuda::std::memcpy(&raw, ptr + window_start, sizeof(raw));
+    window = cudf::hashing::detail::swap_endian(raw);
+  } else {
+    for (size_type i = 0; i < window_bytes; ++i) {
+      window |= static_cast<cuda::std::uint64_t>(ptr[window_start + i]) << (56 - i * 8);
+    }
+  }
+  return window;
+}
+
+/**
+ * @brief Builds the per-element single-`uint64` first-pass key (see `packed_key_layout`)
+ *
+ * The class bit follows `polarity.element_class`, collecting nulls on the requested side of each
+ * segment; a null zeroes the prefix so all nulls in a segment share one key (order immaterial,
+ * bytes never read). Descending complements only the `P` prefix bits, never the class or segment
+ * fields, so one key drives every (order, null_order) combination.
+ */
+struct packed_key_builder {
+  size_type const* d_segment_ids;
+  column_device_view const d_strings;
+  bool const has_nulls;
+  packed_key_layout const layout;
+  sort_polarity const polarity;
+  __device__ cuda::std::uint64_t operator()(size_type idx) const
+  {
+    auto const segment_id   = static_cast<cuda::std::uint64_t>(d_segment_ids[idx]);
+    auto const segment_part = segment_id << (64 - layout.segment_bits);
+    if (has_nulls && d_strings.is_null(idx)) {
+      return segment_part |
+             (static_cast<cuda::std::uint64_t>(polarity.element_class(true)) << layout.prefix_bits);
+    }
+    auto const full_prefix = pack_window(d_strings.element<string_view>(idx), 0);
+
+    auto const prefix = (full_prefix >> (64 - layout.prefix_bits)) ^
+                        (polarity.value_mask64() >> (64 - layout.prefix_bits));
+    // Null-free layouts reserve no class bit; the OR is then provably zero: callers resolve
+    // `nulls_first == false` for null-free columns, and `element_class(false) == nulls_first`.
+    return segment_part |
+           (static_cast<cuda::std::uint64_t>(polarity.element_class(false)) << layout.prefix_bits) |
+           prefix;
+  }
+};
+
+/**
+ * @brief Flags the first position of each maximal run of equal `uint64` keys (1 = head, else 0)
+ *
+ * The `uint64` analogue of `key_head_flag`: inclusive-summing the flags yields the dense run rank
+ * seeding the window path, capturing exactly the order the first sort resolved so packed-key ties
+ * stay in one run for the windows rather than frozen apart.
+ */
+struct key_head_flag_packed {
+  cuda::std::uint64_t const* d_keys;
+  __device__ cuda::std::uint32_t operator()(size_type i) const
+  {
+    if (i == 0) { return 1u; }
+    return d_keys[i - 1] != d_keys[i] ? 1u : 0u;
+  }
+};
+
+/// Shared tie test over the `uint64` first-pass keys: a null-classed position never counts as
+/// tied (nulls are position-final after the first pass); otherwise tied means equal to a
+/// neighbor. One definition keeps `key_tied_flag_packed` and `keep_tied_first` from drifting.
+__device__ inline bool packed_key_is_tied(cuda::std::uint64_t const* d_keys,
+                                          size_type num_elements,
+                                          bool has_nulls,
+                                          int prefix_bits,
+                                          cuda::std::uint32_t null_flag,
+                                          size_type i)
+{
+  auto const cur = d_keys[i];
+  if (has_nulls && static_cast<cuda::std::uint32_t>((cur >> prefix_bits) & 1u) == null_flag) {
+    return false;
+  }
+  auto const eq_prev = i > 0 && d_keys[i - 1] == cur;
+  auto const eq_next = i + 1 < num_elements && d_keys[i + 1] == cur;
+  return eq_prev || eq_next;
+}
+
+/**
+ * @brief Flags `uint64`-key positions equal to a neighbor (a run of two or more), never a null
+ *
+ * Sizes and gates the iterative tie-break. A null is position-final after the first pass and its
+ * order among nulls immaterial, so it is reported untied rather than dragged through every window.
+ * `null_flag` is the class-bit value marking a null (`polarity.element_class(true)`); the bit sits
+ * at `prefix_bits`.
+ */
+struct key_tied_flag_packed {
+  cuda::std::uint64_t const* d_keys;
+  size_type const num_elements;
+  bool const has_nulls;
+  int const prefix_bits;
+  cuda::std::uint32_t const null_flag = 1u;
+  __device__ bool operator()(size_type i) const
+  {
+    return packed_key_is_tied(d_keys, num_elements, has_nulls, prefix_bits, null_flag, i);
+  }
+};
+
+/**
+ * @brief Per-run string-length range: the minimum and maximum byte length over a run of tied keys
+ *
+ * A length-uniform run fully covered by the compared windows holds only copies of one string, so
+ * its order is final; a mixed-length run is a zero-extension family (a shorter string colliding
+ * with a longer one's real or zero-filled bytes) the cleanup must still order shorter-first.
+ */
+struct len_minmax {
+  size_type min_len;
+  size_type max_len;
+};
+
+/// Range union; associative and commutative, as `reduce_by_key` requires.
+struct len_minmax_combine {
+  __device__ len_minmax operator()(len_minmax const& a, len_minmax const& b) const
+  {
+    return len_minmax{cuda::std::min(a.min_len, b.min_len), cuda::std::max(a.max_len, b.max_len)};
+  }
+};
+
+/// Seeds each element's byte length as a degenerate range for the per-run reduction. The loop call
+/// site's active set is null-free (the tie gate excludes nulls), but the first-pass site runs over
+/// every element, so a null is guarded into a zero-length range here -- that slot is never read by
+/// `keep_tied_first`/`keep_active_window`, which bail out on the class bit first.
+struct string_length_minmax {
+  size_type const* d_children;
+  column_device_view const d_strings;
+  bool const has_nulls;
+  __device__ len_minmax operator()(size_type i) const
+  {
+    auto const idx = d_children[i];
+    if (has_nulls && d_strings.is_null(idx)) { return len_minmax{0, 0}; }
+    auto const len = d_strings.element<string_view>(idx).size_bytes();
+    return len_minmax{len, len};
+  }
+};
+
+/**
+ * @brief First-pass tie flag refined to drop byte-identical exhausted runs
+ *
+ * Extends `key_tied_flag_packed`: a run whose lengths are uniform and no greater than
+ * `known_equal_bytes` holds one repeated string, so every copy is position-final at its stable
+ * first-pass slot and skips the loop and its O(N) buffers. A mixed-length run stays: a shorter
+ * string can share a longer one's key through the zero-fill, and only the cleanup can order it.
+ *
+ * The drop is polarity-independent: lengths read real bytes, not the possibly-complemented key,
+ * and the complement is a bijection so runs are identical sets under either order -- uniform-length
+ * covered runs are duplicates whose shared slot is final under any order.
+ */
+struct keep_tied_first {
+  cuda::std::uint64_t const* d_keys;
+  size_type const num_elements;
+  bool const has_nulls;
+  int const prefix_bits;
+  cuda::std::uint32_t const* d_run_ids;
+  len_minmax const* d_run_minmax;
+  size_type const known_equal_bytes;
+  cuda::std::uint32_t const null_flag = 1u;
+  __device__ bool operator()(size_type i) const
+  {
+    if (!packed_key_is_tied(d_keys, num_elements, has_nulls, prefix_bits, null_flag, i)) {
+      return false;
+    }
+    auto const mm        = d_run_minmax[d_run_ids[i] - 1];
+    auto const identical = mm.min_len == mm.max_len && mm.max_len <= known_equal_bytes;
+    return !identical;
+  }
+};
+
+/**
+ * @brief Window-loop tie flag refined to drop byte-identical exhausted runs
+ *
+ * As `keep_tied_first`, with `covered` the leading bytes a run agrees on after this pass: a
+ * length-uniform run within `covered` holds only copies of one string, so its stable radix order
+ * is final and it is frozen like a singleton; a mixed-length run is kept for the length-aware
+ * cleanup. Polarity-independent for the same reason as `keep_tied_first`.
+ */
+struct keep_active_window {
+  prefix_key96 const* d_keys;
+  size_type const num_elements;
+  cuda::std::uint32_t const* d_run_ids;
+  len_minmax const* d_run_minmax;
+  size_type const covered;
+  cuda::std::uint32_t const null_flag = 1u;
+  __device__ bool operator()(size_type i) const
+  {
+    auto const cur = d_keys[i];
+    if ((cur.seg_null & 1u) == null_flag) { return false; }
+    auto const eq_prev = i > 0 && keys_equal(d_keys[i - 1], cur);
+    auto const eq_next = i + 1 < num_elements && keys_equal(d_keys[i + 1], cur);
+    if (!(eq_prev || eq_next)) { return false; }
+    auto const mm        = d_run_minmax[d_run_ids[i] - 1];
+    auto const identical = mm.min_len == mm.max_len && mm.max_len <= covered;
+    return !identical;
+  }
+};
+
+/**
+ * @brief Builds the next-pass radix key for the element currently at a sorted position
+ *
+ * `seg_null` packs the run rank -- the dominant field, so the radix preserves all order resolved
+ * by prior passes and reorders only within a still-tied run -- over the class bit; the window
+ * words hold the next eight string bytes. Descending complements only the window, sending an
+ * exhausted zero to the maximum so a shorter string sorts after longer ones sharing its prefix. A
+ * null (excluded from the tie set, handled defensively) gets the class bit and a zero window.
+ */
+struct window_key_builder {
+  cuda::std::uint32_t const* d_run_ids;
+  size_type const* d_sorted_indices;
+  column_device_view const d_strings;
+  bool const has_nulls;
+  size_type const window_start;
+  sort_polarity const polarity;
+  __device__ prefix_key96 operator()(size_type i) const
+  {
+    auto const run_id = d_run_ids[i];
+    auto const idx    = d_sorted_indices[i];
+    if (has_nulls && d_strings.is_null(idx)) {
+      return prefix_key96{pack_seg_null(run_id, polarity.element_class(true)), 0u, 0u};
+    }
+    prefix_key96 key{pack_seg_null(run_id, polarity.element_class(false)), 0u, 0u};
+    split_prefix(
+      pack_window(d_strings.element<string_view>(idx), window_start) ^ polarity.value_mask64(),
+      key.prefix_hi,
+      key.prefix_lo);
+    return key;
+  }
+};
+
+/**
+ * @brief Seeds the iterative window path's first-pass key from the single-`uint64` first sort
+ *
+ * The seed's run boundaries must match exactly what the first sort resolved and nothing finer, so
+ * `seg_null` packs the dense run rank and the window words stay zero: embedding the first window
+ * here would split packed-key ties into distinct ranks, freezing an arbitrary order the windows
+ * must still be free to refine. The null flag is carried for consistency; the tie set excludes
+ * nulls.
+ */
+struct tied_run_seed_builder {
+  cuda::std::uint32_t const* d_run_ids;
+  cuda::std::uint64_t const* d_packed_keys;
+  int const prefix_bits;
+  bool const has_nulls;
+  __device__ prefix_key96 operator()(size_type i) const
+  {
+    auto const is_null =
+      has_nulls ? static_cast<cuda::std::uint32_t>((d_packed_keys[i] >> prefix_bits) & 1u) : 0u;
+    return prefix_key96{pack_seg_null(d_run_ids[i], is_null), 0u, 0u};
+  }
+};
+
+/**
+ * @brief Unsigned-byte comparison of two strings starting at a shared byte offset
+ *
+ * Reproduces `string_view::compare` exactly for any pair whose first `offset` bytes match -- that
+ * compare would consume those equal bytes with no effect. On an all-equal common region the
+ * full-length difference carries the sign of the length tie-break, including when a string is no
+ * longer than `offset` (e.g. a string vs itself plus a trailing embedded null).
+ */
+__device__ inline int compare_suffix(string_view const& a, string_view const& b, size_type offset)
+{
+  auto const a_len = cuda::std::max(0, a.size_bytes() - offset);
+  auto const b_len = cuda::std::max(0, b.size_bytes() - offset);
+  auto const* pa =
+    reinterpret_cast<unsigned char const*>(a.data()) + cuda::std::min(offset, a.size_bytes());
+  auto const* pb =
+    reinterpret_cast<unsigned char const*>(b.data()) + cuda::std::min(offset, b.size_bytes());
+  auto const common = cuda::std::min(a_len, b_len);
+  for (size_type i = 0; i < common; ++i) {
+    if (pa[i] != pb[i]) { return static_cast<int>(pa[i]) - static_cast<int>(pb[i]); }
+  }
+  return a.size_bytes() - b.size_bytes();
+}
+
+/**
+ * @brief Run length at or above which a prefix-tie run is sorted by heapsort instead of insertion
+ *
+ * Insertion sort is optimal for the typical tiny runs but O(run^2): a fully-shared-prefix segment
+ * collapses to one run spanning it, turning the tie-break into a multi-second straggler. Heapsort
+ * caps that worst case and leaves the common tiny-run path untouched.
+ */
+constexpr size_type TIE_HEAPSORT_THRESHOLD = 32;
+
+/**
+ * @brief Maximum number of iterative eight-byte radix windows after the initial prefix pass
+ *
+ * Bounds the worst case: an arbitrarily long shared prefix would otherwise demand one pass per
+ * eight shared bytes. Whatever stays tied past the cap is finished by the comparison cleanup, so
+ * correctness never depends on the cap, only the pass count does.
+ */
+constexpr size_type MAX_RADIX_PASSES = 8;
+
+/**
+ * @brief Reorders prefix-tied runs by suffix comparison to match the comparison sort exactly
+ *
+ * Each maximal run of equal keys is owned by its first position, which sorts the run's child
+ * indices by unsigned bytes from `tie_offset` (the proven-shared prefix width) onward. Genuine
+ * duplicates compare equal, so the path being unstable is immaterial. Tiny runs use insertion
+ * sort; runs reaching `TIE_HEAPSORT_THRESHOLD` use heapsort so a shared-prefix run spanning a
+ * whole segment cannot go quadratic.
+ *
+ * Descending inverts the comparison's sign, reversing both byte order and the length tie-break to
+ * match the descending window keys' exhausted-zero-to-maximum complement. A null-classed run holds
+ * only nulls, is never compared, and is left in place -- and none reach here, the tie gate
+ * excludes them.
+ */
+struct prefix_tie_breaker {
+  prefix_key96 const* d_keys;
+  size_type* d_indices;
+  column_device_view const d_strings;
+  size_type const num_elements;
+  size_type const tie_offset;
+  bool const descending               = false;
+  cuda::std::uint32_t const null_flag = 1u;
+
+  // Strict "orders before" in the requested direction; descending inverts the suffix compare.
+  __device__ bool index_less(size_type a, size_type b) const
+  {
+    auto const cmp = compare_suffix(
+      d_strings.element<string_view>(a), d_strings.element<string_view>(b), tie_offset);
+    return descending ? cmp > 0 : cmp < 0;
+  }
+
+  // Restores the max-heap property below `root` over the `n`-element run at `base`.
+  __device__ void sift_down(size_type* base, int64_t root, int64_t n) const
+  {
+    while (true) {
+      auto const left = 2 * root + 1;
+      if (left >= n) { break; }
+      auto largest     = left;
+      auto const right = left + 1;
+      if (right < n && index_less(base[left], base[right])) { largest = right; }
+      if (!index_less(base[root], base[largest])) { break; }
+      auto const tmp = base[root];
+      base[root]     = base[largest];
+      base[largest]  = tmp;
+      root           = largest;
+    }
+  }
+
+  // Insertion-sorts the run's indices [i, run_end) by suffix; quadratic but branch-cheap, used
+  // only below TIE_HEAPSORT_THRESHOLD.
+  __device__ void sort_run_insertion(size_type i, size_type run_end) const
+  {
+    for (auto j = i + 1; j < run_end; ++j) {
+      auto const idx_j = d_indices[j];
+      auto const str_j = d_strings.element<string_view>(idx_j);
+      auto k           = j;
+      while (k > i) {
+        auto const cmp =
+          compare_suffix(d_strings.element<string_view>(d_indices[k - 1]), str_j, tie_offset);
+        // Shift a neighbor that must follow `str_j`: greater ascending, smaller descending.
+        if (!(descending ? cmp < 0 : cmp > 0)) { break; }
+        d_indices[k] = d_indices[k - 1];
+        --k;
+      }
+      d_indices[k] = idx_j;
+    }
+  }
+
+  // Heapsorts the run's indices [i, i+run_len) by suffix; guarantees O(n log n) so a
+  // whole-segment shared-prefix run cannot go quadratic.
+  __device__ void sort_run_heap(size_type i, size_type run_len) const
+  {
+    auto* const base = d_indices + i;
+    for (auto start = run_len / 2; start > 0; --start) {
+      sift_down(base, start - 1, run_len);
+    }
+    for (auto heap_size = run_len; heap_size > 1; --heap_size) {
+      auto const tmp      = base[0];
+      base[0]             = base[heap_size - 1];
+      base[heap_size - 1] = tmp;
+      sift_down(base, 0, heap_size - 1);
+    }
+  }
+
+  __device__ void operator()(size_type i) const
+  {
+    // Only the first position of a run does the work; runs are disjoint so writes never overlap.
+    auto const key = d_keys[i];
+    if (i > 0 && keys_equal(d_keys[i - 1], key)) { return; }
+    // A null-classed run's string data must not be read; skip it.
+    if ((key.seg_null & 1u) == null_flag) { return; }
+
+    auto run_end = i + 1;
+    while (run_end < num_elements && keys_equal(d_keys[run_end], key)) {
+      ++run_end;
+    }
+    auto const run_len = run_end - i;
+    if (run_len < 2) { return; }
+
+    if (run_len < TIE_HEAPSORT_THRESHOLD) {
+      sort_run_insertion(i, run_end);
+    } else {
+      sort_run_heap(i, run_len);
+    }
+  }
+};
+
+/// In-place inclusive rank scan (two-call CUB idiom), shared by every tie-refinement site in
+/// `fast_segmented_sorted_order_strings_prefix` -- the packed-key pass, the window-key seed, and
+/// the per-pass loop body all scan a freshly built run-head-flag array the same way.
+inline void inclusive_sum_scan(cuda::std::uint32_t* d_data,
+                               size_type count,
+                               rmm::cuda_stream_view stream)
+{
+  rmm::device_buffer d_temp_storage;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::InclusiveSum(
+    d_temp_storage.data(), temp_storage_bytes, d_data, d_data, count, stream.value());
+  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  cub::DeviceScan::InclusiveSum(
+    d_temp_storage.data(), temp_storage_bytes, d_data, d_data, count, stream.value());
+}
+
+/**
+ * @brief Owns the tie-resolution loop's per-pass working buffers and its initial (pointer, count)
+ * state
+ *
+ * Returned by `setup_tie_resolution_loop` and consumed by the loop that follows it inline in
+ * `fast_segmented_sorted_order_strings_prefix`: the loop itself stays a plain `for` over ordinary
+ * local variables destructured from this struct, never a struct-taking function of its own.
+ */
+struct tie_loop_state {
+  rmm::device_uvector<prefix_key96> tied_keys_a;
+  rmm::device_uvector<prefix_key96> tied_keys_b;
+  rmm::device_uvector<size_type> child_a;
+  rmm::device_uvector<size_type> child_b;
+  rmm::device_uvector<size_type> comp_pos;
+  rmm::device_uvector<size_type> pos_b;
+  rmm::device_uvector<cuda::std::uint32_t> run_ids;
+  rmm::device_uvector<len_minmax> elem_minmax;
+  rmm::device_uvector<len_minmax> run_minmax;
+  cudf::detail::device_scalar<size_type> d_num_tied;
+  size_type num_active;
+  size_type consumed_bytes;
+};
+
+/**
+ * @brief Compacts the tied subset, seeds its rank-only run keys, and allocates the tie-resolution
+ * loop's per-pass buffers
+ *
+ * `tied_keys_packed` is local to this function -- unlike the original single-function version, no
+ * explicit early release is needed, since it goes out of scope (and its device memory is freed,
+ * stream-ordered) when this function returns, strictly before the loop it feeds ever runs.
+ */
+inline tie_loop_state setup_tie_resolution_loop(cuda::std::uint64_t const* keys_out,
+                                                bool const* tied_flags,
+                                                size_type const* d_indices_out,
+                                                cuda::counting_iterator<size_type> counting,
+                                                size_type num_elements,
+                                                size_type num_tied,
+                                                size_type known_equal_bytes,
+                                                bool has_nulls,
+                                                int prefix_bits,
+                                                rmm::cuda_stream_view stream)
+{
+  rmm::device_uvector<size_type> comp_pos(num_tied, stream);
+  rmm::device_uvector<size_type> child_a(num_tied, stream);
+  rmm::device_uvector<cuda::std::uint64_t> tied_keys_packed(num_tied, stream);
+  rmm::device_uvector<prefix_key96> tied_keys_a(num_tied, stream);
+  cudf::detail::device_scalar<size_type> d_num_tied(stream);
+
+  // The tie count is already known, so `d_num_tied` here only satisfies the API; it is re-read
+  // per pass inside the loop.
+  cub_select_flagged(
+    counting, tied_flags, comp_pos.data(), d_num_tied.data(), num_elements, stream);
+  cub_select_flagged(
+    d_indices_out, tied_flags, child_a.data(), d_num_tied.data(), num_elements, stream);
+  cub_select_flagged(
+    keys_out, tied_flags, tied_keys_packed.data(), d_num_tied.data(), num_elements, stream);
+
+  rmm::device_uvector<size_type> child_b(num_tied, stream);
+  rmm::device_uvector<prefix_key96> tied_keys_b(num_tied, stream);
+  rmm::device_uvector<size_type> pos_b(num_tied, stream);
+  rmm::device_uvector<cuda::std::uint32_t> run_ids(num_tied, stream);
+  rmm::device_uvector<len_minmax> elem_minmax(num_tied, stream);
+  rmm::device_uvector<len_minmax> run_minmax(num_tied, stream);
+
+  // Seed `tied_keys_a` with rank-only keys reproducing exactly the runs the uint64 sort left
+  // tied; embedding a window here would over-split them (see `tied_run_seed_builder`).
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    counting,
+                    counting + num_tied,
+                    run_ids.begin(),
+                    key_head_flag_packed{tied_keys_packed.data()});
+  inclusive_sum_scan(run_ids.data(), num_tied, stream);
+  thrust::transform(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    counting,
+    counting + num_tied,
+    tied_keys_a.begin(),
+    tied_run_seed_builder{run_ids.data(), tied_keys_packed.data(), prefix_bits, has_nulls});
+
+  return tie_loop_state{cuda::std::move(tied_keys_a),
+                        cuda::std::move(tied_keys_b),
+                        cuda::std::move(child_a),
+                        cuda::std::move(child_b),
+                        cuda::std::move(comp_pos),
+                        cuda::std::move(pos_b),
+                        cuda::std::move(run_ids),
+                        cuda::std::move(elem_minmax),
+                        cuda::std::move(run_minmax),
+                        cuda::std::move(d_num_tied),
+                        num_tied,
+                        known_equal_bytes};
+}
+
+/**
+ * @brief Resolves any pass-cap survivors by direct comparison, then scatters the tie-resolution
+ * loop's final child order back to its output slots
+ */
+inline void finish_tie_resolution(prefix_key96 const* cur_keys,
+                                  size_type* cur_child,
+                                  size_type const* cur_pos,
+                                  size_type num_active,
+                                  size_type tie_offset,
+                                  column_device_view const& d_input,
+                                  sort_polarity polarity,
+                                  size_type* d_indices_out,
+                                  rmm::cuda_stream_view stream)
+{
+  auto const counting = cuda::counting_iterator<size_type>{0};
+  // Comparison cleanup for runs still tied after the windows: those past the pass cap plus the
+  // mixed-length zero-extension families the drop kept -- pure length ties no window can
+  // separate but `compare_suffix`'s length difference does. Survivors agree on their first
+  // `consumed_bytes` bytes, so the comparison skips them.
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   counting,
+                   counting + num_active,
+                   prefix_tie_breaker{cur_keys,
+                                      cur_child,
+                                      d_input,
+                                      num_active,
+                                      tie_offset,
+                                      polarity.descending,
+                                      polarity.element_class(true)});
+
+  // Scatter the survivors back to their output slots; everything else is already final.
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                  cur_child,
+                  cur_child + num_active,
+                  cur_pos,
+                  d_indices_out);
+}
+
+}  // namespace
+
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_prefix(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_elements = input.size();
+  auto const num_segments = segment_offsets.size() - 1;
+
+  CUDF_EXPECTS(input.has_nulls() or not polarity.nulls_first,
+               "nulls_first requires a nullable column for the packed key layout");
+  CUDF_EXPECTS(num_segments >= 1, "the packed key layout requires at least one segment");
+
+  // Label every element with its dense segment ordinal so one global radix sort orders within each
+  // segment. Ordinals are bounded by the segment count -- unlike `get_segment_indices`'s
+  // offset-derived labels (row-count bound) -- so the key's segment field needs only
+  // `bit_width(num_segments)` bits, widening the prefix; they stay monotonic with the segments,
+  // preserving cross-segment order. Offsets are normalized to span `[0, num_elements]`.
+  rmm::device_uvector<size_type> segment_ids(num_elements, stream);
+  label_segments(segment_offsets.begin<size_type>(),
+                 segment_offsets.end<size_type>(),
+                 segment_ids.begin(),
+                 segment_ids.end(),
+                 stream);
+
+  auto const d_input   = column_device_view::create(input, stream);
+  auto const has_nulls = input.has_nulls();
+
+  auto const layout = make_packed_key_layout(num_segments, has_nulls);
+  // Only floor(P/8) whole bytes are proven equal on a key match; windows and cleanup start here.
+  auto const known_equal_bytes = layout.prefix_bits / 8;
+
+  auto const counting = cuda::counting_iterator<size_type>{0};
+
+  // First-pass outputs; the packed-key inputs are scoped to the sort block below and freed early.
+  rmm::device_uvector<cuda::std::uint64_t> keys_out(num_elements, stream);
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
+  auto const d_indices_out = sorted_indices->mutable_view().begin<size_type>();
+
+  // The window path keys on the 96-bit `prefix_key96` {run rank, eight-byte window}. `seg_null`
+  // packs the rank in bits 1..31 over the null flag; the rank is bounded by the element count (a
+  // `size_type`), so `(rank << 1) | flag` fits 32 bits -- proven once here, not guarded per
+  // element.
+  static_assert(2ull * cuda::std::numeric_limits<size_type>::max() + 1ull <=
+                  cuda::std::numeric_limits<cuda::std::uint32_t>::max(),
+                "size_type run rank does not fit prefix_key96::seg_null after the null-flag shift");
+  auto const decomposer   = prefix_decomposer{};
+  auto constexpr key_bits = static_cast<int>(
+    (sizeof(cuda::std::uint32_t) + sizeof(cuda::std::uint32_t) + sizeof(cuda::std::uint32_t)) * 8);
+
+  // First pass: one global radix sort of the packed key with child indices as the paired values.
+  // The whole word is significant, so the bit range is the full [0, 64). Inputs and temporary
+  // storage are scoped here, released before the tie loop.
+  {
+    rmm::device_uvector<cuda::std::uint64_t> keys_in(num_elements, stream);
+    rmm::device_uvector<size_type> indices_in(num_elements, stream);
+    thrust::transform(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      counting,
+      counting + num_elements,
+      keys_in.begin(),
+      packed_key_builder{segment_ids.data(), *d_input, has_nulls, layout, polarity});
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     indices_in.begin(),
+                     indices_in.end(),
+                     0);
+    rmm::device_buffer d_temp_storage;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    keys_in.data(),
+                                    keys_out.data(),
+                                    indices_in.data(),
+                                    d_indices_out,
+                                    num_elements,
+                                    0,
+                                    static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+                                    stream.value());
+    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    keys_in.data(),
+                                    keys_out.data(),
+                                    indices_in.data(),
+                                    d_indices_out,
+                                    num_elements,
+                                    0,
+                                    static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+                                    stream.value());
+  }
+
+  // `segment_ids` fed only the first-pass key build; free it before the tie path grows.
+  segment_ids = rmm::device_uvector<size_type>{0, stream};
+
+  // Any-tied gate; reading the result is the tie-break's one host synchronization. On
+  // high-cardinality data nothing is tied, so the common path is the first pass plus this probe --
+  // no tie buffers, compaction, loop, or cleanup.
+  auto const tied_pred = key_tied_flag_packed{
+    keys_out.data(), num_elements, has_nulls, layout.prefix_bits, polarity.element_class(true)};
+  auto const any_tied =
+    thrust::any_of(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   counting,
+                   counting + num_elements,
+                   tied_pred);
+
+  if (any_tied) {
+    // Refine the raw packed-key ties by dropping byte-identical runs (see `keep_tied_first`). The
+    // per-run length reduction runs only on this already-gated tie path, and its N-wide
+    // temporaries are freed before the loop.
+    rmm::device_uvector<bool> tied_flags(num_elements, stream);
+    {
+      rmm::device_uvector<cuda::std::uint32_t> first_run_ids(num_elements, stream);
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_elements,
+                        first_run_ids.begin(),
+                        key_head_flag_packed{keys_out.data()});
+      inclusive_sum_scan(first_run_ids.data(), num_elements, stream);
+      rmm::device_uvector<len_minmax> first_elem_minmax(num_elements, stream);
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_elements,
+                        first_elem_minmax.begin(),
+                        string_length_minmax{d_indices_out, *d_input, has_nulls});
+      rmm::device_uvector<len_minmax> first_run_minmax(num_elements, stream);
+      thrust::reduce_by_key(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        first_run_ids.begin(),
+        first_run_ids.end(),
+        first_elem_minmax.begin(),
+        cuda::make_discard_iterator(),
+        first_run_minmax.begin(),
+        cuda::std::equal_to<cuda::std::uint32_t>{},
+        len_minmax_combine{});
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_elements,
+                        tied_flags.begin(),
+                        keep_tied_first{keys_out.data(),
+                                        num_elements,
+                                        has_nulls,
+                                        layout.prefix_bits,
+                                        first_run_ids.data(),
+                                        first_run_minmax.data(),
+                                        known_equal_bytes,
+                                        polarity.element_class(true)});
+    }
+
+    // Compact down to the still-tied positions -- everything untied is already final -- so the
+    // windows and cleanup re-sort only this shrinking subset. `comp_pos` records each tied
+    // element's output slot so the refined order scatters straight back.
+    auto const num_tied = static_cast<size_type>(
+      thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    tied_flags.begin(),
+                    tied_flags.end(),
+                    true));
+
+    auto loop_state = setup_tie_resolution_loop(keys_out.data(),
+                                                tied_flags.data(),
+                                                d_indices_out,
+                                                counting,
+                                                num_elements,
+                                                num_tied,
+                                                known_equal_bytes,
+                                                has_nulls,
+                                                layout.prefix_bits,
+                                                stream);
+    // `keys_out` is fully captured; free it before the loop's working set peaks.
+    keys_out = rmm::device_uvector<cuda::std::uint64_t>{0, stream};
+
+    // Iterative deepening over the compacted tied set: each pass computes a dense run rank from
+    // the current keys, builds the next key as {run rank, next 8-byte window}, and radixes just
+    // the tied subset. The rank is the dominant field, so a pass fixes all prior order and
+    // reorders only within still-tied runs; windows start at `known_equal_bytes` and advance eight
+    // bytes per pass.
+    //
+    // A singleton owns a unique run rank -- no later window can move it -- so resolved elements
+    // scatter to their final slots and drop from the working set; the loop stops once nothing
+    // stays tied.
+    //
+    // `cur_pos` (the still-tied output slots) stays ascending: slots pair with the sorted children
+    // by position and are only compacted, never permuted -- permuting them by the sort would
+    // misassign slots, so the radix reorders only keys and children.
+    auto* cur_keys      = loop_state.tied_keys_a.data();
+    auto* nxt_keys      = loop_state.tied_keys_b.data();
+    auto* cur_child     = loop_state.child_a.data();
+    auto* nxt_child     = loop_state.child_b.data();
+    auto* cur_pos       = loop_state.comp_pos.data();
+    auto* nxt_pos       = loop_state.pos_b.data();
+    auto& run_ids       = loop_state.run_ids;
+    auto& elem_minmax   = loop_state.elem_minmax;
+    auto& run_minmax    = loop_state.run_minmax;
+    auto& d_num_tied    = loop_state.d_num_tied;
+    auto consumed_bytes = loop_state.consumed_bytes;
+    auto num_active     = loop_state.num_active;
+    for (size_type pass = 0; pass < MAX_RADIX_PASSES && num_active > 0; ++pass) {
+      // Dense one-based run rank over the active subset: head flags, then an inclusive sum.
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_active,
+                        run_ids.begin(),
+                        key_head_flag{cur_keys});
+      inclusive_sum_scan(run_ids.data(), num_active, stream);
+
+      // Build the next key {run rank, next eight bytes} and radix the active subset; all 96 bits
+      // are significant, so the bit range is the full [0, key_bits).
+      thrust::transform(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        counting,
+        counting + num_active,
+        nxt_keys,
+        window_key_builder{
+          run_ids.data(), cur_child, *d_input, has_nulls, consumed_bytes, polarity});
+      {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        nxt_keys,
+                                        cur_keys,
+                                        cur_child,
+                                        nxt_child,
+                                        num_active,
+                                        decomposer,
+                                        0,
+                                        key_bits,
+                                        stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        nxt_keys,
+                                        cur_keys,
+                                        cur_child,
+                                        nxt_child,
+                                        num_active,
+                                        decomposer,
+                                        0,
+                                        key_bits,
+                                        stream.value());
+      }
+      // The radix wrote sorted keys to `cur_keys` but sorted children to `nxt_child`; swap so
+      // `cur_child` names the sorted indices.
+      cuda::std::swap(cur_child, nxt_child);
+
+      // Flag who stays tied under the refreshed order: singletons and byte-identical runs drop
+      // (see `keep_active_window`); `covered` is `consumed_bytes` plus this pass's window.
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_active,
+                        elem_minmax.begin(),
+                        string_length_minmax{cur_child, *d_input, has_nulls});
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_active,
+                        run_ids.begin(),
+                        key_head_flag{cur_keys});
+      inclusive_sum_scan(run_ids.data(), num_active, stream);
+      thrust::reduce_by_key(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        run_ids.begin(),
+        run_ids.begin() + num_active,
+        elem_minmax.begin(),
+        cuda::make_discard_iterator(),
+        run_minmax.begin(),
+        cuda::std::equal_to<cuda::std::uint32_t>{},
+        len_minmax_combine{});
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_active,
+                        tied_flags.begin(),
+                        keep_active_window{cur_keys,
+                                           num_active,
+                                           run_ids.data(),
+                                           run_minmax.data(),
+                                           consumed_bytes + PREFIX_BYTES,
+                                           polarity.element_class(true)});
+
+      // Freeze resolved elements: scatter each untied child index to its final output slot.
+      thrust::scatter_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         cur_child,
+                         cur_child + num_active,
+                         cur_pos,
+                         tied_flags.begin(),
+                         d_indices_out,
+                         cuda::std::logical_not<bool>{});
+
+      // Compact keys, children, and slots to the still-tied remainder. Reading the surviving count
+      // is the one host sync per pass; a device-side predicate could remove it, but the pass count
+      // is tiny so it stays simple.
+      cub_select_flagged(
+        cur_keys, tied_flags.data(), nxt_keys, d_num_tied.data(), num_active, stream);
+      cub_select_flagged(
+        cur_child, tied_flags.data(), nxt_child, d_num_tied.data(), num_active, stream);
+      cub_select_flagged(
+        cur_pos, tied_flags.data(), nxt_pos, d_num_tied.data(), num_active, stream);
+      cuda::std::swap(cur_keys, nxt_keys);
+      cuda::std::swap(cur_child, nxt_child);
+      cuda::std::swap(cur_pos, nxt_pos);
+      num_active = d_num_tied.value(stream);
+      consumed_bytes += PREFIX_BYTES;
+    }
+
+    finish_tie_resolution(cur_keys,
+                          cur_child,
+                          cur_pos,
+                          num_active,
+                          consumed_bytes,
+                          *d_input,
+                          polarity,
+                          d_indices_out,
+                          stream);
+  }
+
+  return sorted_indices;
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/sort/segmented_sort_strings.cu
+++ b/cpp/src/sort/segmented_sort_strings.cu
@@ -5,11 +5,13 @@
 
 #include "segmented_sort_fast.cuh"
 #include "segmented_sort_keys.cuh"
+#include "segmented_sort_warp_kernel.cuh"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/device_scalar.hpp>
 #include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/hashing/detail/hash_functions.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/utilities/error.hpp>
@@ -132,8 +134,7 @@ struct packed_key_builder {
              (static_cast<cuda::std::uint64_t>(polarity.element_class(true)) << layout.prefix_bits);
     }
     auto const full_prefix = pack_window(d_strings.element<string_view>(idx), 0);
-
-    auto const prefix = (full_prefix >> (64 - layout.prefix_bits)) ^
+    auto const prefix      = (full_prefix >> (64 - layout.prefix_bits)) ^
                         (polarity.value_mask64() >> (64 - layout.prefix_bits));
     // Null-free layouts reserve no class bit; the OR is then provably zero: callers resolve
     // `nulls_first == false` for null-free columns, and `element_class(false) == nulls_first`.
@@ -496,6 +497,148 @@ struct prefix_tie_breaker {
     }
   }
 };
+
+// ==========================================================================================
+// Graduated-warp per-segment sort for a single STRING key column.
+//
+// When every segment fits `STRINGS_GRAD_WARP_CAP`, sorting each segment in a virtual warp with
+// `cub::WarpMergeSort` beats the global prefix-radix machine. The warp width graduates with the
+// segment-size band (W8 <= 16, W16 17-32, W32 33-64) so a tiny segment never occupies a full warp.
+// The 8-byte comparator key drives the bottom bands, where the 16-byte prekey's merge-exchange
+// volume dominates over mostly-pad tiles; the prekey drives W16/W32, where its packed prefix
+// window amortizes. The (0,8] slice sorts one item per lane, halving pad traffic. A column with
+// any segment above the cap falls through to the prefix path.
+// ==========================================================================================
+
+/// Largest segment size the graduated-warp string path admits: the W32 x 2 register tile.
+constexpr size_type STRINGS_GRAD_WARP_CAP = 64;
+
+/**
+ * @brief Ordering key for the comparator-key bands: the element's global index plus its class
+ *
+ * The comparator reads string bytes through `gidx`, keeping the key at eight bytes. `cls` collects
+ * nulls on the requested side and pad strictly above both classes, as the fixed-width tiers
+ * require. `gidx` is dereferenced only for the valid class, so a null or pad key never reads
+ * string data.
+ */
+struct strings_grad_cmp_key {
+  size_type gidx;
+  cuda::std::uint32_t cls;
+};
+static_assert(sizeof(strings_grad_cmp_key) == 8, "strings_grad_cmp_key must stay eight bytes");
+
+struct strings_grad_cmp_key_builder {
+  column_device_view d_strings;
+  bool has_nulls;
+  sort_polarity polarity;
+  __device__ strings_grad_cmp_key operator()(size_type idx) const
+  {
+    return strings_grad_cmp_key{idx, polarity.element_class(has_nulls && d_strings.is_null(idx))};
+  }
+};
+
+/**
+ * @brief Strict-weak less for the comparator key: class first, then the full byte comparison
+ *
+ * Same-class null or pad keys compare equivalent (unstable path, bytes never read). The valid
+ * class ordinal follows the polarity -- `element_class(false)` is 1 under nulls-first, so a
+ * hardcoded constant would misfire. Descending inverts the comparison's sign, reversing byte order
+ * and the length tie-break.
+ */
+struct strings_grad_cmp_less {
+  column_device_view d_strings;
+  sort_polarity polarity;
+  __device__ bool operator()(strings_grad_cmp_key const& a, strings_grad_cmp_key const& b) const
+  {
+    if (a.cls != b.cls) { return a.cls < b.cls; }
+    if (a.cls != polarity.element_class(false)) { return false; }
+    auto const cmp =
+      d_strings.element<string_view>(a.gidx).compare(d_strings.element<string_view>(b.gidx));
+    return polarity.descending ? cmp > 0 : cmp < 0;
+  }
+};
+
+/**
+ * @brief Ordering key for the prekey bands: a packed leading-byte prefix over the index
+ *
+ * `prefix` is `pack_window` at offset zero, complemented at build time when descending. A prefix
+ * tie leaves two cases -- the strings genuinely share their first eight bytes, or a shorter
+ * string's zero-fill collided with real zero bytes (`S` vs `S + "\0"`) -- and `compare_suffix`
+ * from byte eight orders both: its byte walk the first, its full-length difference the second.
+ */
+struct strings_grad_prekey {
+  cuda::std::uint64_t prefix;
+  size_type gidx;
+  cuda::std::uint32_t cls;
+};
+static_assert(sizeof(strings_grad_prekey) == 16 and alignof(strings_grad_prekey) == 8,
+              "strings_grad_prekey must stay sixteen bytes with eight-byte alignment");
+
+/// A null carries a zero prefix and is never inspected past the class compare.
+struct strings_grad_prekey_builder {
+  column_device_view d_strings;
+  bool has_nulls;
+  sort_polarity polarity;
+  __device__ strings_grad_prekey operator()(size_type idx) const
+  {
+    if (has_nulls && d_strings.is_null(idx)) {
+      return strings_grad_prekey{0, idx, polarity.element_class(true)};
+    }
+    return strings_grad_prekey{
+      pack_window(d_strings.element<string_view>(idx), 0) ^ polarity.value_mask64(),
+      idx,
+      polarity.element_class(false)};
+  }
+};
+
+/**
+ * @brief Strict-weak less for the prekey: class, then packed prefix, bytes only on a tie
+ *
+ * The prefix was complemented at build time under descending, so its plain unsigned compare is
+ * direction-correct. The byte comparison starts at `PREFIX_BYTES` -- the tie proves the window
+ * equal -- and descending inverts its sign. The valid class follows the polarity.
+ */
+struct strings_grad_prekey_less {
+  column_device_view d_strings;
+  sort_polarity polarity;
+  __device__ bool operator()(strings_grad_prekey const& a, strings_grad_prekey const& b) const
+  {
+    if (a.cls != b.cls) { return a.cls < b.cls; }
+    if (a.cls != polarity.element_class(false)) { return false; }
+    if (a.prefix != b.prefix) { return a.prefix < b.prefix; }
+    auto const cmp = compare_suffix(d_strings.element<string_view>(a.gidx),
+                                    d_strings.element<string_view>(b.gidx),
+                                    size_type{PREFIX_BYTES});
+    return polarity.descending ? cmp > 0 : cmp < 0;
+  }
+};
+
+/// Launches one graduated band: `W`-lane virtual warps sort segments sized in `(band_lo, band_hi]`,
+/// self-filtering over the full segment list as the fixed-width warp bands do.
+template <int W,
+          int IPT,
+          typename KeyT,
+          typename KeyBuilder,
+          typename CompareOp,
+          typename SegListIt>
+void launch_strings_grad_band(KeyBuilder const& build_key,
+                              CompareOp const& compare_op,
+                              KeyT const pad_key,
+                              size_type const* d_offsets,
+                              SegListIt d_seg_list,
+                              size_type num_segments,
+                              size_type band_lo,
+                              size_type band_hi,
+                              size_type* d_out,
+                              rmm::cuda_stream_view stream)
+{
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_segments) * W, TIERED_BLOCK_THREADS);
+  tiered_warp_band_kernel<KeyT, KeyBuilder, W, IPT, TIERED_BLOCK_THREADS, CompareOp>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(
+      d_offsets, d_seg_list, num_segments, band_lo, band_hi, build_key, d_out, compare_op, pad_key);
+  CUDF_CHECK_CUDA(stream.value());
+}
 
 /// In-place inclusive rank scan (two-call CUB idiom), shared by every tie-refinement site in
 /// `fast_segmented_sorted_order_strings_prefix` -- the packed-key pass, the window-key seed, and
@@ -961,6 +1104,76 @@ inline void finish_tie_resolution(prefix_key96 const* cur_keys,
                           stream);
   }
 
+  return sorted_indices;
+}
+
+bool strings_grad_all_segments_fit(column_view const& segment_offsets, rmm::cuda_stream_view stream)
+{
+  auto const num_segments = segment_offsets.size() - 1;
+  auto const d_offsets    = segment_offsets.begin<size_type>();
+  auto const oversized =
+    thrust::count_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     cuda::counting_iterator<size_type>{0},
+                     cuda::counting_iterator<size_type>{num_segments},
+                     segment_exceeds_size{d_offsets, STRINGS_GRAD_WARP_CAP});
+  return oversized == 0;
+}
+
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_grad(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_elements = input.size();
+  auto const num_segments = segment_offsets.size() - 1;
+  auto const d_input      = column_device_view::create(input, stream);
+  auto const has_nulls    = input.has_nulls();
+  auto const d_offsets    = segment_offsets.begin<size_type>();
+
+#ifndef NDEBUG
+  // The caller's admission gate already ran this synchronizing probe; re-check in debug builds
+  // only, so a future direct caller cannot slip an oversized segment past the warp-tile cap into
+  // an out-of-bounds gather.
+  CUDF_EXPECTS(strings_grad_all_segments_fit(segment_offsets, stream),
+               "every segment must fit STRINGS_GRAD_WARP_CAP for the graduated path");
+#endif
+
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
+  auto* const d_out = sorted_indices->mutable_view().begin<size_type>();
+
+  // The band kernel walks an explicit segment list; here it is the identity, expressed as a
+  // counting iterator so no device list is allocated or filled.
+  auto const seg_list = cuda::counting_iterator<size_type>{0};
+
+  // Pad stays `tier_pad`, ranking strictly above either element class under any polarity.
+  auto const cmp_build = strings_grad_cmp_key_builder{*d_input, has_nulls, polarity};
+  auto const cmp_less  = strings_grad_cmp_less{*d_input, polarity};
+  auto const cmp_pad =
+    strings_grad_cmp_key{0, static_cast<cuda::std::uint32_t>(tiered_element_class::tier_pad)};
+  auto const pre_build = strings_grad_prekey_builder{*d_input, has_nulls, polarity};
+  auto const pre_less  = strings_grad_prekey_less{*d_input, polarity};
+  auto const pre_pad =
+    strings_grad_prekey{0, 0, static_cast<cuda::std::uint32_t>(tiered_element_class::tier_pad)};
+
+  launch_strings_grad_band<8, 1>(
+    cmp_build, cmp_less, cmp_pad, d_offsets, seg_list, num_segments, 0, 8, d_out, stream);
+  launch_strings_grad_band<8, 2>(
+    cmp_build, cmp_less, cmp_pad, d_offsets, seg_list, num_segments, 8, 16, d_out, stream);
+  launch_strings_grad_band<16, 2>(
+    pre_build, pre_less, pre_pad, d_offsets, seg_list, num_segments, 16, 32, d_out, stream);
+  launch_strings_grad_band<32, 2>(pre_build,
+                                  pre_less,
+                                  pre_pad,
+                                  d_offsets,
+                                  seg_list,
+                                  num_segments,
+                                  32,
+                                  STRINGS_GRAD_WARP_CAP,
+                                  d_out,
+                                  stream);
   return sorted_indices;
 }
 

--- a/cpp/src/sort/segmented_sort_strings.cu
+++ b/cpp/src/sort/segmented_sort_strings.cu
@@ -182,10 +182,10 @@ __device__ inline bool packed_key_is_tied(cuda::std::uint64_t const* d_keys,
 /**
  * @brief Flags `uint64`-key positions equal to a neighbor (a run of two or more), never a null
  *
- * Sizes and gates the iterative tie-break. A null is position-final after the first pass and its
- * order among nulls immaterial, so it is reported untied rather than dragged through every window.
- * `null_flag` is the class-bit value marking a null (`polarity.element_class(true)`); the bit sits
- * at `prefix_bits`.
+ * The `uint64` analogue of `key_tied_flag`, sizing and gating the iterative tie-break. A null is
+ * position-final after the first pass and its order among nulls immaterial, so it is reported
+ * untied rather than dragged through every window. `null_flag` is the class-bit value marking a
+ * null (`polarity.element_class(true)`); the bit sits at `prefix_bits`.
  */
 struct key_tied_flag_packed {
   cuda::std::uint64_t const* d_keys;

--- a/cpp/src/sort/segmented_sort_warp_kernel.cuh
+++ b/cpp/src/sort/segmented_sort_warp_kernel.cuh
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cudf/detail/utilities/assert.cuh>
+#include <cudf/detail/utilities/grid_1d.cuh>
+#include <cudf/types.hpp>
+
+#include <cub/warp/warp_merge_sort.cuh>
+
+namespace cudf {
+namespace detail {
+
+/**
+ * @brief Warp-tier `cub::WarpMergeSort` kernel over a segment-size band
+ *
+ * Key type, builder, comparator and pad are parameters so the packed (null-aware) and raw
+ * (no-null) modes and every `(W, IPT)` shape share one body. A virtual warp of `W` lanes owns one
+ * segment from `d_seg_list` and returns before sorting when its size falls outside
+ * `(band_lo, band_hi]`; all `W` lanes share `seg_size`, so a virtual warp returns together and
+ * never desynchronizes the `__syncwarp` inside `WarpMergeSort`, letting several bands share one
+ * segment list. Slots past the real size hold the pad key; only `[0, seg_size)` is written back.
+ * A function template so the STABLE translation unit, which never instantiates the tiered path,
+ * emits no unused `static` kernel under -Werror.
+ */
+template <typename KeyT,
+          typename KeyBuilder,
+          int W,
+          int IPT,
+          int BLOCK_THREADS,
+          typename CompareOp,
+          typename SegListIt>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_warp_band_kernel(
+  size_type const* d_offsets,
+  SegListIt d_seg_list,
+  size_type num_class_segments,
+  size_type band_lo,
+  size_type band_hi,
+  KeyBuilder build_key,
+  size_type* d_out,
+  CompareOp compare_op,
+  KeyT pad_key)
+{
+  using WarpMergeSortT           = cub::WarpMergeSort<KeyT, IPT, W, size_type>;
+  constexpr int VWARPS_PER_BLOCK = BLOCK_THREADS / W;
+  __shared__ typename WarpMergeSortT::TempStorage temp_storage[VWARPS_PER_BLOCK];
+
+  auto const global_tid = cudf::detail::grid_1d::global_thread_id<BLOCK_THREADS>();
+  auto const vwarp_id   = static_cast<size_type>(global_tid / W);
+  auto const lane       = static_cast<int>(threadIdx.x % W);
+  auto const vwarp_slot = static_cast<int>(threadIdx.x / W);
+  if (vwarp_id >= num_class_segments) { return; }
+
+  auto const seg       = d_seg_list[vwarp_id];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+  if (seg_size <= band_lo || seg_size > band_hi) { return; }
+  // The register tile holds W*IPT elements; a band_hi above that would silently drop elements.
+  cudf_assert(seg_size <= W * IPT && "band segment exceeds the register tile (band_hi > W*IPT)");
+
+  KeyT keys[IPT];
+  size_type vals[IPT];
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) {
+      auto const gidx = seg_start + local;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = pad_key;
+      vals[i] = size_type{0};
+    }
+  }
+
+  WarpMergeSortT(temp_storage[vwarp_slot])
+    .StableSort(keys, vals, compare_op, static_cast<int>(seg_size), pad_key);
+
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) { d_out[seg_start + local] = vals[i]; }
+  }
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/tests/lists/set_operations/difference_distinct_tests.cpp
+++ b/cpp/tests/lists/set_operations/difference_distinct_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,6 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/lists/set_operations.hpp>
 #include <cudf/lists/sorting.hpp>
-#include <cudf/null_mask.hpp>
 
 #include <limits>
 #include <string>
@@ -228,19 +227,13 @@ TEST_F(SetDifferenceTest, StringTestsWithNullsEqual)
        strings_lists{}, /* NULL */
        strings_lists{"aha", "this", "is another", "string???"}},
       null_at(1)};
-    auto const expected = [] {
-      auto str_lists = strings_lists{{strings_lists{"a", "is", "string", "this"},
-                                      strings_lists{} /*NULL*/,
-                                      strings_lists{"a", "is", "string"}},
-                                     null_at(1)}
-                         .release();
-      auto& child = str_lists->child(cudf::lists_column_view::child_column_index);
-      child.set_null_mask(cudf::create_null_mask(child.size(), cudf::mask_state::ALL_VALID), 0);
-      return str_lists;
-    }();
+    auto const expected = strings_lists{{strings_lists{"a", "is", "string", "this"},
+                                         strings_lists{} /*NULL*/,
+                                         strings_lists{"a", "is", "string"}},
+                                        null_at(1)};
 
     auto const results_sorted = set_difference_sorted(lhs, rhs, NULL_EQUAL);
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results_sorted);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results_sorted);
   }
 }
 

--- a/cpp/tests/lists/set_operations/intersect_distinct_tests.cpp
+++ b/cpp/tests/lists/set_operations/intersect_distinct_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,6 @@
 #include <cudf/lists/set_operations.hpp>
 #include <cudf/lists/sorting.hpp>
 #include <cudf/lists/stream_compaction.hpp>
-#include <cudf/null_mask.hpp>
 
 #include <limits>
 #include <string>
@@ -268,18 +267,11 @@ TEST_F(SetIntersectTest, StringTestsWithNullsUnequal)
        strings_lists{}, /* NULL */
        strings_lists{"aha", "this", "is another", "string???"}},
       null_at(1)};
-    auto const expected = [] {
-      auto str_lists =
-        strings_lists{{strings_lists{}, strings_lists{} /*NULL*/, strings_lists{"this"}},
-                      null_at(1)}
-          .release();
-      auto& child = str_lists->child(cudf::lists_column_view::child_column_index);
-      child.set_null_mask(cudf::create_null_mask(child.size(), cudf::mask_state::ALL_VALID), 0);
-      return str_lists;
-    }();
+    auto const expected =
+      strings_lists{{strings_lists{}, strings_lists{} /*NULL*/, strings_lists{"this"}}, null_at(1)};
 
     auto const results_sorted = set_intersect_sorted(lhs, rhs, NULL_UNEQUAL);
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results_sorted);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results_sorted);
   }
 }
 

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -351,6 +351,29 @@ TEST_F(SortListsString, PrefixUtf8Multibyte)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
 }
 
+// The fast path folds every explicit (order, null_order) into its keys; these pin the two combos
+// the ascending/nulls-after tests never touch.
+TEST_F(SortListsString, DescendingAndNullsBeforeFastPath)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+  {  // DESCENDING, no nulls
+    StrLCW input{{"banana", "apple", "cherry", "date"}};
+    StrLCW expected{{"date", "cherry", "banana", "apple"}};
+    auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+      cudf::lists_column_view{input}, cudf::order::DESCENDING, cudf::null_order::AFTER);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+  }
+  {  // ASCENDING, nulls BEFORE: the null moves to the front
+    StrLCW input{StrLCW{{"banana", "x", "apple"}, null_at(1)}};
+    StrLCW expected{StrLCW{{"x", "apple", "banana"}, null_at(0)}};
+    auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+      cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::BEFORE);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+  }
+}
+
 // Per-row prefix ties must resolve without crossing row boundaries (the segment_id key field); the
 // empty row checks dense segment-ordinal labeling skips a zero-length segment without misaligning
 // its neighbors.
@@ -399,6 +422,12 @@ void expect_both_sort_paths_equivalent(cudf::lists_column_view const& input,
   auto const stable_sorted = cudf::lists::stable_sort_lists(input, column_order, null_precedence);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(stable_sorted->view(), expected);
 }
+
+// The three explicit combos beyond the shipped ascending / nulls-after configuration.
+constexpr std::array<std::pair<cudf::order, cudf::null_order>, 3> non_default_combos{
+  {{cudf::order::DESCENDING, cudf::null_order::AFTER},
+   {cudf::order::ASCENDING, cudf::null_order::BEFORE},
+   {cudf::order::DESCENDING, cudf::null_order::BEFORE}}};
 
 // Host oracle for one list row. cudf's null_order is comparator-level and DESCENDING swaps the
 // comparison operands, inverting null placement too: nulls land first iff (BEFORE) != (DESCENDING).
@@ -1035,6 +1064,100 @@ void expect_string_polarity_matrix(std::vector<std::vector<std::string>> const& 
 }
 }  // namespace
 
+// ============= full (order, null_order) polarity matrix over the string prefix path =============
+// Each test drives one facet of the key packing through all four combos.
+
+// Lengths 0,1,7,8,9,15,16,17 straddle the packed-key prefix boundary (~7 whole bytes) and the
+// window boundaries at bytes 8 and 16; descending exercises the byte complement across all three.
+TEST_F(SortListsString, PrefixPolarityMatrixWindowBoundaries)
+{
+  std::vector<std::string> const row{"",
+                                     "z",
+                                     "abcdefg",             // 7: exhausts at the first window
+                                     "abcdefgh",            // 8: byte-7 divergence vs "abcdefg"
+                                     "abcdefgX",            // 8: byte-7 divergence ('X' < 'h')
+                                     "PQRSTUVW1",           // 9: shares 8 bytes, diverges at byte 8
+                                     "PQRSTUVW2",           // 9
+                                     "0123456789ABCDE",     // 15
+                                     "0123456789ABCDEF",    // 16
+                                     "0123456789ABCDEFg",   // 17: byte-16 divergence, 2nd window
+                                     "0123456789ABCDEFh"};  // 17
+  expect_string_polarity_matrix({row}, {std::vector<bool>(row.size(), true)});
+}
+
+// Exhausted-window zero-fill under the descending complement: an exhausted window packs to zero,
+// which descending sends to the maximum, so proper prefixes sort last; the "a" / "a\0"
+// zero-extension pair flips with direction only via the cleanup's length tie-break.
+TEST_F(SortListsString, PrefixPolarityMatrixExhaustedAndEmbeddedNul)
+{
+  std::vector<std::string> const row{"",
+                                     "a",
+                                     std::string("a\0", 2),
+                                     std::string("a\0b", 3),
+                                     "ab",
+                                     "abc",
+                                     "abcd",
+                                     "b",
+                                     "a"};  // exact duplicate of an earlier element
+  expect_string_polarity_matrix({row}, {std::vector<bool>(row.size(), true)});
+}
+
+// Null-bearing rows exercise the class-bit placement in both the first-pass and window keys and
+// the null-run guards in the tie-break; row 1's ties resolve only past the first window.
+TEST_F(SortListsString, PrefixPolarityMatrixNullsBothPrecedences)
+{
+  std::vector<std::vector<std::string>> const rows{
+    {"apple", "x", "apricot", "apple", "y", "banana"},
+    {"z", "AAAAAAAAA", "AAAAAAAAb", "AAAAAAAAa"}};
+  std::vector<std::vector<bool>> const valids{{true, false, true, true, false, true},
+                                              {false, true, true, true}};
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// The 80-byte shared prefix outlasts every window, so the run reaches the tie-break's heapsort
+// branch under each combo; the empty row checks dense segment labeling skips it cleanly.
+TEST_F(SortListsString, PrefixPolarityMatrixMultiSegmentHeapsortRun)
+{
+  std::string const shared(80, 'Q');
+  std::vector<std::string> big;
+  for (int i = 0; i < 70; ++i) {
+    big.push_back(shared + std::to_string(i / 10) + std::to_string(i % 10));
+  }
+  big.push_back(shared + "07");  // exact duplicate within the run
+  auto shuffled = big;
+  std::shuffle(shuffled.begin(), shuffled.end(), std::mt19937{0x5A17});
+  shuffled.insert(shuffled.begin() + 3, "");
+  shuffled.push_back("zzz");
+  std::vector<bool> row0_valids(shuffled.size(), true);
+  row0_valids[1]                   = false;  // two scattered nulls
+  row0_valids[shuffled.size() - 2] = false;
+
+  std::vector<std::vector<std::string>> const rows{
+    shuffled, {}, {"melon", "apple", "cherry", "apple"}};
+  std::vector<std::vector<bool>> const valids{row0_valids, {}, std::vector<bool>(4, true)};
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// Mirrors PrefixSlicedWithNulls (ascending), pinning offset + null handling in both directions.
+TEST_F(SortListsString, PrefixDescendingSliced)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+  StrLCW l{StrLCW{"zz", "aa"},
+           StrLCW{{"banana", "apple", "x", "cherry"}, null_at(2)},  // element 2 ("x") is null
+           StrLCW{"b", "a"}};
+  auto const sliced = cudf::slice(l, {1, 3})[0];  // drops row 0 -> nonzero child offset
+  {  // DESCENDING / AFTER: the comparator swap places the null first, then values descending
+    StrLCW expected{StrLCW{{"z", "cherry", "banana", "apple"}, null_at(0)}, StrLCW{"b", "a"}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{sliced}, expected, cudf::order::DESCENDING, cudf::null_order::AFTER);
+  }
+  {  // DESCENDING / BEFORE: values descending, then the null last
+    StrLCW expected{StrLCW{{"cherry", "banana", "apple", "z"}, null_at(3)}, StrLCW{"b", "a"}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{sliced}, expected, cudf::order::DESCENDING, cudf::null_order::BEFORE);
+  }
+}
+
 // ===== graduated-warp string path: per-band polarity coverage (segments within the 64-element cap)
 // The default string fast path once every segment fits a warp tile; its bands are (0,8] one item
 // per lane, then (8,16] W8, W16, and W32.
@@ -1226,6 +1349,93 @@ TEST_F(SortListsString, GradOversizedSegmentFallsThrough)
   std::vector<std::vector<bool>> const valids{std::vector<bool>(big.size(), true),
                                               {true, true, true}};
   expect_string_polarity_matrix(rows, valids);
+}
+
+// ===== prefix string path: high-value scenarios forced past the 64-element graduated cap =====
+// Each probe pairs its data with a >64-element row: the oversized row fails the graduated
+// admission gate, so the whole column -- probe included -- genuinely rides the prefix path.
+
+// Pins the prefix path's descending byte complement and nulls-BEFORE class-bit placement, which
+// the grad-routed small-segment polarity tests never reach.
+TEST_F(SortListsString, PrefixPolarityMatrixOversizedRun)
+{
+  std::string const shared(80, 'P');
+  std::vector<std::pair<std::string, bool>> elems;
+  for (int i = 0; i < 66; ++i) {
+    elems.emplace_back(shared + std::to_string(i / 10) + std::to_string(i % 10), i % 13 != 0);
+  }
+  std::shuffle(elems.begin(), elems.end(), std::mt19937{0x9A1E});
+  std::vector<std::string> row;
+  std::vector<bool> valids;
+  for (auto const& [str, valid] : elems) {
+    row.push_back(str);
+    valids.push_back(valid);
+  }
+  expect_string_polarity_matrix({row}, {valids});
+}
+
+// The null / all-0xFF sentinel collision under all four combos; the ASCII filler tail pushes the
+// segment past the graduated cap.
+TEST_F(SortListsString, PrefixNullSentinelCollisionFFOversized)
+{
+  std::string const ff72(72, '\xff');
+  std::string const ff73(73, '\xff');
+  std::vector<std::string> row{"apple", ff73, "mango", ff72, ""};
+  std::vector<bool> valids{true, true, true, true, false};
+  for (int i = 0; i < 65; ++i) {
+    row.push_back("filler" + std::to_string(100 + i));
+    valids.push_back(true);
+  }
+  expect_string_polarity_matrix({row}, {valids});
+}
+
+// UTF-8 lead-byte ordering (0xC3 / 0xE2 / 0xF0 after ASCII) on the prefix path's packed key and
+// window compare.
+TEST_F(SortListsString, PrefixUtf8MultibyteOversized)
+{
+  std::vector<std::string> row{
+    "\xE2\x82\xAC\x75\x72\x6F", "zoo", "\xF0\x9F\x98\x80", "\xC3\xA9\x70\xC3\xA9\x65", "apple"};
+  std::vector<bool> valids(row.size(), true);
+  for (int i = 0; i < 65; ++i) {
+    row.push_back("fill" + std::to_string(100 + i));
+    valids.push_back(true);
+  }
+  expect_string_polarity_matrix({row}, {valids});
+}
+
+// Nonzero child offset on the prefix path: the packed-key builder and window compare must honor
+// it under every combo.
+TEST_F(SortListsString, PrefixSlicedOversized)
+{
+  std::string const shared(80, 'M');
+  std::vector<std::pair<std::string, bool>> elems;
+  for (int i = 0; i < 66; ++i) {
+    elems.emplace_back(shared + std::to_string(i / 10) + std::to_string(i % 10), i % 11 != 0);
+  }
+  std::shuffle(elems.begin(), elems.end(), std::mt19937{0x5CED});
+  std::vector<std::string> big;
+  std::vector<bool> big_v;
+  for (auto const& [str, valid] : elems) {
+    big.push_back(str);
+    big_v.push_back(valid);
+  }
+  std::vector<std::vector<std::string>> const rows{{"drop"}, big, {"b", "a"}};
+  std::vector<std::vector<bool>> const valids{{true}, big_v, {true, true}};
+  auto const full   = make_string_lists(rows, valids);
+  auto const sliced = cudf::slice(full->view(), {1, 3})[0];  // drop row 0 -> nonzero child offset
+
+  constexpr std::array<std::pair<cudf::order, cudf::null_order>, 4> combos{
+    {{cudf::order::ASCENDING, cudf::null_order::AFTER},
+     {cudf::order::DESCENDING, cudf::null_order::AFTER},
+     {cudf::order::ASCENDING, cudf::null_order::BEFORE},
+     {cudf::order::DESCENDING, cudf::null_order::BEFORE}}};
+  for (auto const& [ord, np] : combos) {
+    auto const s1 = host_sorted_row(big, big_v, ord, np);
+    auto const s2 =
+      host_sorted_row(std::vector<std::string>{"b", "a"}, std::vector<bool>{true, true}, ord, np);
+    auto const expected = make_string_lists({s1.first, s2.first}, {s1.second, s2.second});
+    expect_both_sort_paths_match(cudf::lists_column_view{sliced}, expected->view(), ord, np);
+  }
 }
 
 // Sign-flip correctness at INT_MIN / INT_MAX for both tiered key widths (int32 -> uint64,
@@ -2217,6 +2427,442 @@ TEST_F(SortListsInt, NumericDecimal128TwoPhaseAllTied)
   expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
 }
 
+// The same all-tied shape under DESCENDING: the complement keeps equal encoded hi64 words equal,
+// so the run still ties and phase two's complemented lo64 must reverse the refined order.
+TEST_F(SortListsInt, NumericDecimal128TwoPhaseAllTiedDescending)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  auto const band      = static_cast<__int128_t>(1) << 63;
+
+  std::vector<__int128_t> row0(250);
+  for (cudf::size_type i = 0; i < 250; ++i) {
+    row0[i] = band + (static_cast<__int128_t>(249 - i) << 32) + (i * 13) % 251;
+  }
+  row0[20] = row0[10];  // exact duplicates inside the run
+  row0[21] = row0[11];
+
+  std::vector<__int128_t> row1;
+  for (int j = 49; j >= 0; --j) {
+    auto const pair_hi      = static_cast<__int128_t>(j + 1) << 70;
+    auto const singleton_hi = static_cast<__int128_t>(j + 200) << 70;
+    row1.push_back(pair_hi + 2 * j + 1);
+    row1.push_back(singleton_hi + j);
+    row1.push_back(pair_hi + 2 * j);
+  }
+
+  auto const make_lists = [&](std::vector<__int128_t> const& a, std::vector<__int128_t> const& b) {
+    std::vector<__int128_t> leaf(a);
+    leaf.insert(leaf.end(), b.begin(), b.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{
+      0, static_cast<cudf::size_type>(a.size()), static_cast<cudf::size_type>(leaf.size())};
+    return cudf::make_lists_column(
+      2,
+      offsets.release(),
+      cudf::test::fixed_point_column_wrapper<__int128_t>(leaf.begin(), leaf.end(), scale).release(),
+      0,
+      {});
+  };
+
+  std::vector<__int128_t> ex0(row0);
+  std::vector<__int128_t> ex1(row1);
+  std::sort(ex0.begin(), ex0.end());
+  std::reverse(ex0.begin(), ex0.end());
+  std::sort(ex1.begin(), ex1.end());
+  std::reverse(ex1.begin(), ex1.end());
+  auto const input    = make_lists(row0, row1);
+  auto const expected = make_lists(ex0, ex1);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()},
+                               expected->view(),
+                               cudf::order::DESCENDING,
+                               cudf::null_order::AFTER);
+}
+
+// ============ full (order, null_order) polarity matrix over the fixed-width fast paths ==========
+// Each test drives one engine family through the three non-shipped combos; under DESCENDING the
+// comparator operands swap, so nulls-AFTER leads with nulls and nulls-BEFORE trails.
+
+// Batcher-network tier (segments <= 8): negatives, duplicates, and nulls make each combo's
+// expectation unique.
+TEST_F(SortListsInt, NumericTieredNetworkPolarityMatrix)
+{
+  std::vector<bool> const in3{true, false, true};
+  std::vector<bool> const in8{true, true, false, true, true, false, true, true};
+  LCW<int32_t> input{LCW<int32_t>{},
+                     LCW<int32_t>{5},
+                     LCW<int32_t>{{2, 0, -7}, in3.begin()},
+                     LCW<int32_t>{{8, -3, 0, 8, 0, 0, -3, 1}, in8.begin()}};
+
+  std::vector<bool> const nulls_lead3{false, true, true};
+  std::vector<bool> const nulls_tail3{true, true, false};
+  std::vector<bool> const nulls_lead8{false, false, true, true, true, true, true, true};
+  std::vector<bool> const nulls_tail8{true, true, true, true, true, true, false, false};
+  {  // DESCENDING / AFTER: nulls first, then values descending
+    LCW<int32_t> expected{LCW<int32_t>{},
+                          LCW<int32_t>{5},
+                          LCW<int32_t>{{0, 2, -7}, nulls_lead3.begin()},
+                          LCW<int32_t>{{0, 0, 8, 8, 1, 0, -3, -3}, nulls_lead8.begin()}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{input}, expected, cudf::order::DESCENDING, cudf::null_order::AFTER);
+  }
+  {  // ASCENDING / BEFORE: nulls first, then values ascending
+    LCW<int32_t> expected{LCW<int32_t>{},
+                          LCW<int32_t>{5},
+                          LCW<int32_t>{{0, -7, 2}, nulls_lead3.begin()},
+                          LCW<int32_t>{{0, 0, -3, -3, 0, 1, 8, 8}, nulls_lead8.begin()}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{input}, expected, cudf::order::ASCENDING, cudf::null_order::BEFORE);
+  }
+  {  // DESCENDING / BEFORE: values descending, then nulls last
+    LCW<int32_t> expected{LCW<int32_t>{},
+                          LCW<int32_t>{5},
+                          LCW<int32_t>{{2, -7, 0}, nulls_tail3.begin()},
+                          LCW<int32_t>{{8, 8, 1, 0, -3, -3, 0, 0}, nulls_tail8.begin()}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{input}, expected, cudf::order::DESCENDING, cudf::null_order::BEFORE);
+  }
+}
+
+// Null-bearing int32/int64 across the packed-key warp bands (w32x1 for 9..32, w32x2 for 33..64)
+// and the radix outlier, pinning the 32/33 and 64/65 boundaries under every non-shipped combo.
+TEST_F(SortListsInt, NumericTieredWarpBandsPolarityMatrix)
+{
+  std::vector<cudf::size_type> const sizes{9, 32, 33, 64, 65};
+  auto const run = [&](auto tag, auto spread) {
+    using T = decltype(tag);
+    for (auto const& [ord, np] : non_default_combos) {
+      std::vector<T> in_vals;
+      std::vector<bool> in_valids;
+      std::vector<T> ex_vals;
+      std::vector<bool> ex_valids;
+      std::vector<cudf::size_type> offsets{0};
+      for (auto const s : sizes) {
+        std::vector<T> rv(s);
+        std::vector<bool> rok(s);
+        for (cudf::size_type i = 0; i < s; ++i) {
+          rv[i]  = static_cast<T>((s - i) * spread);
+          rok[i] = (i % 5 != 2);  // scattered element nulls
+        }
+        rv[0]                = std::numeric_limits<T>::max();
+        rv[1]                = std::numeric_limits<T>::min();
+        rv[3]                = rv[4];  // a duplicate value among the non-nulls
+        auto const [ev, eok] = host_sorted_row(rv, rok, ord, np);
+        in_vals.insert(in_vals.end(), rv.begin(), rv.end());
+        in_valids.insert(in_valids.end(), rok.begin(), rok.end());
+        ex_vals.insert(ex_vals.end(), ev.begin(), ev.end());
+        ex_valids.insert(ex_valids.end(), eok.begin(), eok.end());
+        offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+      }
+      auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+      auto const make_list = [&](std::vector<T> const& vals, std::vector<bool> const& valids) {
+        cudf::test::fixed_width_column_wrapper<T> leaf(vals.begin(), vals.end(), valids.begin());
+        cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+        return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+      };
+      auto const input    = make_list(in_vals, in_valids);
+      auto const expected = make_list(ex_vals, ex_valids);
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    }
+  };
+  run(int32_t{}, int32_t{1});
+  run(int64_t{}, int64_t{5'000'000'000});  // distinct values beyond 32 bits
+}
+
+// Descending encodes the MINIMUM element to the all-ones raw-key pad sentinel -- the mirror of
+// the ascending INT*_MAX collision -- so `rv[1] = min` in every row proves the pad tie-breaks
+// keep it inside the segment across the 8/9, 16/17, 32/33, and 64/65 boundaries.
+TEST_F(SortListsInt, NumericTieredBitonicDescendingPolarityMatrix)
+{
+  std::vector<cudf::size_type> const sizes{8, 9, 16, 17, 32, 33, 48, 64, 65};
+  auto const run = [&](auto tag, auto spread) {
+    using T = decltype(tag);
+    for (auto const& [ord, np] : non_default_combos) {
+      std::vector<T> in_vals;
+      std::vector<T> ex_vals;
+      std::vector<cudf::size_type> offsets{0};
+      for (auto const s : sizes) {
+        std::vector<T> rv(s);
+        for (cudf::size_type i = 0; i < s; ++i) {
+          rv[i] = static_cast<T>((s - i) * spread);
+        }
+        rv[0] = std::numeric_limits<T>::max();
+        rv[1] = std::numeric_limits<T>::min();  // descending: encodes to the raw-key pad sentinel
+        rv[2] = rv[3];                          // a duplicate value
+        std::vector<bool> const rok(s, true);
+        auto const ev = host_sorted_row(rv, rok, ord, np).first;
+        in_vals.insert(in_vals.end(), rv.begin(), rv.end());
+        ex_vals.insert(ex_vals.end(), ev.begin(), ev.end());
+        offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+      }
+      auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+      auto const make_list = [&](std::vector<T> const& vals) {
+        cudf::test::fixed_width_column_wrapper<T> leaf(vals.begin(), vals.end());
+        cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+        return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+      };
+      auto const input    = make_list(in_vals);
+      auto const expected = make_list(ex_vals);
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    }
+  };
+  run(int32_t{}, int32_t{1});
+  run(int64_t{}, int64_t{5'000'000'000});  // distinct values beyond 32 bits
+}
+
+// Packed-radix long lists under the non-shipped combos, across all three key widths and every
+// Site A range gate; the shared-high-word two-phase tie pass must resolve complemented low words.
+TEST_F(SortListsInt, NumericPackedRadixLongListsPolarityMatrix)
+{
+  cudf::size_type const n = 220;  // single row, average 110 -> packed radix
+  auto const check_fixed  = [&](auto tag, auto spread) {
+    using T = decltype(tag);
+    std::vector<T> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<T>((n / 2 - i) * spread);
+    }
+    std::vector<bool> const ok(n, true);
+    auto const input =
+      as_single_row_list(cudf::test::fixed_width_column_wrapper<T>(in.begin(), in.end()).release());
+    for (auto const& [ord, np] : non_default_combos) {
+      auto const ev       = host_sorted_row(in, ok, ord, np).first;
+      auto const expected = as_single_row_list(
+        cudf::test::fixed_width_column_wrapper<T>(ev.begin(), ev.end()).release());
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    }
+  };
+  check_fixed(int32_t{}, int32_t{1});
+  check_fixed(int64_t{}, int64_t{5'000'000'000});
+
+  auto constexpr scale     = numeric::scale_type{0};
+  auto const check_decimal = [&](std::vector<__int128_t> const& in) {
+    std::vector<bool> const ok(in.size(), true);
+    auto const input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), scale).release());
+    for (auto const& [ord, np] : non_default_combos) {
+      auto const ev       = host_sorted_row(in, ok, ord, np).first;
+      auto const expected = as_single_row_list(
+        cudf::test::fixed_point_column_wrapper<__int128_t>(ev.begin(), ev.end(), scale).release());
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    }
+  };
+  {  // range < 2^32 -> min-biased uint64 key (the biased value is complemented in-field)
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i);
+    }
+    check_decimal(in);
+  }
+  {  // fits int64 (range > 2^32) -> prefix_key96 key
+    auto const step = static_cast<__int128_t>(int64_t{1} << 40);
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i) * step;
+    }
+    check_decimal(in);
+  }
+  {  // wide, distinct high words -> two-phase, phase one resolves
+    auto const step = static_cast<__int128_t>(1) << 90;
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i) * step;
+    }
+    check_decimal(in);
+  }
+  {  // wide with shared high words -> the two-phase tie pass orders complemented low words
+    auto const base = static_cast<__int128_t>(1) << 100;
+    std::vector<__int128_t> in;
+    for (int i = 0; i < 110; ++i) {
+      in.push_back(-base + i);
+    }
+    for (int i = 0; i < 110; ++i) {
+      in.push_back(base + i);
+    }
+    check_decimal(in);
+  }
+}
+
+// The Site B two-phase tie pass under every combo: the nulls-first combos flip the key's class
+// bit, so the tie detector's parameterized null flag must still exclude exactly the nulls.
+TEST_F(SortListsInt, NumericDecimal128SiteBPolarityMatrix)
+{
+  auto constexpr scale    = numeric::scale_type{0};
+  cudf::size_type const n = 200;
+  auto const base         = static_cast<__int128_t>(1) << 100;
+  std::vector<__int128_t> in;
+  std::vector<bool> ok;
+  for (int i = 0; i < 100; ++i) {
+    in.push_back(-base + i);
+    ok.push_back(i % 7 != 3);
+  }
+  for (int i = 0; i < 100; ++i) {
+    in.push_back(base + i);
+    ok.push_back(i % 5 != 2);
+  }
+  ASSERT_EQ(static_cast<cudf::size_type>(in.size()), n);
+  auto const input = as_single_row_list(
+    cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), ok.begin(), scale)
+      .release());
+  for (auto const& [ord, np] : non_default_combos) {
+    auto const [ev, eok] = host_sorted_row(in, ok, ord, np);
+    auto const expected  = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ev.begin(), ev.end(), eok.begin(), scale)
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+  }
+}
+
+// The router averages a single row of n as n / 2: check(6) scores 3 (tiny -> tiered network) and
+// check(50) scores 25 (past the CUB band -> tiered warp), so both route tiered regardless of
+// nulls; the nulls exercise tiered_key128's null-class assignment under the descending complement.
+TEST_F(SortListsInt, NumericDecimal128TieredNetworkAndWarpPolarityMatrix)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  auto const check     = [&](cudf::size_type n) {
+    std::vector<__int128_t> in(n);
+    std::vector<bool> ok(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i) * (i % 2 == 0 ? 1 : -1);
+      ok[i] = i % 4 != 1;  // scattered element nulls
+    }
+    auto const input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), ok.begin(), scale)
+        .release());
+    for (auto const& [ord, np] : non_default_combos) {
+      auto const [ev, eok] = host_sorted_row(in, ok, ord, np);
+      auto const expected  = as_single_row_list(
+        cudf::test::fixed_point_column_wrapper<__int128_t>(ev.begin(), ev.end(), eok.begin(), scale)
+          .release());
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    }
+  };
+  check(6);   // Network tier (<= TIERED_NETWORK_CAP == 8).
+  check(50);  // Warp tier (<= TIERED_WARP_CAP == 64).
+}
+
+// Descending routes the lifted CUB band to its `SortPairsDescending` variant; the BEFORE combos
+// pin the zero-null precedence relaxation on that band.
+TEST_F(SortListsInt, NumericMidBandDecimal128CubPolarityMatrix)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  auto const k         = [] {
+    __int128_t v = 1;
+    for (int i = 0; i < 30; ++i) {
+      v *= 10;
+    }
+    return v;
+  }();
+  cudf::size_type const n = 16;
+  std::vector<__int128_t> in(n);
+  for (cudf::size_type i = 0; i < n; ++i) {
+    in[i] = static_cast<__int128_t>(n / 2 - i) * k;
+  }
+  std::vector<bool> const ok(n, true);
+  auto const input = as_single_row_list(
+    cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), scale).release());
+  for (auto const& [ord, np] : non_default_combos) {
+    auto const ev       = host_sorted_row(in, ok, ord, np).first;
+    auto const expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ev.begin(), ev.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+  }
+}
+
+// BOOL8/int8/uint32 are packed-supported but not tiered, so their nulls force the packed radix at
+// any size; uint32 additionally pins the unsigned encode (no sign flip) under the complement.
+TEST_F(SortListsInt, NumericPackedNarrowAndBoolPolarityMatrix)
+{
+  {  // BOOL8 with nulls: values {t, f, X, t, f, X, f}
+    std::vector<bool> const in_valids{true, true, false, true, true, false, true};
+    auto const input =
+      as_single_row_list(cudf::test::fixed_width_column_wrapper<bool>(
+                           {true, false, true, true, false, false, false}, in_valids.begin())
+                           .release());
+    auto const check = [&](std::vector<bool> const& ex_vals,
+                           std::vector<bool> const& ex_valids,
+                           cudf::order ord,
+                           cudf::null_order np) {
+      auto expected = as_single_row_list(cudf::test::fixed_width_column_wrapper<bool>(
+                                           ex_vals.begin(), ex_vals.end(), ex_valids.begin())
+                                           .release());
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    };
+    check({false, false, true, true, false, false, false},
+          {false, false, true, true, true, true, true},
+          cudf::order::DESCENDING,
+          cudf::null_order::AFTER);
+    check({false, false, false, false, false, true, true},
+          {false, false, true, true, true, true, true},
+          cudf::order::ASCENDING,
+          cudf::null_order::BEFORE);
+    check({true, true, false, false, false, false, false},
+          {true, true, true, true, true, false, false},
+          cudf::order::DESCENDING,
+          cudf::null_order::BEFORE);
+  }
+  {  // int8 with nulls, covering both signed extremes
+    std::vector<int8_t> const in{5, -8, 0, 127, -128, 0, 5};
+    std::vector<bool> const ok{true, true, false, true, true, false, true};
+    for (auto const& [ord, np] : non_default_combos) {
+      auto const [ev, eok] = host_sorted_row(in, ok, ord, np);
+      auto input           = as_single_row_list(
+        cudf::test::fixed_width_column_wrapper<int8_t>(in.begin(), in.end(), ok.begin()).release());
+      auto expected = as_single_row_list(
+        cudf::test::fixed_width_column_wrapper<int8_t>(ev.begin(), ev.end(), eok.begin())
+          .release());
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    }
+  }
+  {  // uint32 with a null: unsigned encode, values past INT32_MAX
+    std::vector<uint32_t> const in{4'000'000'000u, 7u, 0u, 0u, 4'000'000'000u};
+    std::vector<bool> const ok{true, true, false, true, true};
+    for (auto const& [ord, np] : non_default_combos) {
+      auto const [ev, eok] = host_sorted_row(in, ok, ord, np);
+      auto input           = as_single_row_list(
+        cudf::test::fixed_width_column_wrapper<uint32_t>(in.begin(), in.end(), ok.begin())
+          .release());
+      auto expected = as_single_row_list(
+        cudf::test::fixed_width_column_wrapper<uint32_t>(ev.begin(), ev.end(), eok.begin())
+          .release());
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    }
+  }
+}
+
+// Timestamps under the non-shipped combos for both rep widths: the signed rep flip composed with
+// the descending complement must order pre-epoch values last.
+TEST_F(SortListsInt, NumericTieredTimestampsPolarityMatrix)
+{
+  auto const run = [&](auto rep_tag, auto wrapper_tag, std::vector<decltype(rep_tag)> const& in) {
+    using Rep     = decltype(rep_tag);
+    using Wrapper = decltype(wrapper_tag);
+    std::vector<bool> const ok{true, true, false, true, true};
+    for (auto const& [ord, np] : non_default_combos) {
+      auto const [ev, eok] = host_sorted_row(in, ok, ord, np);
+      auto input           = as_single_row_list(
+        cudf::test::fixed_width_column_wrapper<Wrapper, Rep>(in.begin(), in.end(), ok.begin())
+          .release());
+      auto expected = as_single_row_list(
+        cudf::test::fixed_width_column_wrapper<Wrapper, Rep>(ev.begin(), ev.end(), eok.begin())
+          .release());
+      expect_both_sort_paths_match(
+        cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+    }
+  };
+  run(int32_t{}, cudf::timestamp_D{}, std::vector<int32_t>{100, -50, 0, 0, 25});
+  auto constexpr big = int64_t{5} * 1'000 * 1'000 * 1'000;  // 5e9 > INT32_MAX
+  run(int64_t{}, cudf::timestamp_ms{}, std::vector<int64_t>{big, -big, 0, 1, -1});
+  // The is_duration branch of radix_encode is textually distinct, so cover one duration per width.
+  run(int32_t{}, cudf::duration_D{}, std::vector<int32_t>{100, -50, 0, 0, 25});
+  run(int64_t{}, cudf::duration_us{}, std::vector<int64_t>{big, -big, 0, 1, -1});
+}
+
 // The block tier's band seams (63/64/65, 128/129, 256/257, 512/513, 1024/1025) per key width;
 // DECIMAL128 routes tiered here because the CUB lift declines this column's oversized segments.
 TEST_F(SortListsInt, NumericTieredBlockTierBoundaries)
@@ -2237,8 +2883,7 @@ TEST_F(SortListsInt, NumericTieredBlockTierBoundariesWithNulls)
   check_block_tier_boundaries<__int128_t>(true, cudf::order::ASCENDING);
 }
 
-// The same seams under DESCENDING, with and without nulls (nulls lead under DESCENDING + AFTER);
-// the gate declines DESCENDING today, so these pin the comparison fallback for a future widening.
+// The same seams under DESCENDING, with and without nulls (nulls lead under DESCENDING + AFTER).
 TEST_F(SortListsInt, NumericTieredBlockTierBoundariesDescending)
 {
   check_block_tier_boundaries<int32_t>(false, cudf::order::DESCENDING);
@@ -2444,5 +3089,65 @@ TEST_F(SortListsDouble, NumericPackedFloatNaNInfinity)
     LCWf input{{{-NaN, Inf, -0.0f, 2.5f, -Inf, denorm, 0.0f, NaN, Max, -Max}, null_at(6)}};
     LCWf expected{{{-Inf, -Max, -0.0f, denorm, 2.5f, Max, Inf, NaN, -NaN, 0.0f}, null_at(9)}};
     expect_both_sort_paths_equivalent(cudf::lists_column_view{input}, expected);
+  }
+}
+
+// NaN ranks above +Inf, so a descending output leads with the NaN block (after any leading
+// nulls); the descending complement maps the canonical all-ones NaN key to the smallest valid key.
+TEST_F(SortListsDouble, NumericPackedFloatNaNInfinityPolarityMatrix)
+{
+  {  // FLOAT64: thirteen elements (one null) land in the warp tier.
+    auto constexpr NaN    = std::numeric_limits<double>::quiet_NaN();
+    auto constexpr Inf    = std::numeric_limits<double>::infinity();
+    auto constexpr denorm = std::numeric_limits<double>::denorm_min();
+    auto constexpr Max    = std::numeric_limits<double>::max();
+    using LCWd            = cudf::test::lists_column_wrapper<double>;
+    LCWd input{
+      {{NaN, -Inf, -0.0, 3.5, -NaN, Inf, 0.0, denorm, -2.0, 0.0, Inf, Max, -Max}, null_at(9)}};
+    {  // DESCENDING / AFTER: null first, then NaNs, then values descending
+      LCWd expected{
+        {{0.0, NaN, -NaN, Inf, Inf, Max, 3.5, denorm, 0.0, -0.0, -2.0, -Max, -Inf}, null_at(0)}};
+      expect_both_sort_paths_equivalent(
+        cudf::lists_column_view{input}, expected, cudf::order::DESCENDING, cudf::null_order::AFTER);
+    }
+    {  // ASCENDING / BEFORE: null first, then values ascending, NaNs last
+      LCWd expected{
+        {{0.0, -Inf, -Max, -2.0, -0.0, 0.0, denorm, 3.5, Max, Inf, Inf, NaN, -NaN}, null_at(0)}};
+      expect_both_sort_paths_equivalent(
+        cudf::lists_column_view{input}, expected, cudf::order::ASCENDING, cudf::null_order::BEFORE);
+    }
+    {  // DESCENDING / BEFORE: NaNs first, values descending, null last
+      LCWd expected{
+        {{NaN, -NaN, Inf, Inf, Max, 3.5, denorm, 0.0, -0.0, -2.0, -Max, -Inf, 0.0}, null_at(12)}};
+      expect_both_sort_paths_equivalent(cudf::lists_column_view{input},
+                                        expected,
+                                        cudf::order::DESCENDING,
+                                        cudf::null_order::BEFORE);
+    }
+  }
+  {  // FLOAT32: ten elements (one null) land in the warp tier.
+    auto constexpr NaN    = std::numeric_limits<float>::quiet_NaN();
+    auto constexpr Inf    = std::numeric_limits<float>::infinity();
+    auto constexpr denorm = std::numeric_limits<float>::denorm_min();
+    auto constexpr Max    = std::numeric_limits<float>::max();
+    using LCWf            = cudf::test::lists_column_wrapper<float>;
+    LCWf input{{{-NaN, Inf, -0.0f, 2.5f, -Inf, denorm, 0.0f, NaN, Max, -Max}, null_at(6)}};
+    {  // DESCENDING / AFTER
+      LCWf expected{{{0.0f, NaN, -NaN, Inf, Max, 2.5f, denorm, -0.0f, -Max, -Inf}, null_at(0)}};
+      expect_both_sort_paths_equivalent(
+        cudf::lists_column_view{input}, expected, cudf::order::DESCENDING, cudf::null_order::AFTER);
+    }
+    {  // ASCENDING / BEFORE
+      LCWf expected{{{0.0f, -Inf, -Max, -0.0f, denorm, 2.5f, Max, Inf, NaN, -NaN}, null_at(0)}};
+      expect_both_sort_paths_equivalent(
+        cudf::lists_column_view{input}, expected, cudf::order::ASCENDING, cudf::null_order::BEFORE);
+    }
+    {  // DESCENDING / BEFORE
+      LCWf expected{{{NaN, -NaN, Inf, Max, 2.5f, denorm, -0.0f, -Max, -Inf, 0.0f}, null_at(9)}};
+      expect_both_sort_paths_equivalent(cudf::lists_column_view{input},
+                                        expected,
+                                        cudf::order::DESCENDING,
+                                        cudf::null_order::BEFORE);
+    }
   }
 }

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -387,6 +387,40 @@ void expect_both_sort_paths_match(cudf::lists_column_view const& input,
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted->view(), expected);
 }
 
+// Host oracle for one list row. cudf's null_order is comparator-level and DESCENDING swaps the
+// comparison operands, inverting null placement too: nulls land first iff (BEFORE) != (DESCENDING).
+template <typename T>
+std::pair<std::vector<T>, std::vector<bool>> host_sorted_row(std::vector<T> const& vals,
+                                                             std::vector<bool> const& valids,
+                                                             cudf::order column_order,
+                                                             cudf::null_order null_precedence)
+{
+  std::vector<T> nn;
+  for (std::size_t i = 0; i < vals.size(); ++i) {
+    if (valids[i]) { nn.push_back(vals[i]); }
+  }
+  std::sort(nn.begin(), nn.end());
+  if (column_order == cudf::order::DESCENDING) { std::reverse(nn.begin(), nn.end()); }
+  auto const num_nulls = vals.size() - nn.size();
+  auto const nulls_first =
+    (null_precedence == cudf::null_order::BEFORE) != (column_order == cudf::order::DESCENDING);
+  std::vector<T> out;
+  std::vector<bool> out_valids;
+  auto const push_nulls = [&] {
+    for (std::size_t k = 0; k < num_nulls; ++k) {
+      out.push_back(T{});
+      out_valids.push_back(false);
+    }
+  };
+  if (nulls_first) { push_nulls(); }
+  for (auto const& v : nn) {
+    out.push_back(v);
+    out_valids.push_back(true);
+  }
+  if (not nulls_first) { push_nulls(); }
+  return {std::move(out), std::move(out_valids)};
+}
+
 // Wraps a leaf column as a one-row LIST, so the sort orders within a single segment.
 std::unique_ptr<cudf::column> as_single_row_list(std::unique_ptr<cudf::column> leaf)
 {
@@ -532,7 +566,6 @@ TEST_F(SortListsString, PrefixIterativeDeepLongSharedPrefix)
     tail.insert(tail.begin(), 4 - tail.size(), '0');
     row1.push_back(prefix1 + tail);
   }
-
   std::shuffle(row1.begin(), row1.end(), std::mt19937{0x5EED});
 
   std::vector<std::string> in_strings;
@@ -705,7 +738,6 @@ TEST_F(SortListsString, PrefixPackedKeyPartialByteTieOffset)
   }
   in_strings.emplace_back("");  // second null placeholder
   in_valids.push_back(false);
-
   auto const num_elements = static_cast<cudf::size_type>(in_strings.size());
 
   std::vector<std::string> non_null;
@@ -832,6 +864,250 @@ TEST_F(SortListsString, PrefixTrueHeapsortRun)
   auto const input    = make_single_row_list(shuffled);
   auto const expected = make_single_row_list(sorted);
   expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+namespace {
+// Builds a LIST<STRING> column from per-row (string, validity) data. Embedded NUL bytes ride
+// through unchanged, so callers pass explicit-length `std::string`s. The leaf takes a mask only
+// when a null exists: the sort returns null-free columns non-nullable, and expected columns built
+// here must match that contract.
+std::unique_ptr<cudf::column> make_string_lists(std::vector<std::vector<std::string>> const& rows,
+                                                std::vector<std::vector<bool>> const& valids)
+{
+  std::vector<std::string> flat;
+  std::vector<bool> flat_v;
+  std::vector<cudf::size_type> offsets{0};
+  for (std::size_t r = 0; r < rows.size(); ++r) {
+    flat.insert(flat.end(), rows[r].begin(), rows[r].end());
+    flat_v.insert(flat_v.end(), valids[r].begin(), valids[r].end());
+    offsets.push_back(static_cast<cudf::size_type>(flat.size()));
+  }
+  auto const has_null_element = std::find(flat_v.cbegin(), flat_v.cend(), false) != flat_v.cend();
+  auto leaf =
+    has_null_element
+      ? cudf::test::strings_column_wrapper(flat.begin(), flat.end(), flat_v.begin()).release()
+      : cudf::test::strings_column_wrapper(flat.begin(), flat.end()).release();
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+  return cudf::make_lists_column(
+    static_cast<cudf::size_type>(rows.size()), off.release(), std::move(leaf), 0, {});
+}
+
+// Drives the rows through all four (order, null_order) combos against a per-row host oracle;
+// `std::string`'s unsigned-byte order and length tie-break match cudf's string order.
+void expect_string_polarity_matrix(std::vector<std::vector<std::string>> const& rows,
+                                   std::vector<std::vector<bool>> const& valids)
+{
+  constexpr std::array<std::pair<cudf::order, cudf::null_order>, 4> combos{
+    {{cudf::order::ASCENDING, cudf::null_order::AFTER},
+     {cudf::order::DESCENDING, cudf::null_order::AFTER},
+     {cudf::order::ASCENDING, cudf::null_order::BEFORE},
+     {cudf::order::DESCENDING, cudf::null_order::BEFORE}}};
+  auto const input = make_string_lists(rows, valids);
+  for (auto const& [ord, np] : combos) {
+    std::vector<std::vector<std::string>> ex_rows(rows.size());
+    std::vector<std::vector<bool>> ex_valids(rows.size());
+    for (std::size_t r = 0; r < rows.size(); ++r) {
+      auto sorted_row = host_sorted_row(rows[r], valids[r], ord, np);
+      ex_rows[r]      = std::move(sorted_row.first);
+      ex_valids[r]    = std::move(sorted_row.second);
+    }
+    auto const expected = make_string_lists(ex_rows, ex_valids);
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+  }
+}
+}  // namespace
+
+// ===== graduated-warp string path: per-band polarity coverage (segments within the 64-element cap)
+// The default string fast path once every segment fits a warp tile; its bands are (0,8] one item
+// per lane, then (8,16] W8, W16, and W32.
+
+// Sizes at and across every band boundary (8/9, 15/16/17, 31/32/33, 63/64) plus an empty row, side
+// by side in one column; the 8/16/32/64 rows fill their tiles exactly (zero pads).
+TEST_F(SortListsString, GradPolarityMatrixBandBoundarySizes)
+{
+  std::vector<cudf::size_type> const sizes{1, 2, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 0};
+  std::mt19937 rng{0xBEEF};
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (auto const n : sizes) {
+    std::vector<std::string> row(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      // Distinct within a row: 97 is coprime to 1000, so the numeric part never repeats for i < 64.
+      row[i] = "k" + std::to_string(i * 97 % 1'000) + static_cast<char>('a' + i % 26);
+    }
+    std::shuffle(row.begin(), row.end(), rng);
+    valids.emplace_back(row.size(), true);
+    rows.push_back(std::move(row));
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// The nulls-first combos put the valid class at ordinal 1: a comparator hardcoding it to 0 would
+// collapse valid-vs-valid pairs to "equal" and keep the shuffled order. Row 1 (2 valid / 15 null /
+// 15 pad) stresses the pad class ranking above tier_null; row 5 is all null.
+TEST_F(SortListsString, GradPolarityMatrixNullsAcrossBands)
+{
+  std::vector<cudf::size_type> const sizes{12, 17, 20, 40, 64, 16, 5, 8};
+  std::mt19937 rng{0xD00D};
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (std::size_t r = 0; r < sizes.size(); ++r) {
+    auto const n = sizes[r];
+    std::vector<std::pair<std::string, bool>> cells(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      // Row 1: only elements 3 and 11 valid (2 valid / 15 null). Row 5: all null. Others: every
+      // (i % 5 == 2) element is null.
+      bool const v = (r == 1) ? (i == 3 || i == 11) : (r == 5 ? false : (i % 5 != 2));
+      cells[i]     = {"v" + std::to_string(i * 97 % 1'000), v};
+    }
+    if (n > 1 && cells[0].second && cells[1].second) {
+      cells[1].first = cells[0].first;  // A duplicate among the valids.
+    }
+    std::shuffle(cells.begin(), cells.end(), rng);  // Interleave nulls; don't pre-group them.
+    std::vector<std::string> row(n);
+    std::vector<bool> valid(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      row[i]   = cells[i].first;
+      valid[i] = cells[i].second;
+    }
+    rows.push_back(std::move(row));
+    valids.push_back(std::move(valid));
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// Zero-extension pairs (`S` vs `S + "\0"`) collide on the zero-filled window and resolve only by
+// the length tie-break, whose side the descending complement flips; the shared eight-byte prefixes
+// force every pair onto the suffix fallback in each band. Row 3 is pure duplicates.
+TEST_F(SortListsString, GradPolarityMatrixTiesAndZeroExtension)
+{
+  using namespace std::string_literals;
+  std::mt19937 rng{0xACE5};
+  std::vector<std::string> row0{""s, "a"s, "ab"s, "ab"s, "ab\0"s, "ab\0c"s, "abc"s, "abcd"s, "b"s};
+  std::vector<std::string> row1;
+  for (int i = 0; i < 16; ++i) {
+    row1.push_back("PPPPPPPP" + std::to_string(i));
+  }
+  row1.push_back("PPPPPPPP"s);
+  row1.push_back("PPPPPPPP\0"s);
+  row1.push_back("PPPPPPPP3"s);  // duplicate
+  row1.push_back("PPPPPPPP7"s);  // duplicate
+  std::vector<std::string> row2;
+  for (int i = 0; i < 38; ++i) {
+    row2.push_back("SAMEPREF" + std::string(1, static_cast<char>('0' + (i % 10))) +
+                   std::to_string(i));
+  }
+  row2.push_back("SAMEPREF"s);
+  row2.push_back("SAMEPREF\0"s);
+  std::vector<std::string> row3(10, "dup"s);
+
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (auto* row : {&row0, &row1, &row2, &row3}) {
+    std::shuffle(row->begin(), row->end(), rng);
+    valids.emplace_back(row->size(), true);
+    rows.push_back(*row);
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// Raw unsigned-byte order across the 2-/3-/4-byte UTF-8 lead classes; row 1 shares a multibyte
+// prefix so the prekey ties past the lead bytes.
+TEST_F(SortListsString, GradPolarityMatrixUtf8Multibyte)
+{
+  std::mt19937 rng{0xFACE};
+  std::vector<std::string> row0{
+    "\xE2\x82\xAC\x75\x72\x6F", "zoo", "\xF0\x9F\x98\x80", "\xC3\xA9\x70\xC3\xA9\x65", "apple"};
+  std::vector<std::string> row1;
+  for (int i = 0; i < 36; ++i) {
+    row1.push_back("\xC3\xA9" + std::to_string(i * 97 % 1'000));
+  }
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (auto* row : {&row0, &row1}) {
+    std::shuffle(row->begin(), row->end(), rng);
+    valids.emplace_back(row->size(), true);
+    rows.push_back(*row);
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// A few hundred segments cycling every band size in (0, 64] drive the string instantiations of
+// the shared warp-band kernel across block boundaries -- hundreds of virtual warps over multiple
+// blocks per band -- where the small tests above stay within two blocks. Scattered nulls and a
+// sprinkle of empty rows ride along, all against the host oracle under every combo.
+TEST_F(SortListsString, GradManySegmentsAcrossBands)
+{
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (int seg = 0; seg < 300; ++seg) {
+    if (seg % 50 == 49) {  // Interleave empty rows; no band owns them.
+      rows.emplace_back();
+      valids.emplace_back();
+      continue;
+    }
+    auto const size = seg % 64 + 1;
+    std::vector<std::string> row(size);
+    std::vector<bool> valid(size);
+    for (int i = 0; i < size; ++i) {
+      row[i]   = "s" + std::to_string((seg * 31 + i * 7) % 97) + std::string(i % 9, 'x');
+      valid[i] = (seg * 13 + i) % 11 != 0;
+    }
+    rows.push_back(std::move(row));
+    valids.push_back(std::move(valid));
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// Slicing off row 0 gives the leaf strings a genuine nonzero offset, which the graduated key
+// builders and comparators must honor under every combo.
+TEST_F(SortListsString, GradSlicedWithNulls)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+  StrLCW l{StrLCW{"zz", "aa"},
+           StrLCW{{"banana", "apple", "x", "cherry"}, null_at(2)},  // element 2 ("x") is null
+           StrLCW{"b", "a"},
+           StrLCW{"x"}};
+  auto const sliced = cudf::slice(l, {1, 4})[0];  // drops row 0 -> nonzero child offset
+  {                                               // ASC / AFTER: values ascending, null last
+    StrLCW expected{
+      StrLCW{{"apple", "banana", "cherry", "x"}, null_at(3)}, StrLCW{"a", "b"}, StrLCW{"x"}};
+    expect_both_sort_paths_match(cudf::lists_column_view{sliced}, expected);
+  }
+  {  // ASC / BEFORE: null first, then values ascending
+    StrLCW expected{
+      StrLCW{{"x", "apple", "banana", "cherry"}, null_at(0)}, StrLCW{"a", "b"}, StrLCW{"x"}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{sliced}, expected, cudf::order::ASCENDING, cudf::null_order::BEFORE);
+  }
+  {  // DESC / AFTER: the comparator swap places the null first, then values descending
+    StrLCW expected{
+      StrLCW{{"x", "cherry", "banana", "apple"}, null_at(0)}, StrLCW{"b", "a"}, StrLCW{"x"}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{sliced}, expected, cudf::order::DESCENDING, cudf::null_order::AFTER);
+  }
+  {  // DESC / BEFORE: values descending, then the null last
+    StrLCW expected{
+      StrLCW{{"cherry", "banana", "apple", "x"}, null_at(3)}, StrLCW{"b", "a"}, StrLCW{"x"}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{sliced}, expected, cudf::order::DESCENDING, cudf::null_order::BEFORE);
+  }
+}
+
+// One 65-element segment exceeds the warp cap and disqualifies the whole column, so the prefix
+// path must produce the result under every combo.
+TEST_F(SortListsString, GradOversizedSegmentFallsThrough)
+{
+  std::mt19937 rng{0xF00D};
+  std::vector<std::string> big(65);
+  for (int i = 0; i < 65; ++i) {
+    big[i] = "q" + std::to_string(i * 97 % 1'000);
+  }
+  std::shuffle(big.begin(), big.end(), rng);
+  std::vector<std::vector<std::string>> const rows{big, {"b", "a", "c"}};
+  std::vector<std::vector<bool>> const valids{std::vector<bool>(big.size(), true),
+                                              {true, true, true}};
+  expect_string_polarity_matrix(rows, valids);
 }
 
 // Sliced string input with a retained null: the packed-key builder, window tie-break, and

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -6,10 +6,23 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/lists/sorting.hpp>
+#include <cudf/null_mask.hpp>
+
+#include <cuda/std/limits>
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace cudf::test::iterators;
 
 template <typename T>
 using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
@@ -176,6 +189,666 @@ TEST_F(SortListsInt, NullRows)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), l);
 }
 
+// A nullable but null-free input must come back non-nullable: the sort cannot add nulls, so
+// neither the returned parent nor its child may keep an allocated all-valid mask.
+TEST_F(SortListsInt, NullableWithZeroNullsDropsMasks)
+{
+  using T = int;
+  cudf::test::fixed_width_column_wrapper<T> child({3, 1, 2, 5, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, 3, 5};
+  auto const input =
+    cudf::make_lists_column(2,
+                            offsets.release(),
+                            child.release(),
+                            0,
+                            cudf::create_null_mask(2, cudf::mask_state::ALL_VALID));
+  ASSERT_TRUE(input->view().nullable());
+  ASSERT_TRUE(cudf::lists_column_view{input->view()}.child().nullable());
+
+  LCW<T> expected{{1, 2, 3}, {4, 5}};
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input->view()}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  EXPECT_FALSE(sorted_lists->view().nullable());
+  EXPECT_FALSE(cudf::lists_column_view{sorted_lists->view()}.child().nullable());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  EXPECT_FALSE(stable_sorted_lists->view().nullable());
+  EXPECT_FALSE(cudf::lists_column_view{stable_sorted_lists->view()}.child().nullable());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+using SortListsString = SortLists<cudf::string_view>;
+
+// Default order: element nulls sort last within a row; a null list row passes through unchanged.
+TEST_F(SortListsString, Strings)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  std::vector<bool> const valids{true, true, false, true};
+  StrLCW input{{StrLCW{{"pear", "apple", "fig", "kiwi"}, null_at(2)},
+                StrLCW{"banana"},
+                StrLCW{"unused"},
+                StrLCW{"melon", "cherry"}},
+               valids.begin()};
+
+  // Null slots keep arbitrary placeholder values ("fig" here); they are never compared.
+  StrLCW expected{{StrLCW{{"apple", "kiwi", "pear", "fig"}, null_at(3)},
+                   StrLCW{"banana"},
+                   StrLCW{"unused"},
+                   StrLCW{"cherry", "melon"}},
+                  valids.begin()};
+
+  auto const [sorted_lists, stable_sorted_lists] =
+    generate_sorted_lists(cudf::lists_column_view{input}, {}, {});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// The Prefix* tests target the string fast path: a packed leading-bytes key, iterative byte-window
+// tie-breaks, then a final comparison cleanup. Each asserts the fast path (sort_lists) and the
+// comparison path (stable_sort_lists) against the same expected column.
+
+// Identical first eight bytes force the full-string tie-break; the proper prefix sorts first.
+TEST_F(SortListsString, PrefixEqualFirstEightBytes)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"abcdefgh1", "abcdefgh0", "abcdefgh"}};
+  StrLCW expected{{"abcdefgh", "abcdefgh0", "abcdefgh1"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Under eight bytes, zero-padding lets the packed key alone order a proper prefix first.
+TEST_F(SortListsString, PrefixSubstringShorterFirst)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"aaa", "aa", "a"}};
+  StrLCW expected{{"a", "aa", "aaa"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Empty strings pack an all-zero key and must sort before any non-empty string.
+TEST_F(SortListsString, PrefixEmptyStringsFirst)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"banana", "", "apple", "", "fig"}};
+  StrLCW expected{{"", "", "apple", "banana", "fig"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Null slots' placeholder values are never compared.
+TEST_F(SortListsString, PrefixMultipleNullsLast)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{StrLCW{{"pear", "apple", "fig", "kiwi", "lime"}, nulls_at({1, 3})}};
+  StrLCW expected{StrLCW{{"fig", "lime", "pear", "apple", "kiwi"}, nulls_at({3, 4})}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+TEST_F(SortListsString, PrefixAllNullListRow)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  std::vector<bool> const valids{true, false, true};
+  StrLCW input{{StrLCW{"cherry", "apple", "banana"}, StrLCW{"unused"}, StrLCW{"date", "egg"}},
+               valids.begin()};
+  StrLCW expected{{StrLCW{"apple", "banana", "cherry"}, StrLCW{"unused"}, StrLCW{"date", "egg"}},
+                  valids.begin()};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// One shared eight-byte prefix makes the whole row a single tie run resolved wholly by full-string
+// comparison -- the tie-break's worst case.
+TEST_F(SortListsString, PrefixWholeRowShared)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"prefix__zebra", "prefix__apple", "prefix__mango", "prefix__"}};
+  StrLCW expected{{"prefix__", "prefix__apple", "prefix__mango", "prefix__zebra"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Raw unsigned-byte order: the two-/three-/four-byte UTF-8 lead bytes (0xC3 < 0xE2 < 0xF0) sort
+// after ASCII and by lead-byte class among themselves.
+TEST_F(SortListsString, PrefixUtf8Multibyte)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{
+    {"\xE2\x82\xAC\x75\x72\x6F", "zoo", "\xF0\x9F\x98\x80", "\xC3\xA9\x70\xC3\xA9\x65", "apple"}};
+  StrLCW expected{
+    {"apple", "zoo", "\xC3\xA9\x70\xC3\xA9\x65", "\xE2\x82\xAC\x75\x72\x6F", "\xF0\x9F\x98\x80"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Per-row prefix ties must resolve without crossing row boundaries (the segment_id key field); the
+// empty row checks dense segment-ordinal labeling skips a zero-length segment without misaligning
+// its neighbors.
+TEST_F(SortListsString, PrefixMultipleSegments)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{StrLCW{"commonpx_b", "commonpx_a", "commonpx_c"},
+               StrLCW{},
+               StrLCW{"melon", "apple", "cherry"},
+               StrLCW{"sharedpx2", "sharedpx0", "sharedpx1"}};
+  StrLCW expected{StrLCW{"commonpx_a", "commonpx_b", "commonpx_c"},
+                  StrLCW{},
+                  StrLCW{"apple", "cherry", "melon"},
+                  StrLCW{"sharedpx0", "sharedpx1", "sharedpx2"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+namespace {
+// Asserts `sort_lists` (fast path) and `stable_sort_lists` (comparison path) both equal
+// `expected`, so every expectation is also re-checked against the comparison semantics.
+void expect_both_sort_paths_match(cudf::lists_column_view const& input,
+                                  cudf::column_view const& expected,
+                                  cudf::order column_order         = cudf::order::ASCENDING,
+                                  cudf::null_order null_precedence = cudf::null_order::AFTER)
+{
+  auto const sorted = cudf::lists::sort_lists(input, column_order, null_precedence);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted->view(), expected);
+  auto const stable_sorted = cudf::lists::stable_sort_lists(input, column_order, null_precedence);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted->view(), expected);
+}
+
+// Wraps a leaf column as a one-row LIST, so the sort orders within a single segment.
+std::unique_ptr<cudf::column> as_single_row_list(std::unique_ptr<cudf::column> leaf)
+{
+  auto const n = static_cast<cudf::size_type>(leaf->size());
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+  return cudf::make_lists_column(1, offsets.release(), std::move(leaf), 0, {});
+}
+}  // namespace
+
+// All shorter than the packed key, so the key alone orders them -- including the second-byte
+// distinction "aaa" < "ab".
+TEST_F(SortListsString, PrefixShortStrings)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"aaa", "aa", "a", "ab", "b"}};
+  StrLCW expected{{"a", "aa", "aaa", "ab", "b"}};
+  expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+}
+
+// Shared leading bytes make the packed key uninformative, so the tie-break does the real ordering.
+TEST_F(SortListsString, PrefixSharedPrefixWithNullAndDuplicate)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{
+    StrLCW{{"AAAAAAAAzebra", "AAAAAAAAapple", "AAAAAAAAmango", "unused", "AAAAAAAAapple"},
+           null_at(3)},
+    StrLCW{"food_pear", "food_kiwi", "food_pear"}};
+  StrLCW expected{
+    StrLCW{{"AAAAAAAAapple", "AAAAAAAAapple", "AAAAAAAAmango", "AAAAAAAAzebra", "unused"},
+           null_at(4)},
+    StrLCW{"food_kiwi", "food_pear", "food_pear"}};
+  expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+}
+
+// A naive all-0xFF null sentinel would collide with genuine all-0xFF strings; the packed key's
+// dedicated is_null bit must separate them. The 72- and 73-byte 0xFF strings stay tied through
+// every byte window and reach the comparison cleanup as one run.
+TEST_F(SortListsString, PrefixNullSentinelCollisionFF)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::string const ff72(72, '\xff');
+  std::string const ff73(73, '\xff');
+
+  std::vector<std::string> const in_strings{"apple", ff73, "mango", ff72, ""};
+  std::vector<bool> const in_valids{true, true, true, true, false};
+
+  std::vector<std::string> const ex_strings{"apple", "mango", ff72, ff73, ""};
+  std::vector<bool> const ex_valids{true, true, true, true, false};
+
+  auto const make_single_row_list = [](std::vector<std::string> const& strs,
+                                       std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(in_strings, in_valids);
+  auto const expected = make_single_row_list(ex_strings, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// The shared prefix outlasts every iterative window, so the whole run reaches the tie-break,
+// exceeds TIE_HEAPSORT_THRESHOLD, and takes the heapsort branch; > 64 elements keep the column on
+// the prefix path. Adds interleaved nulls to the plain PrefixTrueHeapsortRun shape.
+TEST_F(SortListsString, PrefixSharedPrefixHeapsortRun)
+{
+  std::string const prefix(80, 'A');  // 80 > 7 + 8*8 = 71, so ties survive every iterative window.
+  std::vector<std::string> non_null;
+  for (int i = 0; i < 70; ++i) {
+    non_null.push_back(prefix + std::to_string(i / 10) + std::to_string(i % 10));
+  }
+  non_null.push_back(prefix + "05");  // exact duplicates
+  non_null.push_back(prefix + "17");
+
+  auto shuffled = non_null;
+  std::shuffle(shuffled.begin(), shuffled.end(), std::mt19937{0xC0'FFEE});
+
+  auto const null_pos_a = shuffled.size() / 3;
+  auto const null_pos_b = (shuffled.size() * 2) / 3 + 1;
+  std::vector<std::string> in_strings;
+  std::vector<bool> in_valids;
+  for (std::size_t i = 0; i <= shuffled.size(); ++i) {
+    if (i == null_pos_a || i == null_pos_b) {
+      in_strings.emplace_back("");  // null placeholder; never compared
+      in_valids.push_back(false);
+    }
+    if (i < shuffled.size()) {
+      in_strings.push_back(shuffled[i]);
+      in_valids.push_back(true);
+    }
+  }
+
+  auto sorted = non_null;
+  std::sort(sorted.begin(), sorted.end());
+  std::vector<std::string> ex_strings = sorted;
+  std::vector<bool> ex_valids(sorted.size(), true);
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+
+  using StrCW                     = cudf::test::strings_column_wrapper;
+  auto const make_single_row_list = [](std::vector<std::string> const& strs,
+                                       std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(in_strings, in_valids);
+  auto const expected = make_single_row_list(ex_strings, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Deep shared prefixes force several windows past the packed key. Row 0 adds a pure length tie (a
+// string vs itself plus a trailing NUL) that only the cleanup's shorter-is-less rule separates;
+// row 1's thousands of shared-prefix strings exercise the pass cap and the parallel re-sort.
+TEST_F(SortListsString, PrefixIterativeDeepLongSharedPrefix)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::string const prefix0(20, 'A');  // Twenty shared bytes: > 2x the 8-byte key, 5x the 4-byte.
+  std::vector<std::string> row0_non_null{
+    prefix0 + "zebra",
+    prefix0 + "ant",  // shorter tail -> mixed run lengths within the shared run
+    prefix0 + "mango",
+    prefix0 + "ant",                 // exact duplicate
+    prefix0,                         // the shared prefix with no tail
+    prefix0 + std::string(1, '\0'),  // `prefix0` zero-extended: a pure length tie
+    prefix0 + "mango",               // exact duplicate
+    ""};                             // all-zero key, must sort first in the row
+
+  std::string const prefix1(24, 'Q');  // Twenty-four shared bytes -> three windows past an 8B key.
+  std::vector<std::string> row1;
+  row1.reserve(5'000);
+  for (int i = 0; i < 5'000; ++i) {
+    auto tail = std::to_string(i);
+    tail.insert(tail.begin(), 4 - tail.size(), '0');
+    row1.push_back(prefix1 + tail);
+  }
+
+  std::shuffle(row1.begin(), row1.end(), std::mt19937{0x5EED});
+
+  std::vector<std::string> in_strings;
+  std::vector<bool> in_valids;
+  for (auto const& s : row0_non_null) {
+    in_strings.push_back(s);
+    in_valids.push_back(true);
+  }
+  in_strings.emplace_back("");  // null placeholder; never compared
+  in_valids.push_back(false);
+  auto const row0_len = static_cast<cudf::size_type>(in_strings.size());
+  for (auto const& s : row1) {
+    in_strings.push_back(s);
+    in_valids.push_back(true);
+  }
+  auto const total_len = static_cast<cudf::size_type>(in_strings.size());
+
+  // std::string's raw-byte order and length tie-break match cudf's string order.
+  auto row0_sorted = row0_non_null;
+  std::sort(row0_sorted.begin(), row0_sorted.end());
+  auto row1_sorted = row1;
+  std::sort(row1_sorted.begin(), row1_sorted.end());
+
+  std::vector<std::string> ex_strings;
+  std::vector<bool> ex_valids;
+  for (auto const& s : row0_sorted) {
+    ex_strings.push_back(s);
+    ex_valids.push_back(true);
+  }
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+  for (auto const& s : row1_sorted) {
+    ex_strings.push_back(s);
+    ex_valids.push_back(true);
+  }
+
+  auto const make_two_row_list = [&](std::vector<std::string> const& strs,
+                                     std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, row0_len, total_len};
+    return cudf::make_lists_column(2, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_two_row_list(in_strings, in_valids);
+  auto const expected = make_two_row_list(ex_strings, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// A run of byte-identical strings becomes length-uniform and exhausted once the windows cover its
+// length, so the drop freezes it early instead of dragging it to the pass cap and cleanup.
+TEST_F(SortListsString, PrefixExhaustedIdenticalRunDropped)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+  std::vector<std::string> in;
+  for (int i = 0; i < 40; ++i) {
+    in.emplace_back("abcdefghijkl");  // a byte-identical run
+  }
+  in.emplace_back("abcdefghijkZ");  // singleton: differs only in the last byte
+  in.emplace_back("abcdefgh");      // shorter proper prefix: its own run, sorts first
+
+  auto expected = in;
+  std::sort(expected.begin(), expected.end());
+
+  auto const input        = as_single_row_list(StrCW{in.begin(), in.end()}.release());
+  auto const expected_col = as_single_row_list(StrCW{expected.begin(), expected.end()}.release());
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected_col->view());
+}
+
+// A string and its zero-extension collide in every window, so the stable radix keeps arrival
+// order. Placing the LONGER first makes that order wrong lexicographically; an exhaustion-only
+// drop would freeze it, so the length-uniform guard must leave the run for the shorter-first
+// cleanup.
+TEST_F(SortListsString, PrefixZeroExtensionLongerFirstNotDropped)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+  std::string const base(20, 'A');
+  std::string const shorter = base;
+  std::string const longer  = base + std::string(1, '\0');
+
+  // base+"B" / base+"C" keep the run non-trivial; they resolve as singletons.
+  std::vector<std::string> in{longer, shorter, base + "B", base + "C"};
+  auto expected = in;
+  std::sort(expected.begin(), expected.end());  // shorter < longer < base+"B" < base+"C".
+
+  auto const input        = as_single_row_list(StrCW{in.begin(), in.end()}.release());
+  auto const expected_col = as_single_row_list(StrCW{expected.begin(), expected.end()}.release());
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected_col->view());
+}
+
+// The singleton compaction must extract only the deep row's still-tied elements, re-sort just
+// those, and scatter them back without disturbing the first-pass-resolved rows around it.
+TEST_F(SortListsString, PrefixCompactionMixedSingletonAndDeepRows)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::vector<std::vector<std::string>> rows;
+  // Every element differs in its first byte, so these rows resolve in the first pass.
+  for (int r = 0; r < 12; ++r) {
+    rows.push_back({std::string(1, static_cast<char>('a' + r)) + "_zzz",
+                    std::string(1, static_cast<char>('A' + r)) + "_aaa",
+                    std::string(1, static_cast<char>('0' + r)) + "_mmm"});
+  }
+  // The only row the compaction should re-sort: a 32-byte shared prefix, four windows past the key.
+  std::string const deep_prefix(32, 'D');
+  std::vector<std::string> deep;
+  deep.reserve(1'500);
+  for (int i = 0; i < 1'500; ++i) {
+    auto tail = std::to_string(i);
+    tail.insert(tail.begin(), 4 - tail.size(), '0');
+    deep.push_back(deep_prefix + tail);
+  }
+  std::shuffle(deep.begin(), deep.end(), std::mt19937{0xD00D});
+  // Place the deep row in the middle so resolved rows sit on both sides of the compacted block.
+  rows.insert(rows.begin() + 6, deep);
+
+  std::vector<std::string> in_strings;
+  std::vector<std::string> ex_strings;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const& row : rows) {
+    for (auto const& s : row) {
+      in_strings.push_back(s);
+    }
+    auto sorted = row;
+    std::sort(sorted.begin(), sorted.end());
+    for (auto const& s : sorted) {
+      ex_strings.push_back(s);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_strings.size()));
+  }
+
+  auto const num_rows  = static_cast<cudf::size_type>(rows.size());
+  auto const make_list = [&](std::vector<std::string> const& strs) {
+    StrCW leaf{strs.begin(), strs.end()};
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_list(in_strings);
+  auto const expected = make_list(ex_strings);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// With one segment (S = bit_width(1) = 1) and nulls, the packed key holds P = 64 - 1 - 1 = 62
+// prefix bits -- not a byte multiple -- so it proves 7 whole bytes plus byte 7's top six bits.
+// The probe strings differ only in byte 7's low two bits and therefore tie on the key; the
+// tie-break must resume its windows at byte 7 (a stale fixed eight-byte offset would skip past
+// both eight-byte strings and leave them arbitrarily ordered).
+TEST_F(SortListsString, PrefixPackedKeyPartialByteTieOffset)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::string const probe_lo = std::string("AAAAAA") + '\0' + '\x01';  // 8 bytes, byte 7 = 0x01.
+  std::string const probe_hi = std::string("AAAAAA") + '\0' + '\x02';  // 8 bytes, byte 7 = 0x02.
+
+  // The "B" fillers resolve in the first pass and never join the probe pair's run; the two nulls
+  // force the key's null bit (P = 62, not 63).
+  std::vector<std::string> in_strings;
+  std::vector<bool> in_valids;
+  in_strings.push_back(probe_hi);  // out of order, so the tie-break must reorder the pair
+  in_valids.push_back(true);
+  in_strings.push_back(probe_lo);
+  in_valids.push_back(true);
+  in_strings.emplace_back("");  // null placeholder; never compared
+  in_valids.push_back(false);
+  for (int i = 0; in_strings.size() < 199; ++i) {
+    auto tail = std::to_string(i);
+    tail.insert(tail.begin(), 4 - tail.size(), '0');
+    in_strings.push_back("B" + tail);
+    in_valids.push_back(true);
+  }
+  in_strings.emplace_back("");  // second null placeholder
+  in_valids.push_back(false);
+
+  auto const num_elements = static_cast<cudf::size_type>(in_strings.size());
+
+  std::vector<std::string> non_null;
+  for (std::size_t i = 0; i < in_strings.size(); ++i) {
+    if (in_valids[i]) { non_null.push_back(in_strings[i]); }
+  }
+  std::sort(non_null.begin(), non_null.end());
+  std::vector<std::string> ex_strings = non_null;
+  std::vector<bool> ex_valids(non_null.size(), true);
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+
+  auto const make_single_row_list = [](std::vector<std::string> const& strs,
+                                       std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(in_strings, in_valids);
+  auto const expected = make_single_row_list(ex_strings, ex_valids);
+  // The count only keeps the probe pair amid a bulk of first-pass singletons; one row fixes S = 1.
+  EXPECT_EQ(num_elements, 200);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Nulls are position-final after the first pass and excluded from the tie-break set; adjacent
+// nulls beside genuine tie runs verify the exclusion never misplaces them.
+TEST_F(SortListsString, PrefixNullRunsNeverTied)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::vector<std::string> const in_strings{
+    "AAAAAAAA3", "", "", "", "AAAAAAAA1", "AAAAAAAA2", "zebra", "apple", "apple"};
+  std::vector<bool> const in_valids{true, false, false, false, true, true, true, true, true};
+
+  // 'A' (0x41) < 'a' (0x61) < 'z' (0x7A) by raw byte; the three nulls collect last.
+  std::vector<std::string> const ex_strings{
+    "AAAAAAAA1", "AAAAAAAA2", "AAAAAAAA3", "apple", "apple", "zebra", "", "", ""};
+  std::vector<bool> const ex_valids{true, true, true, true, true, true, false, false, false};
+
+  auto const make_single_row_list = [](std::vector<std::string> const& strs,
+                                       std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(in_strings, in_valids);
+  auto const expected = make_single_row_list(ex_strings, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// A whole segment of exact duplicates collapses to one segment-spanning tie run beside ordinary
+// rows.
+TEST_F(SortListsString, PrefixWholeSegmentDuplicate)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::vector<std::string> const dup_row(10, "duplicate");
+  std::vector<std::vector<std::string>> const rows{
+    {"cherry", "apple", "banana"}, dup_row, {"melon", "date", "fig"}};
+
+  std::vector<std::string> in_strings;
+  std::vector<std::string> ex_strings;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const& row : rows) {
+    for (auto const& s : row) {
+      in_strings.push_back(s);
+    }
+    auto sorted = row;
+    std::sort(sorted.begin(), sorted.end());
+    for (auto const& s : sorted) {
+      ex_strings.push_back(s);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_strings.size()));
+  }
+
+  auto const num_rows  = static_cast<cudf::size_type>(rows.size());
+  auto const make_list = [&](std::vector<std::string> const& strs) {
+    StrCW leaf{strs.begin(), strs.end()};
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_list(in_strings);
+  auto const expected = make_list(ex_strings);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// The comparison cleanup's heapsort branch: the first pass proves 7 whole bytes (P = 63) and the
+// 8 windows of 8 bytes reach byte 7 + 64 = 71, so an 80-byte shared prefix survives every window
+// and the run (>= TIE_HEAPSORT_THRESHOLD) is resolved only by the cleanup.
+TEST_F(SortListsString, PrefixTrueHeapsortRun)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::string const prefix(80, 'Z');  // 80 > 7 + 8*8 = 71, so ties survive every iterative window.
+  std::vector<std::string> non_null;
+  // > 64 elements rejects the graduated-warp path, keeping the column on the prefix path.
+  for (int i = 0; i < 70; ++i) {
+    non_null.push_back(prefix + std::to_string(i / 10) + std::to_string(i % 10));
+  }
+  non_null.push_back(prefix + "05");  // exact duplicates
+  non_null.push_back(prefix + "17");
+
+  auto shuffled = non_null;
+  std::shuffle(shuffled.begin(), shuffled.end(), std::mt19937{0x8EA7});
+
+  auto sorted = non_null;
+  std::sort(sorted.begin(), sorted.end());
+
+  auto const make_single_row_list = [](std::vector<std::string> const& strs) {
+    StrCW leaf{strs.begin(), strs.end()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(shuffled);
+  auto const expected = make_single_row_list(sorted);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Sliced string input with a retained null: the packed-key builder, window tie-break, and
+// null handling must all honor the nonzero leaf offset.
+TEST_F(SortListsString, PrefixSlicedWithNulls)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+  StrLCW l{StrLCW{"zz", "aa"},
+           StrLCW{{"banana", "apple", "x", "cherry"}, null_at(2)},
+           StrLCW{"b", "a"},
+           StrLCW{"x"}};
+  auto const sliced_list = cudf::slice(l, {1, 4})[0];  // drops row 0 -> nonzero child offset
+  StrLCW expected{
+    StrLCW{{"apple", "banana", "cherry", "x"}, null_at(3)}, StrLCW{"a", "b"}, StrLCW{"x"}};
+  expect_both_sort_paths_match(cudf::lists_column_view{sliced_list}, expected);
+}
+
 TEST_F(SortListsInt, NestedListElement)
 {
   using T = int;
@@ -307,9 +980,8 @@ TEST_F(SortListsDouble, InfinityAndNaN)
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_lists->view(), expected);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(stable_sorted_lists->view(), expected);
   }
-  // This data includes a row with over 200 elements to test the
-  // radix sort is not used in the logic path in segmented_sort.
-  // Technically radix sort is not expected to be used in either case.
+  // Over 200 no-null elements route the unstable `sort_lists` through the packed-radix engine;
+  // the EQUIVALENT assertions tolerate either engine's ordering.
   {
     // clang-format off
     LCW input{0.0, -0.0, -NaN, -NaN, NaN, Inf, -Inf,

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -1300,6 +1300,55 @@ TEST_F(SortListsInt, NumericPackedTimestamps)
   }
 }
 
+// DECIMAL128 extremes on the tiered kernel (nulls route both rows there): +/-10^37 (~2^123)
+// reaches the high key words, and the sign flip (XOR bit 127) must order them across zero.
+TEST_F(SortListsInt, NumericPackedDecimal128Bounds)
+{
+  auto const pow10_37 = [] {
+    __int128_t v = 1;
+    for (int i = 0; i < 37; ++i) {
+      v *= 10;
+    }
+    return v;
+  }();
+  auto constexpr scale = numeric::scale_type{0};
+
+  {  // A longer row.
+    std::vector<__int128_t> ascending{-pow10_37, -pow10_37};
+    for (int i = -5; i <= 25; ++i) {
+      ascending.push_back(i);
+    }
+    ascending.push_back(pow10_37);
+    auto const null_pos = static_cast<cudf::size_type>(ascending.size());
+
+    // Values arrive reversed; the null-slot value is ignored.
+    std::vector<__int128_t> in_vals;
+    in_vals.push_back(0);
+    in_vals.insert(in_vals.end(), ascending.rbegin(), ascending.rend());
+    std::vector<__int128_t> ex_vals(ascending.begin(), ascending.end());
+    ex_vals.push_back(0);
+
+    auto input    = as_single_row_list(cudf::test::fixed_point_column_wrapper<__int128_t>(
+                                      in_vals.begin(), in_vals.end(), null_at(0), scale)
+                                      .release());
+    auto expected = as_single_row_list(cudf::test::fixed_point_column_wrapper<__int128_t>(
+                                         ex_vals.begin(), ex_vals.end(), null_at(null_pos), scale)
+                                         .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // The shorter-segment shape.
+    std::vector<__int128_t> const in{pow10_37, -pow10_37, -1, 0, 1, -pow10_37, 0};
+    std::vector<__int128_t> const ex{-pow10_37, -pow10_37, -1, 0, 1, pow10_37, 0};
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), null_at(3), scale)
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), null_at(6), scale)
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+}
+
 // BOOL8 is packed-radix-supported but not tiered, so a null routes it to the packed radix at any
 // size -- the only test reaching the bool `radix_encode_u32` branch with the key's null bit.
 TEST_F(SortListsInt, NumericPackedBoolWithNulls)
@@ -1468,8 +1517,8 @@ TEST_F(SortListsString, PrefixSlicedWithNulls)
 }
 
 // The warp tier in isolation (no segment above the 64 cap, so the radix fallback never runs):
-// the int64 and double rows fill their warp tiles exactly (zero pads); the DECIMAL128 row runs
-// the comparison fallback at this stage.
+// the int64 and double rows fill their warp tiles exactly (zero pads), the DECIMAL128 row leaves
+// pad slots.
 TEST_F(SortListsInt, NumericTieredWarpSegments)
 {
   auto constexpr scale = numeric::scale_type{0};
@@ -1500,7 +1549,7 @@ TEST_F(SortListsInt, NumericTieredWarpSegments)
         .release());
     expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
   }
-  {  // decimal128: comparison fallback at this stage.
+  {  // decimal128 warp tier (24-byte key).
     cudf::size_type const n = 50;
     std::vector<__int128_t> in(n);
     std::vector<bool> in_v(n);
@@ -1527,7 +1576,7 @@ TEST_F(SortListsInt, NumericTieredWarpSegments)
     expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
   }
   {  // double at exactly TIERED_WARP_CAP: full-tile occupancy of the generic warp kernel (the
-     // path float/double/chrono share).
+     // path float/double/chrono/decimal128 share).
     cudf::size_type const n = 64;
     std::vector<double> in(n);
     std::vector<bool> in_v(n);
@@ -1577,8 +1626,8 @@ TEST_F(SortListsInt, NumericMidBandInt64Tiered)
   check_single_row(16);  // one segment of sixteen -> tiny-CUB pocket (comparison -> CUB)
 }
 
-// The pocket routes small eight-byte integral shapes to CUB (via comparison), but the CUB engine
-// sorts only integral reps; chrono must stay on the tiered kernel.
+// `dispatch_storage_type` does not reduce chrono to its integer rep, so routing an 8-byte no-null
+// chrono to CUB throws CUDF_FAIL; the mid band must stay on the tiered kernel.
 TEST_F(SortListsInt, NumericMidBandChronoNoNull)
 {
   std::vector<int64_t> in(16);
@@ -1603,6 +1652,86 @@ TEST_F(SortListsInt, NumericMidBandChronoNoNull)
   }
 }
 
+// DECIMAL128 no-null routing trio: tiered below the CUB band, the lifted CUB `DeviceSegmentedSort`
+// (over the __int128 rep) inside it, tiered again above it below the packed-radix cutoff.
+TEST_F(SortListsInt, NumericMidBandDecimal128Cub)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  auto const k         = [] {
+    __int128_t v = 1;
+    for (int i = 0; i < 30; ++i) {
+      v *= 10;
+    }
+    return v;
+  }();
+  auto const check_single_row = [&](cudf::size_type n) {
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i) * k;
+    }
+    std::vector<__int128_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), scale).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check_single_row(8);   // average four: tiered kernel
+  check_single_row(16);  // average eight: DECIMAL128 mid band -> lifted CUB DeviceSegmentedSort
+  check_single_row(40);  // average twenty: above the CUB band, below packed radix -> tiered kernel
+  // The exact gate cells: average five is the first cell past the tiered tiny gate (avg > 4),
+  // average sixteen the last in-band CUB cell, average seventeen the first above-band tiered cell.
+  check_single_row(10);
+  check_single_row(32);
+  check_single_row(34);
+}
+
+// Pins both outcomes of the shape gate's "oversized segments are sparse" ratio
+// (`oversized * 32 <= num_segments`) at one mid-band average: ratio holds -> CUB, fails -> tiered.
+TEST_F(SortListsInt, NumericMidBandDecimal128CubShapeGate)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  auto const check =
+    [&](int num_small, cudf::size_type small_sz, int num_large, cudf::size_type large_sz) {
+      std::vector<__int128_t> in_vals;
+      std::vector<__int128_t> ex_vals;
+      std::vector<cudf::size_type> offsets{0};
+      auto const add_row = [&](cudf::size_type sz) {
+        std::vector<__int128_t> row(sz);
+        for (cudf::size_type i = 0; i < sz; ++i) {
+          row[i] = static_cast<__int128_t>(sz) - i;
+        }
+        for (auto const v : row) {
+          in_vals.push_back(v);
+        }
+        std::sort(row.begin(), row.end());
+        for (auto const v : row) {
+          ex_vals.push_back(v);
+        }
+        offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+      };
+      for (int r = 0; r < num_small; ++r) {
+        add_row(small_sz);
+      }
+      for (int r = 0; r < num_large; ++r) {
+        add_row(large_sz);
+      }
+      auto const num_rows  = static_cast<cudf::size_type>(num_small + num_large);
+      auto const make_list = [&](std::vector<__int128_t> const& vals) {
+        cudf::test::fixed_point_column_wrapper<__int128_t> leaf(vals.begin(), vals.end(), scale);
+        cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+        return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+      };
+      auto const input    = make_list(in_vals);
+      auto const expected = make_list(ex_vals);
+      expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+    };
+  check(200, 10, 2, 40);  // avg ~10, oversized=2: 2*32=64 <= 202 -> shape OK  -> lifted CUB
+  check(10, 10, 2, 40);   // avg ~15, oversized=2: 2*32=64 >  12  -> shape bad -> tiered
+  check(62, 10, 2, 40);   // exact ratio cell: 2*32=64 == 64 segments -> shape still OK (<=) -> CUB
+}
+
 // Pins the packed-radix gate's avg >= 100 boundary exactly: average 100 is the first packed-radix
 // shape, average 99 the last tiered one.
 TEST_F(SortListsInt, NumericPackedRadixAvgGateBoundary)
@@ -1625,8 +1754,7 @@ TEST_F(SortListsInt, NumericPackedRadixAvgGateBoundary)
 }
 
 // The long-list band (avg at/above the packed-radix cutoff) belongs to the one-shot packed radix;
-// both packed key widths span the sign boundary, and DECIMAL128 pins the same shape through its
-// comparison fallback at this stage.
+// all three key widths span the sign boundary.
 TEST_F(SortListsInt, NumericPackedRadixLongLists)
 {
   cudf::size_type const n = 220;  // single row, average 110 -> packed radix
@@ -1891,8 +2019,206 @@ TEST_F(SortListsInt, NumericTieredW32x1Nulls)
   run(int64_t{});
 }
 
+// Site A (the full-column packed radix) picks the narrowest lossless key from the value range:
+// < 2^32 -> min-biased uint64, fits int64 -> prefix_key96, else the two-phase hi64/lo64 sort.
+TEST_F(SortListsInt, NumericDecimal128ComposedSiteA)
+{
+  auto constexpr scale    = numeric::scale_type{0};
+  cudf::size_type const n = 250;  // single row, avg 125 >= 100 -> full-column packed radix (Site A)
+  auto const check        = [&](std::vector<__int128_t> const& in) {
+    std::vector<__int128_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), scale).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  {  // small: value range < 2^32 -> min-biased uint64 key
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i);
+    }
+    check(in);
+  }
+  {  // fits int64 (range > 2^32) -> prefix_key96 key
+    auto const step = static_cast<__int128_t>(int64_t{1} << 40);  // 2^40 > 2^32
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i) * step;
+    }
+    check(in);
+  }
+  {  // wide, distinct high words -> two-phase, phase one resolves (no tie pass)
+    auto const step = static_cast<__int128_t>(1) << 90;  // > int64, distinct hi64
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i) * step;
+    }
+    check(in);
+  }
+  {  // wide with shared high words -> two-phase second pass fires (two sign clusters, distinct
+     // lo64)
+    auto const base = static_cast<__int128_t>(1) << 100;
+    std::vector<__int128_t> in;
+    for (int i = 0; i < 125; ++i) {
+      in.push_back(-base + i);
+    }
+    for (int i = 0; i < 125; ++i) {
+      in.push_back(base + i);
+    }  // 250 total -> avg 125 -> Site A
+    check(in);
+  }
+}
+
+// Site B: with nulls, a segment above the warp cap becomes a tiered radix outlier on the
+// compact-large-segment path, which reuses the range-gated key selection; the all-null case
+// degenerates to the cheapest key.
+TEST_F(SortListsInt, NumericDecimal128ComposedSiteB)
+{
+  auto constexpr scale    = numeric::scale_type{0};
+  cudf::size_type const n = 200;  // one segment > 64 -> radix-tier outlier -> compact path (Site B)
+  auto const check        = [&](std::vector<__int128_t> const& in, std::vector<bool> const& valid) {
+    std::vector<__int128_t> nn;
+    for (cudf::size_type i = 0; i < n; ++i) {
+      if (valid[i]) { nn.push_back(in[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    std::vector<__int128_t> ex = nn;
+    std::vector<bool> ex_v(nn.size(), true);
+    ex.resize(n, __int128_t{0});
+    ex_v.resize(n, false);
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), valid.begin(), scale)
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), ex_v.begin(), scale)
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  {  // null-mixed wide with shared high words: two-phase second pass fires, nulls placed last
+    auto const base = static_cast<__int128_t>(1) << 100;
+    std::vector<__int128_t> in;
+    std::vector<bool> valid;
+    for (int i = 0; i < 100; ++i) {
+      in.push_back(-base + i);
+      valid.push_back(i % 7 != 3);
+    }
+    for (int i = 0; i < 100; ++i) {
+      in.push_back(base + i);
+      valid.push_back(i % 5 != 2);
+    }
+    check(in, valid);
+  }
+  {  // all-null: degenerate range -> cheapest key; every element sorts as a position-final null
+    std::vector<__int128_t> const in(n, __int128_t{0});
+    std::vector<bool> const valid(n, false);
+    check(in, valid);
+  }
+}
+
+// The Site A range gate's 2^32 boundary: a span of exactly 2^32 - 1 still fits the min-biased
+// uint64 key, a span of 2^32 must take the wider prefix_key96.
+TEST_F(SortListsInt, NumericDecimal128RangeGateBoundary)
+{
+  auto constexpr scale    = numeric::scale_type{0};
+  cudf::size_type const n = 250;  // single row, avg 125 >= 100 -> Site A range gate
+  auto const check        = [&](__int128_t span) {
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = (span / (n - 1)) * i;
+    }
+    in[n - 1] = span;  // exact max, so the range is [0, span]
+    std::vector<__int128_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), scale).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check((static_cast<__int128_t>(1) << 32) - 1);  // span 2^32 - 1 -> min-biased uint64 (lossless)
+  check(static_cast<__int128_t>(1) << 32);        // span 2^32     -> prefix_key96
+}
+
+// The key96 gate requires BOTH range bounds inside int64; an asymmetric range -- one bound far
+// outside, the other within -- must fall through to the two-phase key. A loosened gate
+// (`and` -> `or`) would narrow the out-of-range bound through `dec128_int64_key_builder`'s
+// `static_cast<int64_t>` and corrupt the order, which the host oracle below detects.
+TEST_F(SortListsInt, NumericDecimal128AsymmetricRangeGate)
+{
+  auto constexpr scale    = numeric::scale_type{0};
+  cudf::size_type const n = 250;  // single row, avg 125 >= 100 -> packed radix, Site A range gate
+  auto const check        = [&](__int128_t outlier) {
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n - 1; ++i) {
+      in[i] = i - 100;  // small values well inside int64
+    }
+    in[n - 1] = outlier;  // one bound far outside int64
+    std::vector<__int128_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), scale).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check(-(static_cast<__int128_t>(1) << 100));  // min far below INT64_MIN, max within int64
+  check(static_cast<__int128_t>(1) << 100);     // max far above INT64_MAX, min within int64
+}
+
+// The two-phase worst tie shape: every value sits in one aligned 2^64 band, so phase one's
+// encoded hi64 is a single constant and every element ties (num_tied == num_elements) -- phase
+// two must carry the order entirely in lo64. Row 1 mixes two-element runs with untied singletons,
+// so run detection must separate runs inside one segment and the tie scatter must leave untied
+// slots alone.
+TEST_F(SortListsInt, NumericDecimal128TwoPhaseAllTied)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  auto const band      = static_cast<__int128_t>(1) << 63;
+
+  // Span >= 2^32 within the band and max > int64 force the two-phase key.
+  std::vector<__int128_t> row0(250);
+  for (cudf::size_type i = 0; i < 250; ++i) {
+    row0[i] = band + (static_cast<__int128_t>(249 - i) << 32) + (i * 13) % 251;
+  }
+  row0[20] = row0[10];  // exact duplicates inside the run
+  row0[21] = row0[11];
+
+  // List 1: 50 interleaved (pair, singleton, pair-partner) triples, descending across groups.
+  std::vector<__int128_t> row1;
+  for (int j = 49; j >= 0; --j) {
+    auto const pair_hi      = static_cast<__int128_t>(j + 1) << 70;
+    auto const singleton_hi = static_cast<__int128_t>(j + 200) << 70;
+    row1.push_back(pair_hi + 2 * j + 1);
+    row1.push_back(singleton_hi + j);
+    row1.push_back(pair_hi + 2 * j);
+  }
+
+  auto const make_lists = [&](std::vector<__int128_t> const& a, std::vector<__int128_t> const& b) {
+    std::vector<__int128_t> leaf(a);
+    leaf.insert(leaf.end(), b.begin(), b.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{
+      0, static_cast<cudf::size_type>(a.size()), static_cast<cudf::size_type>(leaf.size())};
+    return cudf::make_lists_column(
+      2,
+      offsets.release(),
+      cudf::test::fixed_point_column_wrapper<__int128_t>(leaf.begin(), leaf.end(), scale).release(),
+      0,
+      {});
+  };
+
+  std::vector<__int128_t> ex0(row0);
+  std::vector<__int128_t> ex1(row1);
+  std::sort(ex0.begin(), ex0.end());
+  std::sort(ex1.begin(), ex1.end());
+  auto const input    = make_lists(row0, row1);
+  auto const expected = make_lists(ex0, ex1);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
 // The block tier's band seams (63/64/65, 128/129, 256/257, 512/513, 1024/1025) per key width;
-// DECIMAL128 pins the same seams through its comparison fallback at this stage.
+// DECIMAL128 routes tiered here because the CUB lift declines this column's oversized segments.
 TEST_F(SortListsInt, NumericTieredBlockTierBoundaries)
 {
   check_block_tier_boundaries<int32_t>(false, cudf::order::ASCENDING);
@@ -1912,7 +2238,7 @@ TEST_F(SortListsInt, NumericTieredBlockTierBoundariesWithNulls)
 }
 
 // The same seams under DESCENDING, with and without nulls (nulls lead under DESCENDING + AFTER);
-// the gate declines DESCENDING today, so this pins the expectations via the comparison sort.
+// the gate declines DESCENDING today, so these pin the comparison fallback for a future widening.
 TEST_F(SortListsInt, NumericTieredBlockTierBoundariesDescending)
 {
   check_block_tier_boundaries<int32_t>(false, cudf::order::DESCENDING);

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -387,6 +387,19 @@ void expect_both_sort_paths_match(cudf::lists_column_view const& input,
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted->view(), expected);
 }
 
+// EQUIVALENT variant for floating point: -0.0/+0.0 and distinct NaN bit patterns are
+// interchangeable under the unstable contract, so per-slot bytes may differ within such groups.
+void expect_both_sort_paths_equivalent(cudf::lists_column_view const& input,
+                                       cudf::column_view const& expected,
+                                       cudf::order column_order         = cudf::order::ASCENDING,
+                                       cudf::null_order null_precedence = cudf::null_order::AFTER)
+{
+  auto const sorted = cudf::lists::sort_lists(input, column_order, null_precedence);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted->view(), expected);
+  auto const stable_sorted = cudf::lists::stable_sort_lists(input, column_order, null_precedence);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(stable_sorted->view(), expected);
+}
+
 // Host oracle for one list row. cudf's null_order is comparator-level and DESCENDING swaps the
 // comparison operands, inverting null placement too: nulls land first iff (BEFORE) != (DESCENDING).
 template <typename T>
@@ -1110,6 +1123,95 @@ TEST_F(SortListsString, GradOversizedSegmentFallsThrough)
   expect_string_polarity_matrix(rows, valids);
 }
 
+// Sign-flip correctness at INT_MIN / INT_MAX for both tiered key widths (int32 -> uint64,
+// int64 -> unsigned __int128); the nulls route the rows to the tiered kernel.
+TEST_F(SortListsInt, NumericPackedNegativesAndBounds)
+{
+  {  // int32: the <= 4-byte uint64 tiered key.
+    auto constexpr lo = std::numeric_limits<int32_t>::min();
+    auto constexpr hi = std::numeric_limits<int32_t>::max();
+    std::vector<bool> const in_valids{true, true, false, true, true, true, false};
+    LCW<int32_t> input{{{hi, -1, 0, lo, 0, 1, 0}, in_valids.begin()}};
+    std::vector<bool> const ex_valids{true, true, true, true, true, false, false};
+    LCW<int32_t> expected{{{lo, -1, 0, 1, hi, 0, 0}, ex_valids.begin()}};
+    expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+  }
+  {  // int64: the 8-byte unsigned __int128 key. The file-wide `LCW` sources from `int32_t`, which
+     // cannot hold the 64-bit bounds, hence the direct `int64_t` wrapper.
+    using LCW64       = cudf::test::lists_column_wrapper<int64_t>;
+    auto constexpr lo = std::numeric_limits<int64_t>::min();
+    auto constexpr hi = std::numeric_limits<int64_t>::max();
+    std::vector<bool> const in_valids{true, true, false, true, true, true, false};
+    LCW64 input{{{hi, -1, 0, lo, 0, 1, 0}, in_valids.begin()}};
+    std::vector<bool> const ex_valids{true, true, true, true, true, false, false};
+    LCW64 expected{{{lo, -1, 0, 1, hi, 0, 0}, ex_valids.begin()}};
+    expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+  }
+}
+
+// Degenerate shapes (empty, single-element, all-duplicate rows) through the tiered network tier;
+// the null element is what routes the column there.
+TEST_F(SortListsInt, NumericPackedEmptyAndSingleRows)
+{
+  std::vector<bool> const in_valids{true, false, true};
+  LCW<int32_t> input{LCW<int32_t>{},
+                     LCW<int32_t>{5},
+                     LCW<int32_t>{-3, -3},
+                     LCW<int32_t>{{2, 7, -1}, in_valids.begin()}};
+  std::vector<bool> const ex_valids{true, true, false};
+  LCW<int32_t> expected{LCW<int32_t>{},
+                        LCW<int32_t>{5},
+                        LCW<int32_t>{-3, -3},
+                        LCW<int32_t>{{-1, 2, 7}, ex_valids.begin()}};
+  expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+}
+
+// Pre-/post-epoch timestamps for both rep widths guard the is_timestamp rep-extraction branch;
+// the signed flip must sort pre-epoch (negative rep) values first.
+TEST_F(SortListsInt, NumericPackedTimestamps)
+{
+  {  // TIMESTAMP_DAYS: int32 rep, the <= 4-byte uint64 tiered key.
+    std::vector<int32_t> const in{100, -50, 0, 0, 25};
+    std::vector<int32_t> const ex{-50, 0, 25, 100, 0};
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_D>(in.begin(), in.end(), null_at(2))
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_D>(ex.begin(), ex.end(), null_at(4))
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // TIMESTAMP_MILLISECONDS: int64 rep exceeding int32, the 8-byte unsigned __int128 tiered key.
+    auto constexpr big = int64_t{5} * 1'000 * 1'000 * 1'000;  // 5e9 > INT32_MAX, post-epoch
+    std::vector<int64_t> const in{big, -big, 0, 1, -1};
+    std::vector<int64_t> const ex{-big, -1, 1, big, 0};
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_ms>(in.begin(), in.end(), null_at(2))
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_ms>(ex.begin(), ex.end(), null_at(4))
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+}
+
+// BOOL8 is packed-radix-supported but not tiered, so a null routes it to the packed radix at any
+// size -- the only test reaching the bool `radix_encode_u32` branch with the key's null bit.
+TEST_F(SortListsInt, NumericPackedBoolWithNulls)
+{
+  std::vector<bool> const in_valids{true, true, false, true, true, false, true};
+  auto input =
+    as_single_row_list(cudf::test::fixed_width_column_wrapper<bool>(
+                         {true, false, true, true, false, false, false}, in_valids.begin())
+                         .release());
+  std::vector<bool> const ex_valids{true, true, true, true, true, false, false};
+  auto expected =
+    as_single_row_list(cudf::test::fixed_width_column_wrapper<bool>(
+                         {false, false, false, true, true, false, false}, ex_valids.begin())
+                         .release());
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
 // Sliced string input with a retained null: the packed-key builder, window tie-break, and
 // null handling must all honor the nonzero leaf offset.
 TEST_F(SortListsString, PrefixSlicedWithNulls)
@@ -1123,6 +1225,159 @@ TEST_F(SortListsString, PrefixSlicedWithNulls)
   StrLCW expected{
     StrLCW{{"apple", "banana", "cherry", "x"}, null_at(3)}, StrLCW{"a", "b"}, StrLCW{"x"}};
   expect_both_sort_paths_match(cudf::lists_column_view{sliced_list}, expected);
+}
+
+// Pins the packed-radix gate's avg >= 100 boundary exactly: average 100 is the first packed-radix
+// shape, average 99 the last tiered one.
+TEST_F(SortListsInt, NumericPackedRadixAvgGateBoundary)
+{
+  auto const check_single_row = [](cudf::size_type n) {
+    std::vector<int32_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = n / 2 - i;
+    }
+    std::vector<int32_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int32_t>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int32_t>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check_single_row(200);  // average exactly 100 -> the first packed-radix cell
+  check_single_row(198);  // average 99 -> the last tiered cell
+}
+
+// The long-list band (avg at/above the packed-radix cutoff) belongs to the one-shot packed radix;
+// all three key widths span the sign boundary.
+TEST_F(SortListsInt, NumericPackedRadixLongLists)
+{
+  cudf::size_type const n = 220;  // single row, average 110 -> packed radix
+  {                               // int32
+    std::vector<int32_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = n / 2 - i;
+    }
+    std::vector<int32_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int32_t>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int32_t>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // int64 beyond the 32-bit range
+    auto constexpr big = int64_t{5} * 1'000 * 1'000 * 1'000;
+    std::vector<int64_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = (static_cast<int64_t>(n / 2) - i) * big;
+    }
+    std::vector<int64_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // decimal128 into the high value words
+    auto constexpr scale = numeric::scale_type{0};
+    auto const k         = [] {
+      __int128_t v = 1;
+      for (int i = 0; i < 30; ++i) {
+        v *= 10;
+      }
+      return v;
+    }();
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i) * k;
+    }
+    std::vector<__int128_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), scale).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+}
+
+// No-null non-tiered types reach the packed radix only when num_rows >= 1<<18 AND avg >= 100 -- a
+// route no other test takes; the no-null key drops the null-class bit for the full value budget.
+TEST_F(SortListsInt, NumericPackedRadixNoNullNarrowTypes)
+{
+  cudf::size_type const n = 1 << 18;
+  auto const check        = [&](auto tag) {
+    using T = decltype(tag);
+    std::vector<T> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<T>((static_cast<int64_t>(n) - i) % 60'000);
+    }
+    std::vector<T> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input =
+      as_single_row_list(cudf::test::fixed_width_column_wrapper<T>(in.begin(), in.end()).release());
+    auto expected =
+      as_single_row_list(cudf::test::fixed_width_column_wrapper<T>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check(uint16_t{});
+  check(int16_t{});
+  check(uint64_t{});
+
+  // DECIMAL32/64 (non-tiered) take the same no-null packed radix over their int32/int64 rep.
+  auto const check_decimal = [&](auto rep_tag) {
+    using Rep            = decltype(rep_tag);
+    auto constexpr scale = numeric::scale_type{0};
+    std::vector<Rep> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<Rep>((static_cast<int64_t>(n) - i) % 60'000);
+    }
+    std::vector<Rep> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<Rep>(in.begin(), in.end(), scale).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<Rep>(ex.begin(), ex.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check_decimal(int32_t{});  // DECIMAL32.
+  check_decimal(int64_t{});  // DECIMAL64.
+}
+
+// The CUB-preference gate is a disjunction: a high average alone must not force the packed radix
+// while the total row count stays under `MAX_LIST_SIZE_FOR_FAST_SORT`. This shape (avg 149,
+// 150'000 rows) holds only through the row-count disjunct, exercising the CUB fast path at a
+// narrow-type cell no other test reaches; fast and comparison paths must agree.
+TEST_F(SortListsInt, NumericPackedRadixNarrowTypeHighAvgLowRowCount)
+{
+  cudf::size_type const num_segments = 1'000;
+  cudf::size_type const seg_size     = 150;  // avg = 150'000 / 1'001 = 149 >= 100
+  std::vector<uint16_t> in_vals(static_cast<std::size_t>(num_segments) * seg_size);
+  for (std::size_t i = 0; i < in_vals.size(); ++i) {
+    in_vals[i] = static_cast<uint16_t>((i * 31) % 60'000);
+  }
+  std::vector<cudf::size_type> offsets(num_segments + 1);
+  for (cudf::size_type i = 0; i <= num_segments; ++i) {
+    offsets[i] = i * seg_size;
+  }
+  std::vector<uint16_t> ex_vals(in_vals);
+  for (cudf::size_type s = 0; s < num_segments; ++s) {
+    std::sort(ex_vals.begin() + offsets[s], ex_vals.begin() + offsets[s + 1]);
+  }
+  auto const make_list = [&](std::vector<uint16_t> const& vals) {
+    return cudf::make_lists_column(
+      num_segments,
+      cudf::test::fixed_width_column_wrapper<cudf::size_type>(offsets.begin(), offsets.end())
+        .release(),
+      cudf::test::fixed_width_column_wrapper<uint16_t>(vals.begin(), vals.end()).release(),
+      0,
+      {});
+  };
+  auto const input    = make_list(in_vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
 }
 
 TEST_F(SortListsInt, NestedListElement)
@@ -1289,5 +1544,34 @@ TEST_F(SortListsDouble, InfinityAndNaN)
       generate_sorted_lists(cudf::lists_column_view{input}, {}, {});
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_lists->view(), expected);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(stable_sorted_lists->view(), expected);
+  }
+}
+
+// cudf orders -Inf < finite < +Inf < NaN (all payloads equal, last), nulls after NaN. Every NaN
+// canonicalizes to the all-ones key, so an un-canonicalized -NaN cannot sort near -Inf; the two
+// rows land in the warp tier, covering both key widths.
+TEST_F(SortListsDouble, NumericPackedFloatNaNInfinity)
+{
+  {  // FLOAT64: the 8-byte unsigned __int128 tiered key; thirteen elements land in the warp tier.
+    auto constexpr NaN    = std::numeric_limits<double>::quiet_NaN();
+    auto constexpr Inf    = std::numeric_limits<double>::infinity();
+    auto constexpr denorm = std::numeric_limits<double>::denorm_min();
+    auto constexpr Max    = std::numeric_limits<double>::max();  // DBL_MAX boundary vs. Inf
+    using LCWd            = cudf::test::lists_column_wrapper<double>;
+    LCWd input{
+      {{NaN, -Inf, -0.0, 3.5, -NaN, Inf, 0.0, denorm, -2.0, 0.0, Inf, Max, -Max}, null_at(9)}};
+    LCWd expected{
+      {{-Inf, -Max, -2.0, -0.0, 0.0, denorm, 3.5, Max, Inf, Inf, NaN, -NaN, 0.0}, null_at(12)}};
+    expect_both_sort_paths_equivalent(cudf::lists_column_view{input}, expected);
+  }
+  {  // FLOAT32: the <= 4-byte uint64 tiered key; ten elements land in the warp tier.
+    auto constexpr NaN    = std::numeric_limits<float>::quiet_NaN();
+    auto constexpr Inf    = std::numeric_limits<float>::infinity();
+    auto constexpr denorm = std::numeric_limits<float>::denorm_min();
+    auto constexpr Max    = std::numeric_limits<float>::max();  // FLT_MAX boundary vs. Inf
+    using LCWf            = cudf::test::lists_column_wrapper<float>;
+    LCWf input{{{-NaN, Inf, -0.0f, 2.5f, -Inf, denorm, 0.0f, NaN, Max, -Max}, null_at(6)}};
+    LCWf expected{{{-Inf, -Max, -0.0f, denorm, 2.5f, Max, Inf, NaN, -NaN, 0.0f}, null_at(9)}};
+    expect_both_sort_paths_equivalent(cudf::lists_column_view{input}, expected);
   }
 }

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -441,6 +441,111 @@ std::unique_ptr<cudf::column> as_single_row_list(std::unique_ptr<cudf::column> l
   cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
   return cudf::make_lists_column(1, offsets.release(), std::move(leaf), 0, {});
 }
+
+// One column straddling every block-tier band seam, checked against an independent host sort. The
+// 400 single-element filler rows pull the average list size to ~10 -- below the packed-radix cutoff
+// and above the int64 tiny-average pocket -- so a no-null column still routes to the tiered engine.
+template <typename T>
+void check_block_tier_boundaries(bool with_nulls, cudf::order column_order)
+{
+  // Both sides of every seam: 63/64/65 (warp cap), 128/129, 256/257, 512/513 (the graduated block
+  // bands), 1024/1025 (block cap -> radix spill).
+  std::vector<cudf::size_type> const sizes{63, 64, 65, 128, 129, 256, 257, 512, 513, 1'024, 1'025};
+  auto const gen = [](cudf::size_type s, cudf::size_type i) -> T {
+    if constexpr (std::is_same_v<T, __int128_t>) {
+      __int128_t k = 1;
+      for (int j = 0; j < 30; ++j) {
+        k *= 10;
+      }
+      return static_cast<__int128_t>(s / 2 - i) * k;  // mixed sign, into the high value word
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+      return static_cast<int64_t>(s - i) * int64_t{5'000'000'011};  // beyond the 32-bit range
+    } else if constexpr (std::is_floating_point_v<T>) {
+      return static_cast<T>(s / 2 - i) * T{1.5};  // mixed sign, exactly representable
+    } else {
+      return static_cast<T>(s - i);
+    }
+  };
+  bool const descending = column_order == cudf::order::DESCENDING;
+  std::vector<T> in_vals;
+  std::vector<bool> in_valids;
+  std::vector<T> ex_vals;
+  std::vector<bool> ex_valids;
+  std::vector<cudf::size_type> offsets{0};
+  auto const push_row = [&](std::vector<T> const& rv, std::vector<bool> const& rok) {
+    std::vector<T> nn;
+    for (std::size_t i = 0; i < rv.size(); ++i) {
+      in_vals.push_back(rv[i]);
+      in_valids.push_back(rok[i]);
+      if (rok[i]) { nn.push_back(rv[i]); }
+    }
+    // Skipping the trivial call sidesteps gcc-14's -O3 -Warray-bounds false positive on the
+    // inlined insertion sort's memmove for the single-element filler rows.
+    if (nn.size() > 1) {
+      std::sort(nn.begin(), nn.end());
+      if (descending) { std::reverse(nn.begin(), nn.end()); }
+    }
+    auto const num_nulls  = rv.size() - nn.size();
+    auto const push_nulls = [&] {
+      for (std::size_t k = 0; k < num_nulls; ++k) {
+        ex_vals.push_back(T{0});
+        ex_valids.push_back(false);
+      }
+    };
+    if (descending) { push_nulls(); }
+    for (auto const v : nn) {
+      ex_vals.push_back(v);
+      ex_valids.push_back(true);
+    }
+    if (not descending) { push_nulls(); }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  };
+  for (auto const s : sizes) {
+    std::vector<T> rv(s);
+    std::vector<bool> rok(s, true);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i] = gen(s, i);
+      if (with_nulls) { rok[i] = (i % 7 != 3); }  // scattered element nulls
+    }
+    // cuda::std::numeric_limits covers __int128_t in every language mode (std:: only in gnu mode).
+    rv[0] = cuda::std::numeric_limits<T>::max();
+    rv[1] = cuda::std::numeric_limits<T>::lowest();
+    rv[2] = rv[3];  // a duplicate value
+    push_row(rv, rok);
+  }
+  for (int f = 0; f < 400; ++f) {
+    push_row(std::vector<T>{gen(1, 0)}, std::vector<bool>{true});
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(offsets.size() - 1);
+  auto const make_list = [&](std::vector<T> const& vals, std::vector<bool> const& valids) {
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    auto leaf = [&]() -> std::unique_ptr<cudf::column> {
+      if constexpr (std::is_same_v<T, __int128_t>) {
+        auto constexpr scale = numeric::scale_type{0};
+        if (with_nulls) {
+          return cudf::test::fixed_point_column_wrapper<__int128_t>(
+                   vals.begin(), vals.end(), valids.begin(), scale)
+            .release();
+        }
+        return cudf::test::fixed_point_column_wrapper<__int128_t>(vals.begin(), vals.end(), scale)
+          .release();
+      } else {
+        if (with_nulls) {
+          return cudf::test::fixed_width_column_wrapper<T>(vals.begin(), vals.end(), valids.begin())
+            .release();
+        }
+        return cudf::test::fixed_width_column_wrapper<T>(vals.begin(), vals.end()).release();
+      }
+    }();
+    return cudf::make_lists_column(num_rows, off.release(), std::move(leaf), 0, {});
+  };
+  auto const input    = make_list(in_vals, in_valids);
+  auto const expected = make_list(ex_vals, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()},
+                               expected->view(),
+                               column_order,
+                               cudf::null_order::AFTER);
+}
 }  // namespace
 
 // All shorter than the packed key, so the key alone orders them -- including the second-byte
@@ -1212,7 +1317,142 @@ TEST_F(SortListsInt, NumericPackedBoolWithNulls)
   expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
 }
 
-// Sliced string input with a retained null: the packed-key builder, window tie-break, and
+// All three tiers in one column -- network (<= 8), warp (9..64), radix (> 64), with both exact
+// caps and their first over-cap sizes -- must merge into one gather map with no cross-row
+// contamination; the nulls are what route the column to the tiered kernel.
+TEST_F(SortListsInt, NumericTieredThreeSizeClasses)
+{
+  std::vector<cudf::size_type> const sizes{0, 1, 3, 8, 9, 33, 64, 65, 600, 3'000};
+  std::vector<int32_t> in_vals;
+  std::vector<bool> in_valids;
+  std::vector<int32_t> ex_vals;
+  std::vector<bool> ex_valids;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const s : sizes) {
+    std::vector<int32_t> rv(s);
+    std::vector<bool> rok(s);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i]  = static_cast<int32_t>(s - i);  // distinct, descending -> the sort must fully reorder
+      rok[i] = (i % 7 != 3);                 // scattered element nulls
+    }
+    if (s >= 2) { rv[1] = rv[0]; }  // a duplicate value among the non-nulls
+    std::vector<int32_t> nn;
+    for (cudf::size_type i = 0; i < s; ++i) {
+      in_vals.push_back(rv[i]);
+      in_valids.push_back(rok[i]);
+      if (rok[i]) { nn.push_back(rv[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    for (auto const v : nn) {
+      ex_vals.push_back(v);
+      ex_valids.push_back(true);
+    }
+    for (cudf::size_type k = static_cast<cudf::size_type>(nn.size()); k < s; ++k) {
+      ex_vals.push_back(0);
+      ex_valids.push_back(false);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+  auto const make_list = [&](std::vector<int32_t> const& vals, std::vector<bool> const& valids) {
+    cudf::test::fixed_width_column_wrapper<int32_t> leaf(vals.begin(), vals.end(), valids.begin());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(in_vals, in_valids);
+  auto const expected = make_list(ex_vals, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// 200 network-tier and 10 warp-tier segments make both kernels' grids span >= 2 blocks (128
+// threads = 4 virtual warps per block), which no other tiered test reaches.
+TEST_F(SortListsInt, NumericTieredMultiBlockGrid)
+{
+  std::vector<cudf::size_type> sizes;
+  for (int i = 0; i < 200; ++i) {
+    sizes.push_back(1 + (i % 8));
+  }  // 200 network-tier segments
+  for (int i = 0; i < 10; ++i) {
+    sizes.push_back(16 + (i % 40));
+  }  // 10 warp-tier segments
+  std::vector<int32_t> in_vals;
+  std::vector<int32_t> ex_vals;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const s : sizes) {
+    std::vector<int32_t> rv(s);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i] = static_cast<int32_t>(s - i);
+    }
+    for (auto const v : rv) {
+      in_vals.push_back(v);
+    }
+    std::sort(rv.begin(), rv.end());
+    for (auto const v : rv) {
+      ex_vals.push_back(v);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+  auto const make_list = [&](std::vector<int32_t> const& vals) {
+    cudf::test::fixed_width_column_wrapper<int32_t> leaf(vals.begin(), vals.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(in_vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Zero-one principle: a comparison network that sorts every 0/1 input sorts every input, so
+// running all patterns at sizes 1..8 permanently pins the hand-unrolled 19-comparator network.
+TEST_F(SortListsInt, NumericTieredNetworkZeroOneExhaustive)
+{
+  std::vector<int32_t> vals;
+  std::vector<int32_t> ex_vals;
+  std::vector<cudf::size_type> offsets{0};
+  for (int n = 1; n <= 8; ++n) {
+    for (int pattern = 0; pattern < (1 << n); ++pattern) {
+      int ones = 0;
+      for (int b = 0; b < n; ++b) {
+        int const bit = (pattern >> b) & 1;
+        vals.push_back(bit);
+        ones += bit;
+      }
+      for (int b = 0; b < n; ++b) {
+        ex_vals.push_back(b < n - ones ? 0 : 1);
+      }
+      offsets.push_back(static_cast<cudf::size_type>(vals.size()));
+    }
+  }
+  auto const num_lists = static_cast<cudf::size_type>(offsets.size() - 1);
+  auto const make_list = [&](std::vector<int32_t> const& v) {
+    cudf::test::fixed_width_column_wrapper<int32_t> leaf(v.begin(), v.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_lists, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Nonzero child offset plus a retained null: the tiered engine must read validity through the
+// offset. Sliced covers the offset alone.
+TEST_F(SortListsInt, SlicedWithNulls)
+{
+  using T = int;
+  std::vector<bool> const valids{true, false, true};  // row 1's middle element (5) is null
+  LCW<T> l{{3, 2, 1, 4}, {{7, 5, 6}, valids.begin()}, {8, 9}, {10}};
+
+  auto const sliced_list = cudf::slice(l, {1, 4})[0];  // drops row 0 -> nonzero child offset
+  std::vector<bool> const ex_valids{true, true, false};
+  auto const expected = LCW<T>{{{6, 7, 0}, ex_valids.begin()}, {8, 9}, {10}};
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{sliced_list}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Mirrors SlicedWithNulls for the string engine: the packed-key builder, window tie-break, and
 // null handling must all honor the nonzero leaf offset.
 TEST_F(SortListsString, PrefixSlicedWithNulls)
 {
@@ -1225,6 +1465,142 @@ TEST_F(SortListsString, PrefixSlicedWithNulls)
   StrLCW expected{
     StrLCW{{"apple", "banana", "cherry", "x"}, null_at(3)}, StrLCW{"a", "b"}, StrLCW{"x"}};
   expect_both_sort_paths_match(cudf::lists_column_view{sliced_list}, expected);
+}
+
+// The warp tier in isolation (no segment above the 64 cap, so the radix fallback never runs):
+// the int64 and double rows fill their warp tiles exactly (zero pads); the DECIMAL128 row runs
+// the comparison fallback at this stage.
+TEST_F(SortListsInt, NumericTieredWarpSegments)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  {  // int64 warp tier.
+    cudf::size_type const n = 64;
+    std::vector<int64_t> in(n);
+    std::vector<bool> in_v(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] =
+        static_cast<int64_t>(n - i) * 1'000'000'007LL;  // distinct, descending, beyond 32 bits
+      in_v[i] = (i % 5 != 2);                           // scattered nulls
+    }
+    in[1] = in[0];  // a duplicate value among the non-nulls
+    std::vector<int64_t> nn;
+    for (cudf::size_type i = 0; i < n; ++i) {
+      if (in_v[i]) { nn.push_back(in[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    std::vector<int64_t> ex = nn;
+    std::vector<bool> ex_v(nn.size(), true);
+    ex.resize(n, int64_t{0});
+    ex_v.resize(n, false);
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(in.begin(), in.end(), in_v.begin())
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(ex.begin(), ex.end(), ex_v.begin())
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // decimal128: comparison fallback at this stage.
+    cudf::size_type const n = 50;
+    std::vector<__int128_t> in(n);
+    std::vector<bool> in_v(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i]   = static_cast<__int128_t>(n - i) * (i % 2 == 0 ? 1 : -1);  // mixed sign, distinct
+      in_v[i] = (i % 6 != 4);
+    }
+    in[3] = in[2];  // a duplicate value
+    std::vector<__int128_t> nn;
+    for (cudf::size_type i = 0; i < n; ++i) {
+      if (in_v[i]) { nn.push_back(in[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    std::vector<__int128_t> ex = nn;
+    std::vector<bool> ex_v(nn.size(), true);
+    ex.resize(n, __int128_t{0});
+    ex_v.resize(n, false);
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), in_v.begin(), scale)
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), ex_v.begin(), scale)
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // double at exactly TIERED_WARP_CAP: full-tile occupancy of the generic warp kernel (the
+     // path float/double/chrono share).
+    cudf::size_type const n = 64;
+    std::vector<double> in(n);
+    std::vector<bool> in_v(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i]   = static_cast<double>(n - i);  // distinct, descending
+      in_v[i] = (i % 5 != 2);                // scattered nulls
+    }
+    in[1] = in[0];  // a duplicate value among the non-nulls
+    std::vector<double> nn;
+    for (cudf::size_type i = 0; i < n; ++i) {
+      if (in_v[i]) { nn.push_back(in[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    std::vector<double> ex = nn;
+    std::vector<bool> ex_v(nn.size(), true);
+    ex.resize(n, 0.0);
+    ex_v.resize(n, false);
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<double>(in.begin(), in.end(), in_v.begin()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<double>(ex.begin(), ex.end(), ex_v.begin()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+}
+
+// No-null int64 single-segment shapes this small sit in the eight-byte tiny-CUB pocket (average
+// at or below the network cap, few offsets), so both sizes route to `comparison` and resolve to
+// the pre-existing CUB `DeviceSegmentedSort` fast path rather than the tiered network/warp
+// kernels; the cells pin the pocket's fast-vs-comparison agreement.
+TEST_F(SortListsInt, NumericMidBandInt64Tiered)
+{
+  auto constexpr big          = int64_t{5} * 1'000 * 1'000 * 1'000;  // > INT32_MAX
+  auto const check_single_row = [big](cudf::size_type n) {
+    std::vector<int64_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = (static_cast<int64_t>(n / 2) - i) * big;
+    }
+    std::vector<int64_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check_single_row(8);   // one segment of eight -> tiny-CUB pocket (comparison -> CUB)
+  check_single_row(16);  // one segment of sixteen -> tiny-CUB pocket (comparison -> CUB)
+}
+
+// The pocket routes small eight-byte integral shapes to CUB (via comparison), but the CUB engine
+// sorts only integral reps; chrono must stay on the tiered kernel.
+TEST_F(SortListsInt, NumericMidBandChronoNoNull)
+{
+  std::vector<int64_t> in(16);
+  for (cudf::size_type i = 0; i < 16; ++i) {
+    in[i] = (8 - i) * int64_t{1'000'000'000};
+  }
+  std::vector<int64_t> ex(in);
+  std::sort(ex.begin(), ex.end());
+  {  // TIMESTAMP_MILLISECONDS (int64 rep)
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_ms>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_ms>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // DURATION_MICROSECONDS (int64 rep)
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::duration_us>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::duration_us>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
 }
 
 // Pins the packed-radix gate's avg >= 100 boundary exactly: average 100 is the first packed-radix
@@ -1249,7 +1625,8 @@ TEST_F(SortListsInt, NumericPackedRadixAvgGateBoundary)
 }
 
 // The long-list band (avg at/above the packed-radix cutoff) belongs to the one-shot packed radix;
-// all three key widths span the sign boundary.
+// both packed key widths span the sign boundary, and DECIMAL128 pins the same shape through its
+// comparison fallback at this stage.
 TEST_F(SortListsInt, NumericPackedRadixLongLists)
 {
   cudf::size_type const n = 220;  // single row, average 110 -> packed radix
@@ -1378,6 +1755,174 @@ TEST_F(SortListsInt, NumericPackedRadixNarrowTypeHighAvgLowRowCount)
   auto const input    = make_list(in_vals);
   auto const expected = make_list(ex_vals);
   expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// The no-null int32 register-bitonic bands with the 8/9, 32/33, and 64/65 boundaries in one
+// column. INT32_MAX radix-encodes to the raw-key pad sentinel, so the pad tie-break must keep it
+// inside the segment.
+TEST_F(SortListsInt, NumericTieredBitonicNoNullInt32)
+{
+  std::vector<cudf::size_type> const sizes{8, 9, 16, 17, 32, 33, 48, 64, 65};
+  auto constexpr lo = std::numeric_limits<int32_t>::min();
+  auto constexpr hi = std::numeric_limits<int32_t>::max();
+  std::vector<int32_t> in_vals;
+  std::vector<int32_t> ex_vals;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const s : sizes) {
+    std::vector<int32_t> rv(s);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i] = static_cast<int32_t>(s - i);
+    }
+    rv[0] = hi;                     // a real INT32_MAX (radix-encodes to the raw-key pad sentinel)
+    if (s >= 2) { rv[1] = lo; }     // INT32_MIN
+    if (s >= 4) { rv[2] = rv[3]; }  // a duplicate value
+    for (auto const v : rv) {
+      in_vals.push_back(v);
+    }
+    std::sort(rv.begin(), rv.end());
+    for (auto const v : rv) {
+      ex_vals.push_back(v);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+  auto const make_list = [&](std::vector<int32_t> const& vals) {
+    cudf::test::fixed_width_column_wrapper<int32_t> leaf(vals.begin(), vals.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(in_vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// The no-null int64 bitonic/narrow split: register bitonic up to 32, raw-key `WarpMergeSort` for
+// 33..64, pinned at the 32/33 and 64/65 boundaries. INT64_MAX encodes to exactly the raw-key pad
+// sentinel, so pads must never displace the real element.
+TEST_F(SortListsInt, NumericTieredBitonicNarrowNoNullInt64)
+{
+  std::vector<cudf::size_type> const sizes{9, 32, 33, 40, 48, 64, 65};
+  auto constexpr lo  = std::numeric_limits<int64_t>::min();
+  auto constexpr hi  = std::numeric_limits<int64_t>::max();
+  auto constexpr big = int64_t{5} * 1'000 * 1'000 * 1'000;  // > INT32_MAX
+  std::vector<int64_t> in_vals;
+  std::vector<int64_t> ex_vals;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const s : sizes) {
+    std::vector<int64_t> rv(s);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i] = (static_cast<int64_t>(s) - i) * big;
+    }
+    rv[0] = hi;                     // a real INT64_MAX (encodes to the raw-key pad sentinel)
+    if (s >= 2) { rv[1] = lo; }     // INT64_MIN
+    if (s >= 4) { rv[2] = rv[3]; }  // a duplicate value
+    for (auto const v : rv) {
+      in_vals.push_back(v);
+    }
+    std::sort(rv.begin(), rv.end());
+    for (auto const v : rv) {
+      ex_vals.push_back(v);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+  auto const make_list = [&](std::vector<int64_t> const& vals) {
+    cudf::test::fixed_width_column_wrapper<int64_t> leaf(vals.begin(), vals.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(in_vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Null-bearing int32/int64 warp tier: the packed-key `WarpMergeSort` (one item per lane to 32,
+// two to 64) across the 8/9, 32/33, and 64/65 boundaries.
+TEST_F(SortListsInt, NumericTieredW32x1Nulls)
+{
+  std::vector<cudf::size_type> const sizes{8, 9, 32, 33, 64, 65};
+  auto const run = [&](auto tag) {
+    using T           = decltype(tag);
+    auto constexpr lo = std::numeric_limits<T>::min();
+    auto constexpr hi = std::numeric_limits<T>::max();
+    std::vector<T> in_vals;
+    std::vector<bool> in_valids;
+    std::vector<T> ex_vals;
+    std::vector<bool> ex_valids;
+    std::vector<cudf::size_type> offsets{0};
+    for (auto const s : sizes) {
+      std::vector<T> rv(s);
+      std::vector<bool> rok(s);
+      for (cudf::size_type i = 0; i < s; ++i) {
+        rv[i]  = static_cast<T>(s - i);
+        rok[i] = (i % 5 != 2);  // scattered element nulls
+      }
+      rv[0] = hi;
+      if (s >= 2) { rv[1] = lo; }
+      if (s >= 4) { rv[2] = rv[3]; }  // a duplicate among the non-nulls
+      std::vector<T> nn;
+      for (cudf::size_type i = 0; i < s; ++i) {
+        in_vals.push_back(rv[i]);
+        in_valids.push_back(rok[i]);
+        if (rok[i]) { nn.push_back(rv[i]); }
+      }
+      std::sort(nn.begin(), nn.end());
+      for (auto const v : nn) {
+        ex_vals.push_back(v);
+        ex_valids.push_back(true);
+      }
+      for (cudf::size_type k = static_cast<cudf::size_type>(nn.size()); k < s; ++k) {
+        ex_vals.push_back(T{0});
+        ex_valids.push_back(false);
+      }
+      offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+    }
+    auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+    auto const make_list = [&](std::vector<T> const& vals, std::vector<bool> const& valids) {
+      cudf::test::fixed_width_column_wrapper<T> leaf(vals.begin(), vals.end(), valids.begin());
+      cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+      return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+    };
+    auto const input    = make_list(in_vals, in_valids);
+    auto const expected = make_list(ex_vals, ex_valids);
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  run(int32_t{});
+  run(int64_t{});
+}
+
+// The block tier's band seams (63/64/65, 128/129, 256/257, 512/513, 1024/1025) per key width;
+// DECIMAL128 pins the same seams through its comparison fallback at this stage.
+TEST_F(SortListsInt, NumericTieredBlockTierBoundaries)
+{
+  check_block_tier_boundaries<int32_t>(false, cudf::order::ASCENDING);
+  check_block_tier_boundaries<int64_t>(false, cudf::order::ASCENDING);
+  check_block_tier_boundaries<float>(false, cudf::order::ASCENDING);
+  check_block_tier_boundaries<__int128_t>(false, cudf::order::ASCENDING);
+}
+
+// The same seams with nulls: every block band must place nulls purely through the packed key's
+// class flag.
+TEST_F(SortListsInt, NumericTieredBlockTierBoundariesWithNulls)
+{
+  check_block_tier_boundaries<int32_t>(true, cudf::order::ASCENDING);
+  check_block_tier_boundaries<int64_t>(true, cudf::order::ASCENDING);
+  check_block_tier_boundaries<float>(true, cudf::order::ASCENDING);
+  check_block_tier_boundaries<__int128_t>(true, cudf::order::ASCENDING);
+}
+
+// The same seams under DESCENDING, with and without nulls (nulls lead under DESCENDING + AFTER);
+// the gate declines DESCENDING today, so this pins the expectations via the comparison sort.
+TEST_F(SortListsInt, NumericTieredBlockTierBoundariesDescending)
+{
+  check_block_tier_boundaries<int32_t>(false, cudf::order::DESCENDING);
+  check_block_tier_boundaries<int64_t>(false, cudf::order::DESCENDING);
+  check_block_tier_boundaries<float>(false, cudf::order::DESCENDING);
+  check_block_tier_boundaries<__int128_t>(false, cudf::order::DESCENDING);
+  check_block_tier_boundaries<int32_t>(true, cudf::order::DESCENDING);
+  check_block_tier_boundaries<int64_t>(true, cudf::order::DESCENDING);
+  check_block_tier_boundaries<float>(true, cudf::order::DESCENDING);
+  check_block_tier_boundaries<__int128_t>(true, cudf::order::DESCENDING);
 }
 
 TEST_F(SortListsInt, NestedListElement)

--- a/cpp/tests/lists/stream_compaction/distinct_tests.cpp
+++ b/cpp/tests/lists/stream_compaction/distinct_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -562,13 +562,34 @@ TEST_F(ListDistinctTest, InputListsOfStructsHaveNull)
   {
     auto const input_original = cudf::make_lists_column(
       3, int32s_col{0, 8, 16, 24}.release(), get_structs().release(), 0, {});
-    auto const expected_original = cudf::make_lists_column(
-      3, int32s_col{0, 6, 12, 20}.release(), get_expected().release(), 0, {});
-    auto const input    = cudf::slice(*input_original, {1, 3})[0];
-    auto const expected = cudf::slice(*expected_original, {1, 3})[0];
+    auto const input = cudf::slice(*input_original, {1, 3})[0];
+
+    // The sliced range holds no struct-level nulls, so the result's struct child is non-nullable;
+    // build the expected column directly (slicing `get_expected()` would keep its allocated mask).
+    auto const expected = [] {
+      auto child1 =
+        int32s_col{{null, 1, 1, 1, 1, 2, null, null, 2, 2, 2, 3, 3, 3}, nulls_at({0, 6, 7})};
+      auto child2  = strings_col{{"", /*NULL*/
+                                  "Bear",
+                                  "Cat",
+                                  "Dog",
+                                  "Duck",
+                                  "Panda",
+                                  "ÁÁÁ",
+                                  "ÉÉÉÉÉ",
+                                  "ÁBC",
+                                  "ÁÁÁ",
+                                  "ÍÍÍÍÍ",
+                                  "", /*NULL*/
+                                  "XYZ",
+                                  "ÁBC"},
+                                nulls_at({0, 11})};
+      auto structs = structs_col{{child1, child2}};
+      return cudf::make_lists_column(2, int32s_col{0, 6, 14}.release(), structs.release(), 0, {});
+    }();
 
     auto const results_sorted = distinct_sorted(input);
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results_sorted);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results_sorted);
   }
 }
 

--- a/cpp/tests/sort/segmented_sort_tests.cpp
+++ b/cpp/tests/sort/segmented_sort_tests.cpp
@@ -382,7 +382,7 @@ TEST_F(SegmentedSortInt, UnbalancedOffsets)
 // The unstable single-column fast paths (tiered, packed-radix, strings) require segment offsets
 // spanning every row `[0, num_rows]`, while the public contract also allows partial and
 // single-index offsets. These tests pin the offsets-coverage guard that routes such inputs to the
-// comparison path, for each fast-path family.
+// comparison path, for each fast-path family and for both explicit sort orders.
 
 // Without the guard these offsets would take the tiered fast path; guarded, only [3, 7) sorts.
 TEST_F(SegmentedSortInt, FastPathPartialOffsetsNumeric)
@@ -442,6 +442,38 @@ TEST_F(SegmentedSortInt, FastPathPartialOffsetsPackedRadix)
   CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
 }
 
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsPackedRadixDescending)
+{
+  using T                 = int;
+  cudf::size_type const n = 400;
+  std::vector<T> vals(n);
+  std::vector<T> ex(n);
+  for (cudf::size_type i = 0; i < n; ++i) {
+    vals[i] = i;  // strictly ascending, distinct
+    // [100, 300) sorted descending is 299..100.
+    ex[i] = (i < 100 or i >= 300) ? vals[i] : (399 - i);
+  }
+  column_wrapper<T> col(vals.begin(), vals.end());
+  column_wrapper<T> expected(ex.begin(), ex.end());
+  column_wrapper<int> segments{{100, 300}};
+  cudf::table_view input{{col}};
+  auto result = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::DESCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsDescending)
+{
+  using T = int;
+  column_wrapper<T> col{{50, 51, 52, 40, 10, 30, 20, 57, 58, 59}};
+  column_wrapper<int> segments{{3, 7}};
+  cudf::table_view input{{col}};
+  column_wrapper<T> expected{{50, 51, 52, 40, 30, 20, 10, 57, 58, 59}};
+  auto result = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::DESCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
 // Without the guard these offsets would take the strings fast path; guarded, only [3, 7) sorts.
 TEST_F(SegmentedSortInt, FastPathPartialOffsetsStrings)
 {
@@ -453,6 +485,19 @@ TEST_F(SegmentedSortInt, FastPathPartialOffsetsStrings)
   auto const input = cudf::table_view{{col}};
   auto result      = cudf::segmented_sort_by_key(
     input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsStringsDescending)
+{
+  cudf::test::strings_column_wrapper col{
+    "a0", "a1", "a2", "banana", "apple", "cherry", "date", "z7", "z8", "z9"};
+  cudf::test::strings_column_wrapper expected{
+    "a0", "a1", "a2", "date", "cherry", "banana", "apple", "z7", "z8", "z9"};
+  column_wrapper<int> segments{{3, 7}};
+  auto const input = cudf::table_view{{col}};
+  auto result      = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::DESCENDING}, {cudf::null_order::AFTER});
   CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
 }
 

--- a/cpp/tests/sort/segmented_sort_tests.cpp
+++ b/cpp/tests/sort/segmented_sort_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -207,6 +207,31 @@ TYPED_TEST(SegmentedSort, StableWithNulls)
   CUDF_TEST_EXPECT_TABLES_EQUAL(results->view(), cudf::table_view{{col_des}});
 }
 
+// Values that are nullable but hold no nulls must come back without a null mask: the sort-by-key
+// gather cannot add nulls, so the output is nullable only when nulls are present.
+TEST_F(SegmentedSortInt, ValuesWithZeroNullsDropMask)
+{
+  using T = int;
+  column_wrapper<T> keys{{3, 1, 2, 7, 5, 6}};
+  column_wrapper<T> values{{10, 20, 30, 40, 50, 60}, {1, 1, 1, 1, 1, 1}};
+  column_wrapper<int> segments{{0, 3, 6}};
+  cudf::table_view values_view{{values}};
+  cudf::table_view keys_view{{keys}};
+  ASSERT_TRUE(cudf::column_view{values}.nullable());
+  ASSERT_EQ(cudf::column_view{values}.null_count(), 0);
+
+  column_wrapper<T> expected{{20, 30, 10, 50, 60, 40}};
+  auto result = cudf::segmented_sort_by_key(
+    values_view, keys_view, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  EXPECT_FALSE(result->get_column(0).nullable());
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+
+  result = cudf::stable_segmented_sort_by_key(
+    values_view, keys_view, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  EXPECT_FALSE(result->get_column(0).nullable());
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
 TEST_F(SegmentedSortInt, NonZeroSegmentsStart)
 {
   using T = int;
@@ -352,4 +377,18 @@ TEST_F(SegmentedSortInt, UnbalancedOffsets)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result->view().column(0), expected->view().column(0));
   result = cudf::stable_segmented_sort_by_key(input_view, input_view, segments);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result->view().column(0), expected->view().column(0));
+}
+
+// Without the guard these offsets would take the strings fast path; guarded, only [3, 7) sorts.
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsStrings)
+{
+  cudf::test::strings_column_wrapper col{
+    "a0", "a1", "a2", "banana", "apple", "cherry", "date", "z7", "z8", "z9"};
+  cudf::test::strings_column_wrapper expected{
+    "a0", "a1", "a2", "apple", "banana", "cherry", "date", "z7", "z8", "z9"};
+  column_wrapper<int> segments{{3, 7}};
+  auto const input = cudf::table_view{{col}};
+  auto result      = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
 }

--- a/cpp/tests/sort/segmented_sort_tests.cpp
+++ b/cpp/tests/sort/segmented_sort_tests.cpp
@@ -379,12 +379,12 @@ TEST_F(SegmentedSortInt, UnbalancedOffsets)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result->view().column(0), expected->view().column(0));
 }
 
-// The unstable single-column fast paths (packed-radix, strings) require segment offsets spanning
-// every row `[0, num_rows]`, while the public contract also allows partial and single-index
-// offsets. These tests pin the offsets-coverage guard that routes such inputs to the comparison
-// path, for each fast-path family.
+// The unstable single-column fast paths (tiered, packed-radix, strings) require segment offsets
+// spanning every row `[0, num_rows]`, while the public contract also allows partial and
+// single-index offsets. These tests pin the offsets-coverage guard that routes such inputs to the
+// comparison path, for each fast-path family.
 
-// Short lists route to the comparison/CUB path before the guard is consulted; only [3, 7) sorts.
+// Without the guard these offsets would take the tiered fast path; guarded, only [3, 7) sorts.
 TEST_F(SegmentedSortInt, FastPathPartialOffsetsNumeric)
 {
   using T = int;

--- a/cpp/tests/sort/segmented_sort_tests.cpp
+++ b/cpp/tests/sort/segmented_sort_tests.cpp
@@ -379,6 +379,69 @@ TEST_F(SegmentedSortInt, UnbalancedOffsets)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result->view().column(0), expected->view().column(0));
 }
 
+// The unstable single-column fast paths (packed-radix, strings) require segment offsets spanning
+// every row `[0, num_rows]`, while the public contract also allows partial and single-index
+// offsets. These tests pin the offsets-coverage guard that routes such inputs to the comparison
+// path, for each fast-path family.
+
+// Short lists route to the comparison/CUB path before the guard is consulted; only [3, 7) sorts.
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsNumeric)
+{
+  using T = int;
+  column_wrapper<T> col{{50, 51, 52, 40, 10, 30, 20, 57, 58, 59}};
+  column_wrapper<int> segments{{3, 7}};
+  cudf::table_view input{{col}};
+  column_wrapper<T> expected{{50, 51, 52, 10, 20, 30, 40, 57, 58, 59}};
+  auto result = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
+// Each case satisfies exactly one half of the guard's `first == 0 and last == num_rows`
+// conjunction, pinning the two halves independently.
+TEST_F(SegmentedSortInt, FastPathOneSidedOffsets)
+{
+  using T = int;
+  column_wrapper<T> col{{50, 51, 52, 40, 10, 30, 20, 57, 58, 59}};
+  cudf::table_view input{{col}};
+  {  // first == 0 only
+    column_wrapper<int> segments{{0, 7}};
+    column_wrapper<T> expected{{10, 20, 30, 40, 50, 51, 52, 57, 58, 59}};
+    auto result = cudf::segmented_sort_by_key(
+      input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+    CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+  }
+  {  // last == num_rows only
+    column_wrapper<int> segments{{3, 10}};
+    column_wrapper<T> expected{{50, 51, 52, 10, 20, 30, 40, 57, 58, 59}};
+    auto result = cudf::segmented_sort_by_key(
+      input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+    CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+  }
+}
+
+// {100, 300} over 400 rows (average list size 200) reaches the packed-radix band, which would
+// globally relabel all rows without the guard.
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsPackedRadix)
+{
+  using T                 = int;
+  cudf::size_type const n = 400;
+  std::vector<T> vals(n);
+  std::vector<T> ex(n);
+  for (cudf::size_type i = 0; i < n; ++i) {
+    vals[i] = 1'000 - i;  // strictly descending, distinct
+    // [100, 300) sorted ascending is 701..900.
+    ex[i] = (i < 100 or i >= 300) ? vals[i] : (701 + (i - 100));
+  }
+  column_wrapper<T> col(vals.begin(), vals.end());
+  column_wrapper<T> expected(ex.begin(), ex.end());
+  column_wrapper<int> segments{{100, 300}};
+  cudf::table_view input{{col}};
+  auto result = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
 // Without the guard these offsets would take the strings fast path; guarded, only [3, 7) sorts.
 TEST_F(SegmentedSortInt, FastPathPartialOffsetsStrings)
 {
@@ -391,4 +454,26 @@ TEST_F(SegmentedSortInt, FastPathPartialOffsetsStrings)
   auto result      = cudf::segmented_sort_by_key(
     input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
   CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
+// A single offset (num_segments == 0) sorts nothing per the contract; the guard's two-offset
+// minimum avoids the fast paths' zero-width segment field shifting a 64-bit key by 64 (UB).
+TEST_F(SegmentedSortInt, FastPathSingleIndexOffsets)
+{
+  column_wrapper<int> segments{{5}};
+  {
+    using T = int;
+    column_wrapper<T> col{{50, 40, 30, 20, 10, 90, 80, 70, 60, 55}};
+    cudf::table_view input{{col}};
+    auto result = cudf::segmented_sort_by_key(
+      input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+    CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), input);
+  }
+  {
+    cudf::test::strings_column_wrapper col{"e", "d", "c", "b", "a", "j", "i", "h", "g", "f"};
+    auto const input = cudf::table_view{{col}};
+    auto result      = cudf::segmented_sort_by_key(
+      input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+    CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), input);
+  }
 }

--- a/cpp/tests/sort/top_k_tests.cpp
+++ b/cpp/tests/sort/top_k_tests.cpp
@@ -11,6 +11,7 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
@@ -18,11 +19,14 @@
 
 #include <cuda/iterator>
 
+#include <limits>
 #include <type_traits>
 #include <vector>
 
-using TestTypes = cudf::test::
-  Concat<cudf::test::IntegralTypesNotBool, cudf::test::FloatingPointTypes, cudf::test::ChronoTypes>;
+using TestTypes = cudf::test::Concat<cudf::test::IntegralTypesNotBool,
+                                     cudf::test::FloatingPointTypes,
+                                     cudf::test::ChronoTypes,
+                                     cudf::test::FixedPointTypes>;
 
 template <typename T>
 struct TopKTypes : public cudf::test::BaseFixture {};
@@ -122,6 +126,44 @@ TYPED_TEST(TopKTypes, TopKSegmented)
     result = cudf::segmented_top_k_order(input, offsets, 3, cudf::order::ASCENDING);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_order, result->view());
   }
+}
+
+// A no-null input whose average segment length (~128) exceeds the fast-sort cutoff at a row count
+// past the CUB small-total pocket routes the default DESCENDING k-selection through the
+// packed-radix segmented-sort fast path, which the null-carrying tests above never reach.
+TYPED_TEST(TopKTypes, TopKSegmentedLongSegmentsNoNulls)
+{
+  using T = TypeParam;
+
+  constexpr cudf::size_type num_segments = 2'048;
+  constexpr cudf::size_type seg_size     = 128;
+  std::vector<int32_t> values(static_cast<std::size_t>(num_segments) * seg_size);
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int32_t>(i % seg_size);
+  }
+  auto input = cudf::test::fixed_width_column_wrapper<T, int32_t>(values.begin(), values.end());
+  std::vector<int32_t> offset_vals(num_segments + 1);
+  for (cudf::size_type i = 0; i <= num_segments; ++i) {
+    offset_vals[i] = i * seg_size;
+  }
+  auto offsets =
+    cudf::test::fixed_width_column_wrapper<int32_t>(offset_vals.begin(), offset_vals.end());
+
+  std::vector<int32_t> expected_vals;
+  std::vector<cudf::size_type> expected_offsets{0};
+  for (cudf::size_type s = 0; s < num_segments; ++s) {
+    expected_vals.insert(expected_vals.end(), {127, 126, 125});
+    expected_offsets.push_back(static_cast<cudf::size_type>(expected_vals.size()));
+  }
+  auto expected_leaf =
+    cudf::test::fixed_width_column_wrapper<T, int32_t>(expected_vals.begin(), expected_vals.end());
+  auto expected_off = cudf::test::fixed_width_column_wrapper<cudf::size_type>(
+    expected_offsets.begin(), expected_offsets.end());
+  auto expected =
+    cudf::make_lists_column(num_segments, expected_off.release(), expected_leaf.release(), 0, {});
+
+  auto result = cudf::segmented_top_k(input, offsets, 3);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected->view(), result->view());
 }
 
 // Empty segments (leading, trailing, interior, or consecutive) must produce empty result lists.
@@ -470,4 +512,84 @@ TEST_F(TopK, TopKSegmentedEmptyMultiBlock)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   result = cudf::segmented_top_k_order(input, offsets, 2);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+}
+
+// BOOL8 is packed-radix-supported but not tiered-supported, so a null-bearing bool column takes
+// the packed radix at any list size -- a (type x null) cell outside the typed suite, which
+// excludes bool. One valid true and one valid false per segment keep the unstable top-k
+// deterministic.
+TEST_F(TopK, SegmentedTopKBoolWithNulls)
+{
+  using LCWB = cudf::test::lists_column_wrapper<bool>;
+  using LCWO = cudf::test::lists_column_wrapper<cudf::size_type>;
+  auto input = cudf::test::fixed_width_column_wrapper<bool>({true, false, true, false, true, true},
+                                                            {true, true, false, true, false, true});
+  auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, 3, 6});
+  // seg0 valid: true@0, false@1 ; seg1 valid: false@3, true@5. Descending top-2 per segment.
+  LCWB expected({LCWB{true, false}, LCWB{true, false}});
+  LCWO expected_order({LCWO{0, 1}, LCWO{5, 3}});
+  auto result = cudf::segmented_top_k(input, offsets, 2);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+  result = cudf::segmented_top_k_order(input, offsets, 2);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+}
+
+// One 200-element segment averages 100, routing the no-null DECIMAL128 column to the packed
+// radix, whose range gate picks the key width; the three steps force each width in turn.
+TEST_F(TopK, SegmentedTopKDecimal128KeyWidths)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  auto const check     = [&](__int128_t base, __int128_t step) {
+    cudf::size_type const n = 200;
+    std::vector<__int128_t> vals(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      vals[i] = base + step * (n - 1 - i);
+    }
+    auto input =
+      cudf::test::fixed_point_column_wrapper<__int128_t>(vals.begin(), vals.end(), scale);
+    auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, n});
+    std::vector<__int128_t> top{base + step * 199, base + step * 198, base + step * 197};
+    auto expected_leaf =
+      cudf::test::fixed_point_column_wrapper<__int128_t>(top.begin(), top.end(), scale);
+    auto expected_off = cudf::test::fixed_width_column_wrapper<cudf::size_type>({0, 3});
+    auto expected =
+      cudf::make_lists_column(1, expected_off.release(), expected_leaf.release(), 0, {});
+    auto result = cudf::segmented_top_k(input, offsets, 3);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected->view(), result->view());
+  };
+  check(0, 1);                                 // span < 2^32 -> min-biased uint64 key
+  check(0, static_cast<__int128_t>(1) << 32);  // span >= 2^32, fits int64 -> prefix_key96
+  check(-(static_cast<__int128_t>(1) << 100),  // beyond int64 -> two-phase hi64/lo64
+        static_cast<__int128_t>(1) << 64);
+}
+
+// cudf orders -Inf < finite < +Inf < NaN, so descending top-k leads with NaN then +Inf. Five
+// elements per segment keep the no-null double column on the tiered fast path's network tier,
+// driving `radix_encode_u64`'s NaN canonicalization through the top_k entry point; one NaN and
+// one Inf per segment keep the unstable selection deterministic.
+TEST_F(TopK, SegmentedTopKFloatNaNInfinity)
+{
+  auto constexpr NaN = std::numeric_limits<double>::quiet_NaN();
+  auto constexpr Inf = std::numeric_limits<double>::infinity();
+  using LCWD         = cudf::test::lists_column_wrapper<double>;
+  using LCWO         = cudf::test::lists_column_wrapper<cudf::size_type>;
+  auto input         = cudf::test::fixed_width_column_wrapper<double>(
+    {NaN, -Inf, 3.5, Inf, -2.0, 0.0, 1.0, -Inf, Inf, NaN});
+  auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, 5, 10});
+  {
+    LCWD expected({LCWD{NaN, Inf}, LCWD{NaN, Inf}});
+    LCWO expected_order({LCWO{0, 3}, LCWO{9, 8}});
+    auto result = cudf::segmented_top_k(input, offsets, 2);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+    result = cudf::segmented_top_k_order(input, offsets, 2);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+  }
+  {
+    LCWD expected({LCWD{-Inf, -2.0}, LCWD{-Inf, 0.0}});
+    LCWO expected_order({LCWO{1, 4}, LCWO{7, 5}});
+    auto result = cudf::segmented_top_k(input, offsets, 2, cudf::order::ASCENDING);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+    result = cudf::segmented_top_k_order(input, offsets, 2, cudf::order::ASCENDING);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_order, result->view());
+  }
 }


### PR DESCRIPTION
## Note

### This is aggregation of the entire work — for reference only, not to be merged. It will be broken down to smaller PRs for review.

## Description

This work is to speed up segmented sort and `cudf::lists::sort_lists` for a single fixed-width or `STRING` key column with GPU fast paths: radix sorts on packed keys, and warp/block merge sorts for short lists.

Benchmarks that every one of the 2'040 measured benchmarked cells beats `main` — worst cell 1.38x, best 31.06x; per-type geomeans range from 4.32x (`STRING`) to 10.75x (`FLOAT32`).

The series also fixes output nullability in the touched paths: a sort whose gather produced a spurious all-valid null mask (zero nulls) now drops that mask instead of returning a needlessly nullable column — in the by-key values gather (`segmented_sort_impl.cuh`) and in `sort_lists`/`stable_sort_lists` (`lists/segmented_sort.cu`), each with a contract test; three existing test files drop their workarounds for it.

### The seven-PR series

This mega-PR is split to the followiong series:

1. **Benchmarks** — adds the `sort_list_of_{numbers,decimal128,strings}` nvbench suites that every later PR measures against.
2. **Strings prefix-radix engine** — sorts **`STRING`** by their leading bytes with a radix sort, reading more bytes only where strings still tie (strings previously always took the comparison sort); adds the shared scaffolding the later PRs plug into.
3. **Strings graduated-warp fold** — speeds **`STRING`** segmented sort further on short segments (<= 64 elements).
4. **Packed-radix foundation** — improve segmented sort for **`INT32`/`INT64`/`FLOAT32`/`FLOAT64`** on long segments (average length >= 100).
5. **Tiered small-segment engine** — extends the same four types to short segments, the dominant real-world shape.
6. **`DECIMAL128` support** — improvement for **`DECIMAL128`** on the fixed-width engines.
7. **All-polarity** — extends every fast path (all six types above) to all four `(order, null_order)` combinations.

### Code statistics

Code changes rounded to the nearest ten:

| Category | Code changes | % of churn | Comment density (added) |
|---|---:|---:|---:|
| Library (`cpp/src/**`, `cpp/include/**`, `cpp/CMakeLists.txt`) | +4000 -40 | 52.6% | 27.0% (~1010/~3750) |
| Unit tests (`cpp/tests/**`) | +3140 -40 | 41.4% | 9.6% (~280/~2940) |
| Benchmarks (`cpp/benchmarks/**`) | +460 -0 | 6.0% | 18.7% (~80/~410) |
| **Total** | **+7600 -80** | **100%** | **19.3% (~1370/~7090)** |

## Benchmark results

Mean times measured on a Quadro RTX 6000, baseline = `main`; per-cell speedup = `main` time / this-PR time:

| Benchmark | Key type | Cells | Geomean | Min | Max |
|---|---|---|---|---|---|
| `sort_list_of_numbers` | INT32 | 176 | 7.88x | 2.23x | 22.54x |
| `sort_list_of_numbers` | INT64 | 172 | 5.97x | 1.38x | 17.26x |
| `sort_list_of_numbers` | FLOAT32 | 176 | 10.75x | 4.64x | 31.06x |
| `sort_list_of_numbers` | FLOAT64 | 176 | 7.83x | 2.72x | 22.52x |
| `sort_list_of_decimal128` | DECIMAL128 | 500 | 6.64x | 1.50x | 19.82x |
| `sort_list_of_strings` | STRING | 840 | 4.32x | 2.30x | 8.97x |

Whole-benchmark geomeans: `sort_list_of_numbers` 7.944x; `sort_list_of_decimal128` 6.637x; `sort_list_of_strings` 4.316x.

<details><summary>Per-grid detail tables (2'040 cells)</summary>

#### `sort_list_of_numbers` — 700 cells, all four (order, null_order) combos (speedup = main/PR, >1 = PR faster)

Whole numbers grid: geomean **7.944x**, min 1.380x, max 31.060x, N=700; 700 of 700 cells are >= 1.0x.

**Top 10 cells by speedup**

| T | num_rows | max_list_size | null_frequency | order | null_order | main GPU | PR GPU | speedup |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| F32 | 16'777'216 | 4 | 0 | ASC | AFTER | 67.580 ms | 2.176 ms | 31.06× |
| F32 | 16'777'216 | 4 | 0 | DESC | AFTER | 67.535 ms | 2.180 ms | 30.98× |
| F32 | 16'777'216 | 4 | 0 | DESC | BEFORE | 67.025 ms | 2.177 ms | 30.78× |
| F32 | 16'777'216 | 4 | 0 | ASC | BEFORE | 67.359 ms | 2.205 ms | 30.54× |
| F32 | 2'097'152 | 4 | 0 | DESC | AFTER | 8.073 ms | 311.5 us | 25.92× |
| F32 | 2'097'152 | 4 | 0 | DESC | BEFORE | 8.013 ms | 312.9 us | 25.61× |
| F32 | 2'097'152 | 4 | 0 | ASC | AFTER | 8.040 ms | 315.4 us | 25.49× |
| F32 | 2'097'152 | 4 | 0 | ASC | BEFORE | 7.997 ms | 314.0 us | 25.47× |
| I32 | 16'777'216 | 4 | 0.1 | ASC | BEFORE | 57.295 ms | 2.542 ms | 22.54× |
| F64 | 16'777'216 | 4 | 0 | DESC | BEFORE | 75.192 ms | 3.339 ms | 22.52× |

**Bottom 10 cells by speedup**

| T | num_rows | max_list_size | null_frequency | order | null_order | main GPU | PR GPU | speedup |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| I64 | 2'097'152 | 64 | 0 | DESC | AFTER | 23.487 ms | 10.829 ms | 2.17× |
| I64 | 2'097'152 | 64 | 0 | ASC | BEFORE | 23.454 ms | 10.817 ms | 2.17× |
| I64 | 32'768 | 4 | 0 | DESC | AFTER | 111.2 us | 70.1 us | 1.59× |
| I64 | 32'768 | 4 | 0 | ASC | AFTER | 114.7 us | 72.4 us | 1.58× |
| I64 | 32'768 | 4 | 0 | DESC | BEFORE | 110.5 us | 70.3 us | 1.57× |
| I64 | 32'768 | 4 | 0 | ASC | BEFORE | 111.3 us | 73.3 us | 1.52× |
| I64 | 32'768 | 16 | 0 | ASC | BEFORE | 159.9 us | 114.4 us | 1.40× |
| I64 | 32'768 | 16 | 0 | DESC | BEFORE | 159.8 us | 114.4 us | 1.40× |
| I64 | 32'768 | 16 | 0 | ASC | AFTER | 159.0 us | 114.6 us | 1.39× |
| I64 | 32'768 | 16 | 0 | DESC | AFTER | 157.6 us | 114.2 us | 1.38× |

#### `sort_list_of_decimal128` — 500 cells (speedup = main/PR, >1 = PR faster)

Axes — `dec_regime` {`u64`, `key96`, `twophase`}, `num_rows` {32'768, 262'144, 2'097'152, 16'777'216}, `max_list_size` {4, 16, 32, 64, 128, 256}, `null_frequency` {0, 0.1}, `order` {`ASC`, `DESC`}, `null_order` {`AFTER`, `BEFORE`}.

**Top 10 inputs by speedup**

| `num_rows` | `max_list_size` | `dec_regime` | `null_frequency` | `order` | `null_order` | `main` (ms) | this PR (ms) | Speedup |
|---|---|---|---|---|---|---|---|---|
| 16'777'216 | 4 | `key96` | 0 | `ASC` | `BEFORE` | 86.951 | 4.387 | 19.818x |
| 16'777'216 | 4 | `key96` | 0 | `DESC` | `BEFORE` | 86.687 | 4.401 | 19.699x |
| 16'777'216 | 4 | `u64` | 0 | `ASC` | `BEFORE` | 87.182 | 4.434 | 19.662x |
| 16'777'216 | 4 | `key96` | 0 | `ASC` | `AFTER` | 87.059 | 4.433 | 19.639x |
| 16'777'216 | 4 | `twophase` | 0 | `DESC` | `AFTER` | 86.885 | 4.435 | 19.593x |
| 16'777'216 | 4 | `twophase` | 0 | `ASC` | `BEFORE` | 86.642 | 4.424 | 19.583x |
| 16'777'216 | 4 | `twophase` | 0 | `DESC` | `BEFORE` | 86.240 | 4.406 | 19.572x |
| 16'777'216 | 4 | `twophase` | 0 | `ASC` | `AFTER` | 86.816 | 4.448 | 19.516x |
| 16'777'216 | 4 | `u64` | 0 | `DESC` | `BEFORE` | 86.464 | 4.432 | 19.508x |
| 16'777'216 | 4 | `u64` | 0 | `ASC` | `AFTER` | 87.124 | 4.471 | 19.484x |

**Bottom 10 inputs by speedup**

| `num_rows` | `max_list_size` | `dec_regime` | `null_frequency` | `order` | `null_order` | `main` (ms) | this PR (ms) | Speedup |
|---|---|---|---|---|---|---|---|---|
| 2'097'152 | 256 | `twophase` | 0 | `DESC` | `BEFORE` | 984.778 | 608.829 | 1.617x |
| 2'097'152 | 256 | `twophase` | 0 | `DESC` | `AFTER` | 983.354 | 609.111 | 1.614x |
| 262'144 | 256 | `twophase` | 0 | `DESC` | `AFTER` | 116.145 | 75.427 | 1.540x |
| 32'768 | 256 | `twophase` | 0 | `ASC` | `AFTER` | 14.404 | 9.371 | 1.537x |
| 32'768 | 256 | `twophase` | 0 | `DESC` | `AFTER` | 14.378 | 9.353 | 1.537x |
| 262'144 | 256 | `twophase` | 0 | `ASC` | `BEFORE` | 116.050 | 75.565 | 1.536x |
| 262'144 | 256 | `twophase` | 0 | `ASC` | `AFTER` | 115.835 | 75.416 | 1.536x |
| 32'768 | 256 | `twophase` | 0 | `ASC` | `BEFORE` | 14.402 | 9.375 | 1.536x |
| 32'768 | 256 | `twophase` | 0 | `DESC` | `BEFORE` | 14.355 | 9.404 | 1.526x |
| 262'144 | 256 | `twophase` | 0 | `DESC` | `BEFORE` | 116.356 | 77.432 | 1.503x |

Whole grid: geomean **6.637x**, min 1.503x, max 19.818x, N=500 — every paired input is a win; the 375 inputs on the newly opened orders (`order=DESC` or `null_order=BEFORE`) alone: geomean 6.641x.

Per-`dec_regime` geomeans:

| `dec_regime` | Cells | Geomean | Min | Max |
|---|---|---|---|---|
| `u64` | 168 | 6.884x | 2.638x | 19.662x |
| `key96` | 164 | 6.738x | 2.643x | 19.818x |
| `twophase` | 168 | 6.304x | 1.503x | 19.593x |
| **all** | **500** | **6.637x** | **1.503x** | **19.818x** |

#### `sort_list_of_strings` — 840 cells, all four (order, null_order) combos (speedup = main/PR, >1 = PR faster)

**Per-axis geomean highlights** (combined regimes)

| axis | value | n | geomean speedup |
|---|---|---|---|
| `num_rows` | 32'768 | 288 | 4.356x |
| `num_rows` | 262'144 | 288 | 4.265x |
| `num_rows` | 2'097'152 | 192 | 4.443x |
| `num_rows` | 16'777'216 | 72 | 4.041x |
| `max_list_size` | 4 | 192 | 3.804x |
| `max_list_size` | 16 | 168 | 4.958x |
| `max_list_size` | 32 | 144 | 5.415x |
| `max_list_size` | 64 | 120 | 5.774x |
| `max_list_size` | 128 | 120 | 3.059x |
| `max_list_size` | 256 | 96 | 3.319x |
| `row_width` | 16 | 456 | 4.265x |
| `row_width` | 64 | 384 | 4.379x |
| `shared_prefix_len` | 0 | 280 | 4.442x |
| `shared_prefix_len` | 8 | 280 | 4.251x |
| `shared_prefix_len` | 32 | 280 | 4.259x |
| `null_frequency` | 0 | 420 | 4.505x |
| `null_frequency` | 0.1 | 420 | 4.135x |
| `order` | ASC | 420 | 4.349x |
| `order` | DESC | 420 | 4.284x |
| `null_order` | AFTER | 420 | 4.314x |
| `null_order` | BEFORE | 420 | 4.319x |

**Top 10 cells by speedup**

| `num_rows` | `max_list_size` | `row_width` | `shared_prefix_len` | `null_frequency` | `order` | `null_order` | `main` (ms) | this PR (ms) | speedup |
|---|---|---|---|---|---|---|---|---|---|
| 32'768 | 4 | 64 | 32 | 0 | ASC | BEFORE | 1.870 | 0.209 | 8.969x |
| 32'768 | 4 | 64 | 32 | 0 | ASC | AFTER | 1.953 | 0.224 | 8.702x |
| 32'768 | 4 | 64 | 32 | 0 | DESC | AFTER | 1.623 | 0.213 | 7.639x |
| 32'768 | 4 | 64 | 32 | 0 | DESC | BEFORE | 1.552 | 0.205 | 7.552x |
| 32'768 | 64 | 64 | 8 | 0 | ASC | AFTER | 10.414 | 1.471 | 7.082x |
| 32'768 | 64 | 64 | 8 | 0 | DESC | BEFORE | 10.155 | 1.437 | 7.069x |
| 32'768 | 64 | 64 | 8 | 0 | ASC | BEFORE | 10.398 | 1.477 | 7.039x |
| 32'768 | 64 | 64 | 8 | 0 | DESC | AFTER | 10.153 | 1.487 | 6.827x |
| 32'768 | 4 | 16 | 32 | 0 | DESC | BEFORE | 1.032 | 0.153 | 6.724x |
| 32'768 | 4 | 16 | 32 | 0 | DESC | AFTER | 1.029 | 0.154 | 6.663x |

**Bottom 10 cells by speedup**

| `num_rows` | `max_list_size` | `row_width` | `shared_prefix_len` | `null_frequency` | `order` | `null_order` | `main` (ms) | this PR (ms) | speedup |
|---|---|---|---|---|---|---|---|---|---|
| 262'144 | 128 | 16 | 8 | 0 | ASC | BEFORE | 84.877 | 34.532 | 2.458x |
| 262'144 | 128 | 16 | 8 | 0 | DESC | AFTER | 84.838 | 34.560 | 2.455x |
| 32'768 | 128 | 16 | 32 | 0 | DESC | BEFORE | 12.055 | 4.930 | 2.445x |
| 32'768 | 128 | 16 | 8 | 0 | DESC | AFTER | 11.262 | 4.723 | 2.385x |
| 32'768 | 128 | 16 | 8 | 0 | ASC | AFTER | 11.306 | 4.750 | 2.380x |
| 32'768 | 128 | 16 | 8 | 0.1 | ASC | AFTER | 9.497 | 3.997 | 2.376x |
| 32'768 | 128 | 16 | 32 | 0 | ASC | AFTER | 11.704 | 4.935 | 2.372x |
| 32'768 | 128 | 16 | 32 | 0 | ASC | BEFORE | 11.738 | 4.951 | 2.371x |
| 32'768 | 128 | 16 | 8 | 0 | DESC | BEFORE | 11.299 | 4.767 | 2.370x |
| 32'768 | 128 | 16 | 8 | 0 | ASC | BEFORE | 11.289 | 4.910 | 2.299x |


</details>

### Compile time

Cold per-TU compile times (`ccache` off, `time ninja <object>`); baseline = the same TUs built on `main`:

| TU | `main` | this PR |
|---|---|---|
| `cpp/src/sort/segmented_sort_fixed_width.cu` | — (new in this PR) | 33.7 s |
| `cpp/src/sort/segmented_sort_strings.cu` | — (new in this PR) | 17.8 s |
| `cpp/src/sort/segmented_sort.cu` | 54.8 s | 55.6 s |
| `cpp/src/sort/stable_segmented_sort.cu` | 53.7 s | 52.0 s |

## Follow up

The techniques in this work can be adopted elsewhere to achieve higher performance such as widen the packed-key engines to `stable_sort_lists` and improve performance of `cudf::sort`/`cudf::sorted_order`:
- Use strings prefix-radix engine to accelerate string sorting.
- Sort nullable fixed-width columns in a single radix pass (instead of using merge sort today).
- Widen `cudf::top_k` float and with-nulls cases from a full-sort fallback to linear `cub::DeviceTopK` selection over order-mapped keys.
- Range-gate `DECIMAL128` radix sort to the narrowest lossless key (4-12 passes instead of a fixed 16).

Not just sorting, the datastructure here can be used in hashing-based operations too. For instance:
- Use 8-byte word for string equality compasion on the hash probe paths of hash groupby, join, and distinct.
- Implement in groupby/distinct/contains hash-set slots with a 32-bit hash — as hash join already does — to reject probe candidates without full comparisons.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.




















