### PR TITLE
Fix rtcx embed target-level dependencies under the Makefiles generator

### DIFF
--- a/cpp/librtcx/embed.cmake
+++ b/cpp/librtcx/embed.cmake
@@ -171,6 +171,14 @@ function(rtcx_embed_blob TARGET)
       APPEND
       PROPERTY EMBED_TARGET_DEPS $<TARGET_OBJECTS:${CMAKE_MATCH_1}>
     )
+    # Also record the target name itself. Depending only on $<TARGET_OBJECTS:...> creates file-level
+    # dependencies without a target-level ordering, which breaks the Makefiles generator (Ninja
+    # resolves it via its global build graph).
+    set_property(
+      TARGET ${TARGET}__embed_props
+      APPEND
+      PROPERTY EMBED_TARGET_DEP_NAMES ${CMAKE_MATCH_1}
+    )
   else()
     if(NOT EXISTS "${ARG_FILE}")
       message(FATAL_ERROR "Source file '${ARG_FILE}' does not exist")
@@ -256,6 +264,11 @@ function(rtcx_embed TARGET)
     PROPERTY EMBED_TARGET_DEPS
   )
   get_property(
+    EMBED_TARGET_DEP_NAMES
+    TARGET ${TARGET}__embed_props
+    PROPERTY EMBED_TARGET_DEP_NAMES
+  )
+  get_property(
     EMBED_ARRAY_IDS
     TARGET ${TARGET}__embed_props
     PROPERTY EMBED_ARRAY_IDS
@@ -306,7 +319,7 @@ function(rtcx_embed TARGET)
   add_custom_command(
     OUTPUT ${OUTPUT_DIR}/${TARGET}.hpp ${OUTPUT_DIR}/${TARGET}.s ${OUTPUT_DIR}/${TARGET}.bin
     COMMAND "${CMAKE_COMMAND}" -E env $<TARGET_FILE:${RUNNER}>
-    DEPENDS "${EMBED_SCRIPT}" ${EMBED_SOURCE_FILES} ${EMBED_TARGET_DEPS}
+    DEPENDS "${EMBED_SCRIPT}" ${EMBED_SOURCE_FILES} ${EMBED_TARGET_DEPS} ${EMBED_TARGET_DEP_NAMES}
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     COMMENT "Generating JIT embed for ${TARGET} into ${OUTPUT_DIR}"
     VERBATIM


### PR DESCRIPTION
## Description

Since #22680, a from-scratch `./build.sh` with the **Unix Makefiles** generator fails with:

```
gmake[2]: *** No rule to make target 'CMakeFiles/cudf_fragments_transform_kernel_20.dir/src/transform/jit/kernel.fatbin', needed by 'rtcx_embed/cudf_fragments.hpp'.  Stop.
```

The `rtcx_embed()` custom command depends on the fragment object libraries only via `$<TARGET_OBJECTS:...>` generator expressions. With the Makefiles generator this produces file-level prerequisites with no build rule and no target-level ordering — `cudf_fragments.dir/all` only depended on `cudf_fragments__jit_embed_run`, not on the 21 `cudf_fragments_transform_kernel_N` object libraries — so a parallel make races ahead of the fatbin compilations and dies. Ninja resolves the same dependency through its global build graph, which is why CI never hit this.

The fix records the object-library target names in a new `EMBED_TARGET_DEP_NAMES` property alongside the existing `$<TARGET_OBJECTS:...>` genexes, and passes those names to the custom command `DEPENDS`. Naming a real target there makes CMake emit a proper target-level dependency, so the Makefiles generator builds all fragment fatbins before running the embed step.

Verified locally with CMake 4.3.4 + Unix Makefiles: after this change `Makefile2` contains target-level deps from `cudf_fragments.dir/all` on every `cudf_fragments_transform_kernel_N.dir/all`, and a clean-state `-j32` build of `cudf_fragments` (and a full `./build.sh`) succeeds where it previously failed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.