### PR TITLE
[BUG] Fix ORC chunked writer root row statistics

### DIFF
--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -388,7 +388,7 @@ intermediate_statistics::intermediate_statistics(orc_table_view const& table,
     });
 }
 
-void persisted_statistics::persist(int num_table_rows,
+void persisted_statistics::persist(uint64_t num_table_rows,
                                    single_write_mode write_mode,
                                    intermediate_statistics&& intermediate_stats,
                                    rmm::cuda_stream_view stream)

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -395,8 +395,8 @@ void persisted_statistics::persist(int num_table_rows,
 {
   stats_dtypes = std::move(intermediate_stats.stats_dtypes);
   col_types    = std::move(intermediate_stats.col_types);
-  num_rows     = num_table_rows;
-  if (num_rows == 0) { return; }
+  num_rows += num_table_rows;
+  if (num_table_rows == 0) { return; }
 
   if (write_mode == single_write_mode::NO) {
     // persist the strings in the chunks into a string pool and update pointers

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -393,10 +393,10 @@ void persisted_statistics::persist(uint64_t num_table_rows,
                                    intermediate_statistics&& intermediate_stats,
                                    rmm::cuda_stream_view stream)
 {
-  stats_dtypes = std::move(intermediate_stats.stats_dtypes);
-  col_types    = std::move(intermediate_stats.col_types);
+  col_types = std::move(intermediate_stats.col_types);
   num_rows += num_table_rows;
   if (num_table_rows == 0) { return; }
+  stats_dtypes = std::move(intermediate_stats.stats_dtypes);
 
   if (write_mode == single_write_mode::NO) {
     // persist the strings in the chunks into a string pool and update pointers

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -23,6 +23,7 @@
 #include <cuda/iterator>
 #include <thrust/host_vector.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -169,7 +169,7 @@ struct persisted_statistics {
     num_rows = 0;
   }
 
-  void persist(int num_table_rows,
+  void persist(uint64_t num_table_rows,
                single_write_mode write_mode,
                intermediate_statistics&& intermediate_stats,
                rmm::cuda_stream_view stream);
@@ -179,7 +179,7 @@ struct persisted_statistics {
   std::vector<rmm::device_uvector<char>> string_pools;
   std::vector<statistics_dtype> stats_dtypes;
   std::vector<data_type> col_types;
-  int num_rows = 0;
+  uint64_t num_rows = 0;
 };
 
 /**

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -707,6 +707,22 @@ TEST_F(OrcChunkedWriterTest, SimpleTable)
   CUDF_TEST_EXPECT_TABLES_EQUAL(*result.tbl, *full_table);
 }
 
+TEST_F(OrcChunkedWriterTest, RootStatisticsAccumulateRows)
+{
+  auto table1 = create_random_fixed_table<int>(1, 5, false);
+  auto table2 = create_random_fixed_table<int>(1, 1, false);
+
+  auto filepath = temp_env->get_temp_filepath("ChunkedRootStatistics.orc");
+  cudf::io::chunked_orc_writer_options opts =
+    cudf::io::chunked_orc_writer_options::builder(cudf::io::sink_info{filepath});
+  cudf::io::orc_chunked_writer(opts).write(*table1).write(*table2);
+
+  auto const stats = cudf::io::read_parsed_orc_statistics(cudf::io::source_info{filepath});
+  ASSERT_FALSE(stats.file_stats.empty());
+  ASSERT_TRUE(stats.file_stats.front().number_of_values.has_value());
+  EXPECT_EQ(*stats.file_stats.front().number_of_values, 6);
+}
+
 TEST_F(OrcChunkedWriterTest, LargeTables)
 {
   srand(31337);

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -711,11 +711,12 @@ TEST_F(OrcChunkedWriterTest, RootStatisticsAccumulateRows)
 {
   auto table1 = create_random_fixed_table<int>(1, 5, false);
   auto table2 = create_random_fixed_table<int>(1, 1, false);
+  auto table3 = create_random_fixed_table<int>(1, 0, false);
 
   auto filepath = temp_env->get_temp_filepath("ChunkedRootStatistics.orc");
   cudf::io::chunked_orc_writer_options opts =
     cudf::io::chunked_orc_writer_options::builder(cudf::io::sink_info{filepath});
-  cudf::io::orc_chunked_writer(opts).write(*table1).write(*table2);
+  cudf::io::orc_chunked_writer(opts).write(*table1).write(*table2).write(*table3);
 
   auto const stats = cudf::io::read_parsed_orc_statistics(cudf::io::source_info{filepath});
   ASSERT_FALSE(stats.file_stats.empty());
@@ -2191,6 +2192,13 @@ TEST_F(OrcReaderTest, SizeTypeRowsOverflow)
     reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}});
   EXPECT_EQ(metadata.num_rows(), total_rows);
   EXPECT_EQ(metadata.num_stripes(), total_rows / 1'000'000);
+
+  auto const stats =
+    cudf::io::read_parsed_orc_statistics(cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}});
+  ASSERT_FALSE(stats.file_stats.empty());
+  ASSERT_TRUE(stats.file_stats.front().number_of_values.has_value());
+  EXPECT_EQ(*stats.file_stats.front().number_of_values, static_cast<uint64_t>(total_rows));
 
   constexpr auto num_rows_to_read = 1'000'000;
   auto const num_rows_to_skip     = metadata.num_rows() - num_rows_to_read;


### PR DESCRIPTION
## Description

Fix ORC root column statistics when an `orc_chunked_writer` receives multiple non-empty tables.

`persisted_statistics::persist` replaced `num_rows` on every write, so the root `numberOfValues` stored in the footer reflected only the final table. Accumulate the row count across writes instead, while retaining the existing early return for an empty current table.

This caused Spark ORC aggregate pushdown to return the number of output files instead of the row count for `COUNT` on a top-level struct written by the RAPIDS Accelerator. Related issue: https://github.com/NVIDIA/cudf-spark/issues/15186.

Validation:

- Before the fix, `OrcChunkedWriterTest.RootStatisticsAccumulateRows` failed with root `number_of_values = 1`, expected `6`.
- After the fix, the targeted test passed.
- Full `ORC_TEST`: `197 tests from 36 test suites`, `197 passed`, `4 disabled`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
