### PR TITLE
Support fused arithmetic expressions in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -984,10 +984,8 @@ def _(
                     return expr.BinOp(dtype, sub, a, expr.BinOp(dtype, mul, b, c))
                 case "fms":
                     return expr.BinOp(dtype, sub, expr.BinOp(dtype, mul, a, b), c)
-                case _:
-                    raise NotImplementedError(
-                        f"Unsupported fused expression {flavor=}"
-                    )  # pragma: no cover
+                case _:  # pragma: no cover
+                    raise NotImplementedError(f"Unsupported fused expression {flavor=}")
         if name == "log" or (
             name == "l"
             and isinstance(options[0], str)

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -966,6 +966,28 @@ def _(
         )
     elif isinstance(name, str):
         children = (translator.translate_expr(n=n, schema=schema) for n in node.input)
+        if name == "fused":
+            # TODO: fuse into a single kernel via JIT transform, see
+            # https://github.com/rapidsai/cudf/issues/21456. We don't use
+            # libcudf AST here because it widens the dtype for integer types
+            # narrower than int32 (e.g. int8*int8 to int32), then fails
+            # with a type mismatch when doing the add/sub with the third operand.
+            (flavor,) = options
+            a, b, c = children
+            mul = plc.binaryop.BinaryOperator.MUL
+            add = plc.binaryop.BinaryOperator.ADD
+            sub = plc.binaryop.BinaryOperator.SUB
+            match flavor:
+                case "fma":
+                    return expr.BinOp(dtype, add, expr.BinOp(dtype, mul, a, b), c)
+                case "fsm":
+                    return expr.BinOp(dtype, sub, a, expr.BinOp(dtype, mul, b, c))
+                case "fms":
+                    return expr.BinOp(dtype, sub, expr.BinOp(dtype, mul, a, b), c)
+                case _:
+                    raise NotImplementedError(
+                        f"Unsupported fused expression {flavor=}"
+                    )  # pragma: no cover
         if name == "log" or (
             name == "l"
             and isinstance(options[0], str)

--- a/python/cudf_polars/tests/expressions/test_numeric_binops.py
+++ b/python/cudf_polars/tests/expressions/test_numeric_binops.py
@@ -10,8 +10,9 @@ import polars as pl
 
 from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
+    assert_ir_translation_raises,
 )
-from cudf_polars.utils.versions import POLARS_VERSION_LT_140
+from cudf_polars.utils.versions import POLARS_VERSION_LT_140, POLARS_VERSION_LT_142
 
 dtypes = [
     pl.Int8,
@@ -165,4 +166,7 @@ def test_fused_arithmetic(engine: pl.GPUEngine, expr: pl.Expr) -> None:
     # fms: fused multiply subtract
     df = pl.LazyFrame({"a": [1, 2, 3], "b": [10, 20, 30], "c": [5, 5, 5]})
     q = df.select(expr)
-    assert_gpu_result_equal(q, engine=engine)
+    if POLARS_VERSION_LT_142:
+        assert_ir_translation_raises(q, engine, NotImplementedError)
+    else:
+        assert_gpu_result_equal(q, engine=engine)

--- a/python/cudf_polars/tests/expressions/test_numeric_binops.py
+++ b/python/cudf_polars/tests/expressions/test_numeric_binops.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ import polars as pl
 
 from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
-    assert_ir_translation_raises,
 )
 from cudf_polars.utils.versions import POLARS_VERSION_LT_140
 
@@ -166,4 +165,4 @@ def test_fused_arithmetic(engine: pl.GPUEngine, expr: pl.Expr) -> None:
     # fms: fused multiply subtract
     df = pl.LazyFrame({"a": [1, 2, 3], "b": [10, 20, 30], "c": [5, 5, 5]})
     q = df.select(expr)
-    assert_ir_translation_raises(q, engine, NotImplementedError)
+    assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
For the CPU engine, these expressions are SIMD'ed. For the GPU engine, this translates best as doing the operation in a fused kernel. The best way to do that would be to use `cudf::transform` but I want to punt on that right now and think of a more general solution as a part of https://github.com/rapidsai/cudf/issues/21456. So for now, we'll just translate the fused expression back to binary operations.

Closes #22797
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
