### PR TITLE
Fix type annotation for CachedParquetInfo.size

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/utils/io.py
+++ b/python/cudf_polars/cudf_polars/dsl/utils/io.py
@@ -44,7 +44,7 @@ class CachedParquetInfo:
     """
 
     path: str
-    size: int
+    size: int | None
     file_metadata: plc.io.parquet_metadata.FileMetaData
 
 
@@ -70,7 +70,7 @@ def _prefetch_parquet_footers_for_paths(paths: list[str]) -> list[CachedParquetI
     """
     # TODO: https://github.com/rapidsai/cudf/issues/22734, use object metadata from polars
     # For now, we'll just use kvikio to explicitly get the size.
-    sizes = []
+    sizes: list[int | None] = []
 
     try:  # pragma: no cover; kvikio is optional
         import kvikio


### PR DESCRIPTION
## Description

This can be an `int | None`. Currently, we only pass it through to `plc.io.types.FilepathSource(info.path, info.size)`, which already accepts an `int | None`, so we were fine at runtime.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
