### PR TITLE
Add Quent trace export to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ compile_commands.json
 # pytest artifacts
 rmm_log.txt
 python/cudf/cudf_pandas_tests/data/rmm_log.txt
+
+# Quent traces
+logs/*.ndjson


### PR DESCRIPTION
## Description

https://github.com/rapidsai/cudf/pull/22337 updated the cudf-polars benchmark runner to output quent traces. This PR updates the repo's .gitignore to ignore those files.
