### PR TITLE
Support single-partition `pl.Expr.is_empty`

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/boolean.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/boolean.py
@@ -99,6 +99,7 @@ class BooleanFunction(Expr):
             BooleanFunction.Name.All,
             BooleanFunction.Name.Any,
             BooleanFunction.Name.IsDuplicated,
+            BooleanFunction.Name.IsEmpty,
             BooleanFunction.Name.IsFirstDistinct,
             BooleanFunction.Name.IsLastDistinct,
             BooleanFunction.Name.IsSorted,
@@ -107,7 +108,6 @@ class BooleanFunction(Expr):
         if self.name in {
             BooleanFunction.Name.HasNulls,
             BooleanFunction.Name.IsClose,
-            BooleanFunction.Name.IsEmpty,
         }:
             raise NotImplementedError(
                 f"Boolean function {self.name}"
@@ -192,6 +192,19 @@ class BooleanFunction(Expr):
         self, df: DataFrame, *, context: ExecutionContext = ExecutionContext.FRAME
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
+        if self.name is BooleanFunction.Name.IsEmpty:
+            (child,) = self.children
+            column = child.evaluate(df, context=context)
+            return Column(
+                plc.Column.from_scalar(
+                    plc.Scalar.from_py(
+                        column.size == 0, self.dtype.plc_type, stream=df.stream
+                    ),
+                    1,
+                    stream=df.stream,
+                ),
+                dtype=self.dtype,
+            )
         if self.name in (
             BooleanFunction.Name.IsFinite,
             BooleanFunction.Name.IsInfinite,

--- a/python/cudf_polars/tests/expressions/test_booleanfunction.py
+++ b/python/cudf_polars/tests/expressions/test_booleanfunction.py
@@ -12,7 +12,10 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
-from cudf_polars.utils.versions import POLARS_VERSION_LT_142
+from cudf_polars.utils.versions import (
+    POLARS_VERSION_LT_141,
+    POLARS_VERSION_LT_142,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -280,6 +283,17 @@ def test_boolean_is_close(engine: pl.GPUEngine):
     q = ldf.select(pl.col("a").is_close(1.4, abs_tol=0.1))
 
     assert_ir_translation_raises(q, engine, NotImplementedError)
+
+
+@pytest.mark.skipif(
+    POLARS_VERSION_LT_141,
+    reason="has_nulls/is_empty added to polars' BooleanFunction in 1.41",
+)
+@pytest.mark.parametrize("data", [[1, 2, 3], [None, None], []])
+def test_boolean_is_empty(engine: pl.GPUEngine, data):
+    ldf = pl.LazyFrame({"a": pl.Series(data, dtype=pl.Int64)})
+    q = ldf.select(pl.col("a").is_empty())
+    assert_gpu_result_equal(q, engine=engine)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
xref https://github.com/rapidsai/cudf/issues/23151

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
