### PR TITLE
[FEA] Support force_ascii flag in JSON writer

### DIFF
--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -329,6 +329,7 @@ def _plc_write_json(
     include_nulls: bool = True,
     lines: bool = False,
     rows_per_chunk: int = 1024 * 64,  # 64K rows
+    force_ascii: bool = True,
 ) -> None:
     with access_columns(*table._columns, mode="read", scope="internal"):
         try:
@@ -346,6 +347,7 @@ def _plc_write_json(
                 .include_nulls(include_nulls)
                 .lines(lines)
                 .compression(_to_plc_compression(compression))
+                .utf8_escaped(force_ascii)
                 .build()
             )
             if rows_per_chunk != np.iinfo(np.int32).max:

--- a/python/cudf/cudf/tests/input_output/test_json.py
+++ b/python/cudf/cudf/tests/input_output/test_json.py
@@ -190,6 +190,24 @@ def test_cudf_json_writer(pdf, lines):
     assert_eq(pdf_string, gdf_string)
 
 
+@pytest.mark.parametrize("force_ascii", [True, False])
+def test_cudf_json_writer_force_ascii(force_ascii):
+    pdf = pd.DataFrame({"a": [1, 2, 3], "b": ["4", "5", "\U0001f331"]})
+    gdf = cudf.DataFrame(pdf)
+
+    pdf_string = pdf.to_json(
+        orient="records", lines=True, force_ascii=force_ascii
+    )
+    gdf_string = gdf.to_json(
+        orient="records",
+        lines=True,
+        engine="cudf",
+        force_ascii=force_ascii,
+    )
+
+    assert_eq(pdf_string, gdf_string)
+
+
 def test_cudf_json_writer_read(gdf_writer_types):
     dtypes = {
         col_name: col_name[len("col_") :]

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -898,7 +898,9 @@ double_precision : int, default 10
     The number of decimal places to use when encoding
     floating point values.
 force_ascii : bool, default True
-    Force encoded string to be ASCII.
+    Force encoded string to be ASCII. If False, non-ASCII characters
+    are written as-is instead of being escaped to ``\\uXXXX`` sequences.
+    Supported with both the ``pandas`` and ``cudf`` engines.
 date_unit : string, default 'ms' (milliseconds)
     The time unit to encode to, governs timestamp and ISO8601
     precision.  One of 's', 'ms', 'us', 'ns' for second, millisecond,


### PR DESCRIPTION
## Description
Closes #15211

This PR adds support for passing the `force_ascii` flag to the `cudf` JSON engine, mirroring the Pandas implementation. 
If `force_ascii=False`, non-ASCII characters (like emojis) are written as-is instead of being escaped. 

- Modifies `_plc_write_json` in `json.py` to accept the flag and pass `.utf8_escaped(force_ascii)` to the `pylibcudf` backend.
- Updates `ioutils.py` docstrings to explicitly indicate `cudf` engine support.
- Adds parameterized tests to verify the outputs match Pandas exactly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
