### PR TITLE
Set `GPUS` arguments on streaming tests

### DIFF
--- a/cpp/libcudf_streaming/tests/CMakeLists.txt
+++ b/cpp/libcudf_streaming/tests/CMakeLists.txt
@@ -34,6 +34,8 @@ function(libcudf_streaming_mpirun_test_add)
       NAME "${_MPIRUN_TEST_TEST_TARGET}_${np}"
       COMMAND mpirun --oversubscribe --map-by node --bind-to none -np ${np}
               "$<TARGET_FILE:${_MPIRUN_TEST_TEST_TARGET}>"
+      GPUS ALL
+      PERCENT 100
       INSTALL_COMPONENT_SET testing INSTALL_TARGET ${_MPIRUN_TEST_TEST_TARGET}
     )
   endforeach(np)
@@ -105,6 +107,8 @@ target_link_libraries(
 rapids_test_add(
   NAME libcudf_streaming_single_tests
   COMMAND libcudf_streaming_single_tests
+  GPUS ALL
+  PERCENT 100
   INSTALL_COMPONENT_SET testing
 )
 


### PR DESCRIPTION
## Description
Ensure that these GPU-based tests can only run one at a time.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
