### PR TITLE
Set `RUN_SERIAL` property on streaming tests

### DIFF
--- a/cpp/libcudf_streaming/tests/CMakeLists.txt
+++ b/cpp/libcudf_streaming/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ function(libcudf_streaming_mpirun_test_add)
               "$<TARGET_FILE:${_MPIRUN_TEST_TEST_TARGET}>"
       INSTALL_COMPONENT_SET testing INSTALL_TARGET ${_MPIRUN_TEST_TEST_TARGET}
     )
+    set_tests_properties("${_MPIRUN_TEST_TEST_TARGET}_${np}" PROPERTIES RUN_SERIAL TRUE)
   endforeach(np)
 endfunction(libcudf_streaming_mpirun_test_add)
 
@@ -107,6 +108,7 @@ rapids_test_add(
   COMMAND libcudf_streaming_single_tests
   INSTALL_COMPONENT_SET testing
 )
+set_tests_properties(libcudf_streaming_single_tests PROPERTIES RUN_SERIAL TRUE)
 
 # ##################################################################################################
 # MPI and UCXX based tests -------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Ensure that these tests only ever run one at a time so they can use all the GPUs.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
