### PR TITLE
Handle Arrow bool masks in DataFrame getitem

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1608,7 +1608,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
             if is_list_like(mask):
                 dtype = None
                 mask = pd.Series(mask, dtype=dtype)
-            if mask.dtype == "bool":
+            if getattr(mask.dtype, "kind", None) == "b":
                 return self._apply_boolean_mask(BooleanMask(mask, len(self)))
             else:
                 return self._get_columns_by_label(mask)

--- a/python/cudf/cudf/tests/dataframe/indexing/test_getitem.py
+++ b/python/cudf/cudf/tests/dataframe/indexing/test_getitem.py
@@ -211,6 +211,14 @@ def test_dataframe_boolean_mask(mask_fn):
     assert pdf_masked.to_string().split() == gdf_masked.to_string().split()
 
 
+def test_dataframe_getitem_bool_pyarrow_mask():
+    pdf = pd.DataFrame({"x": range(4), "y": range(10, 14)})
+    gdf = cudf.from_pandas(pdf)
+    mask = cudf.Series([True, False, True, False], dtype="bool[pyarrow]")
+
+    assert_eq(pdf[[True, False, True, False]], gdf[mask])
+
+
 @pytest.mark.parametrize(
     "gdf_kwargs",
     [


### PR DESCRIPTION
Closes #23200

## Description

Treat Arrow-backed boolean masks such as `bool[pyarrow]` as boolean row masks in `DataFrame.__getitem__`.

`DataFrame.__getitem__` previously only checked `mask.dtype == "bool"`. Comparisons on nullable string columns can produce `bool[pyarrow]`, which is still a boolean dtype but was routed to column-label selection and failed with `Series object is not iterable`.

This PR switches the mask check to use the dtype kind, matching the behavior already used by `.loc` indexing and `BooleanMask`, and adds a regression test for `DataFrame[mask]` with a `bool[pyarrow]` cudf Series.

Validation:

- `git diff --check`
- Temporarily patched the installed `cudf/core/dataframe.py` in conda environment, then verified the nullable-string comparison snippet filters correctly.
- Ran `python -m pytest -q python/cudf/cudf/tests/dataframe/indexing/test_getitem.py::test_dataframe_getitem_bool_pyarrow_mask` with the temporary patch: passed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

