### PR TITLE
Update benchmark data-generator to allow nullable with no nulls

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -242,6 +242,11 @@ struct bool_generator {
   __device__ bool operator()(size_t n)
   {
     engine.discard(n);
+    // Short-circuit the degenerate endpoints so that probability_true == 1.0 (null_probability ==
+    // 0) always yields all-valid and probability_true == 0.0 always yields all-null, independent of
+    // the float distribution's endpoint behavior (which can return exactly 1.0f).
+    if (probability_true >= 1.0) return true;
+    if (probability_true <= 0.0) return false;
     return dist(engine) < probability_true;
   }
 };


### PR DESCRIPTION
## Description
Adds short-circuit logic for generating null rows in the `bool_generator` utility to ensure no nulls are set for probability=0.0.
This is to ensure we create a predictable `nullable` column even though when `null_count` is expected to be 0.

Closes #23197 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
