### PR TITLE
Support remote storage URLs for PDS-H validation

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/streaming/benchmarks/utils.py
@@ -221,20 +221,12 @@ class ValidationMethod:
     comparison_options: dict[str, Any]
     expected_location: str | None
 
-    def expected_file(self, q_id: int) -> Path:
+    def expected_file(self, q_id: int) -> str:
         """Return path to disk-based result for the given query."""
         if self.expected_location is None:
             raise RuntimeError("No expected location given")
 
-        # search for either q_{q_id:02d}.parquet or q{q_id:02d}.parquet
-        files = list(Path(self.expected_location).glob(f"q*{q_id:02d}.parquet"))
-        if not files:
-            raise FileNotFoundError(f"Expected result file for query {q_id} not found")
-        elif len(files) > 1:
-            raise ValueError(
-                f"Multiple expected result files for query {q_id}: {files}"
-            )
-        return files[0]
+        return self.expected_location.rstrip("/") + f"/q*{q_id:02d}.parquet"
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -599,7 +591,7 @@ class RunConfig:
                 expected_source="duckdb-disk",
                 comparison_method="polars",
                 comparison_options=get_validation_options(args),
-                expected_location=str(args.validate_directory),
+                expected_location=args.validate_directory,
             )
         elif args.validate_against is not None:
             validation_method = ValidationMethod(
@@ -2101,12 +2093,12 @@ def build_parser(num_queries: int = 22) -> argparse.ArgumentParser:
     )
     group.add_argument(
         "--validate-directory",
-        type=Path,
+        type=str,
         default=None,
         help=(
-            "Validate the results against a directory with a pre-computed set of 'golden' results. "
-            "The directory should contain one parquet file per query, named 'q_DD.parquet', or `qDD.parquet` "
-            "where DD is the zero-padded query number."
+            "Validate the results against a directory or object-storage prefix with a pre-computed set "
+            "of 'golden' results. The directory should contain one parquet file per query, "
+            "named 'q_DD.parquet', or `qDD.parquet` where DD is the zero-padded query number."
         ),
     )
     parser.add_argument(
@@ -2210,14 +2202,6 @@ def parse_args(
         parser.error(
             "--blocksize is not supported with --frontend; "
             "use --target-partition-size instead."
-        )
-
-    if (
-        parsed_args.validate_directory is not None
-        and not parsed_args.validate_directory.exists()
-    ):
-        raise FileNotFoundError(
-            f"--validate-directory: {parsed_args.validate_directory} does not exist."
         )
 
     if (


### PR DESCRIPTION
## Description

This updates our pds-h benchmarks script to accept an s3://-style URL for `--validate-directory`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
