### PR TITLE
Error when parquet decode string corruption detected

### DIFF
--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -1096,11 +1096,13 @@ inline __device__ bool prefetch_string_data(int t,
  * @param s Page state containing data_start, dict_size and other info
  * @param num_values_to_process Number of values to process
  * @param str_offsets Output buffer for string offsets
+ * @param error_code Error code to set if a string length overruns the page
  */
 template <int32_t block_size, size_t prefetch_size>
 inline __device__ void read_string_offsets_buffered(page_state_s* s,
                                                     size_t num_values_to_process,
-                                                    uint32_t* str_offsets)
+                                                    uint32_t* str_offsets,
+                                                    kernel_error::pointer error_code)
 {
   auto const block     = cg::this_thread_block();
   int const t          = block.thread_rank();
@@ -1123,6 +1125,7 @@ inline __device__ void read_string_offsets_buffered(page_state_s* s,
   size_t num_values_written = num_values_to_process;  // Will update below if run out of data
   for (size_t pos = 0; pos < num_values_to_process; pos++) {
     int32_t const string_offset = next_length_offset + sizeof(int32_t);
+    // Benign end-of-data: length prefix itself is past the end (nullable pages over-read).
     if (string_offset > dict_size) {
       num_values_written = pos;  // Can't read any more valid data
       break;
@@ -1146,8 +1149,13 @@ inline __device__ void read_string_offsets_buffered(page_state_s* s,
                       reinterpret_cast<void const*>(&prefetch_buffer[prefetch_read_index]),
                       sizeof(int32_t));
 
+    // Genuine corruption: a valid length prefix claims more bytes than remain in the page.
     if (string_offset + len > dict_size) {
       num_values_written = pos;  // Data is corrupted or incomplete
+      if (t == 0) {
+        set_error(static_cast<kernel_error::value_type>(decode_error::STRING_DATA_OVERRUN),
+                  error_code);
+      }
       break;
     }
     next_length_offset = string_offset + len;
@@ -1177,11 +1185,13 @@ inline __device__ void read_string_offsets_buffered(page_state_s* s,
  * @param s Page state containing data_start, dict_size and other info
  * @param num_values_to_process Number of values to process
  * @param str_offsets Output buffer for string offsets
+ * @param error_code Error code to set if a string length overruns the page
  */
 template <int32_t block_size>
 inline __device__ void read_string_offsets_sequential(page_state_s* s,
                                                       size_t num_values_to_process,
-                                                      uint32_t* str_offsets)
+                                                      uint32_t* str_offsets,
+                                                      kernel_error::pointer error_code)
 {
   auto const block = cg::this_thread_block();
   int const t      = block.thread_rank();
@@ -1199,6 +1209,7 @@ inline __device__ void read_string_offsets_sequential(page_state_s* s,
     num_values_written = num_values_to_process;  // Will update below if run out of data
     for (size_t pos = 0; pos < num_values_to_process; pos++) {
       uint32_t const string_offset = length_offset + sizeof(int32_t);
+      // Benign end-of-data: length prefix itself is past the end (nullable pages over-read).
       if (string_offset > dict_size) {
         num_values_written = pos;  // Can't read any more valid data
         break;
@@ -1210,8 +1221,11 @@ inline __device__ void read_string_offsets_sequential(page_state_s* s,
                         reinterpret_cast<void const*>(&cur[length_offset]),
                         sizeof(int32_t));
 
+      // Genuine corruption: a valid length prefix claims more bytes than remain in the page.
       if (string_offset + len > dict_size) {
         num_values_written = pos;  // Data is corrupted or incomplete
+        set_error(static_cast<kernel_error::value_type>(decode_error::STRING_DATA_OVERRUN),
+                  error_code);
         break;
       }
       str_offsets[pos] = string_offset;
@@ -1245,6 +1259,7 @@ inline __device__ void read_string_offsets_sequential(page_state_s* s,
  * @param page_mask Boolean vector indicating which pages need to be processed
  * @param min_row Minimum row index to read
  * @param num_rows Number of rows to read starting from min_row
+ * @param error_code Error code to set if string data is corrupted
  */
 template <int decode_block_size, size_t prefetch_size>
 CUDF_KERNEL void preprocess_string_offsets_kernel(
@@ -1253,7 +1268,8 @@ CUDF_KERNEL void preprocess_string_offsets_kernel(
   device_span<size_t const> page_string_offset_indices,
   cudf::device_span<bool const> page_mask,
   size_t min_row,
-  size_t num_rows)
+  size_t num_rows,
+  kernel_error::pointer error_code)
 {
   int const page_idx = cg::this_grid().block_rank();
   PageInfo* const pp = &pages[page_idx];
@@ -1309,11 +1325,12 @@ CUDF_KERNEL void preprocess_string_offsets_kernel(
 
   if (avg_string_length > max_avg_string_length_for_buffer) {
     // Use sequential processing for large average string lengths
-    read_string_offsets_sequential<decode_block_size>(s, num_values_to_process, str_offsets);
+    read_string_offsets_sequential<decode_block_size>(
+      s, num_values_to_process, str_offsets, error_code);
   } else {
     // Use buffered processing for typical string lengths
     read_string_offsets_buffered<decode_block_size, prefetch_size>(
-      s, num_values_to_process, str_offsets);
+      s, num_values_to_process, str_offsets, error_code);
   }
 }
 
@@ -1328,6 +1345,7 @@ CUDF_KERNEL void preprocess_string_offsets_kernel(
  * @param page_mask Boolean vector indicating which pages need to be processed
  * @param min_row Minimum row index to read
  * @param num_rows Number of rows to read starting from min_row
+ * @param error_code Error code to set if string data is corrupted
  * @param stream CUDA stream to use
  */
 void preprocess_string_offsets(cudf::detail::hostdevice_span<PageInfo> pages,
@@ -1336,6 +1354,7 @@ void preprocess_string_offsets(cudf::detail::hostdevice_span<PageInfo> pages,
                                cudf::device_span<bool const> page_mask,
                                size_t min_row,
                                size_t num_rows,
+                               kernel_error::pointer error_code,
                                rmm::cuda_stream_view stream)
 {
   if (pages.size() == 0) { return; }
@@ -1347,8 +1366,13 @@ void preprocess_string_offsets(cudf::detail::hostdevice_span<PageInfo> pages,
   dim3 dim_grid(pages.size(), 1);  // 1 threadblock per page
 
   preprocess_string_offsets_kernel<preprocess_block_size, prefetch_size>
-    <<<dim_grid, dim_block, 0, stream.value()>>>(
-      pages.device_ptr(), chunks, page_string_offset_indices, page_mask, min_row, num_rows);
+    <<<dim_grid, dim_block, 0, stream.value()>>>(pages.device_ptr(),
+                                                 chunks,
+                                                 page_string_offset_indices,
+                                                 page_mask,
+                                                 min_row,
+                                                 num_rows,
+                                                 error_code);
   CUDF_CUDA_TRY(cudaGetLastError());
 }
 

--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -1048,8 +1048,7 @@ void compute_page_string_sizes_pass2(cudf::detail::hostdevice_span<PageInfo> pag
  * @param prefetch_buffer Shared memory buffer for prefetching
  * @param[in,out] buffer_base Offset corresponding to the start of the prefetched buffer
  * @param[in,out] buffer_end Offset corresponding to the end of the prefetched buffer
- * @return True if the buffer holds at least a full length prefix (sizeof(int32_t) bytes) starting
- * at next_length_offset; false if fewer bytes remain (i.e. we've reached the end of the data)
+ * @return Whether the buffer contains valid data
  */
 template <int32_t prefetch_size, int32_t block_size>
 inline __device__ bool prefetch_string_data(int t,
@@ -1064,10 +1063,7 @@ inline __device__ bool prefetch_string_data(int t,
   buffer_base = next_length_offset;
 
   int32_t const total_bytes_to_copy = cuda::std::min(prefetch_size, dict_size - buffer_base);
-  // Callers read a 4-byte length prefix directly out of the prefetched buffer, so require a full
-  // prefix to be available. Fewer bytes than that means we've reached the end of the data: report
-  // failure so the caller stops rather than reading a partial (out-of-bounds) length.
-  if (total_bytes_to_copy < static_cast<int32_t>(sizeof(int32_t))) { return false; }
+  if (total_bytes_to_copy <= 0) { return false; }  // No data left to copy
   buffer_end = buffer_base + total_bytes_to_copy;
 
   // Nominally, each thread will copy an equal number of bytes; this rounds up.
@@ -1160,15 +1156,15 @@ inline __device__ void read_string_offsets_buffered(page_state_s* s,
     // near-INT_MAX corrupt length cannot overflow the comparison itself (int32 overflow is UB).
     if (len < 0 || static_cast<int64_t>(string_offset) + len > dict_size) {
       num_values_written = pos;  // Data is corrupted or incomplete
-      if (t == 0) {
+      cg::invoke_one(block, [&]() {
         set_error(static_cast<kernel_error::value_type>(decode_error::STRING_DATA_OVERRUN),
                   error_code);
-      }
+      });
       break;
     }
     next_length_offset = string_offset + len;
 
-    if (t == 0) { str_offsets[pos] = string_offset; }
+    cg::invoke_one(block, [&]() { str_offsets[pos] = string_offset; });
   }
 
   // +4 for "stored" length of "next" string that we'll subtract off during decode
@@ -1207,7 +1203,7 @@ inline __device__ void read_string_offsets_sequential(page_state_s* s,
   __shared__ size_t num_values_written;
   __shared__ uint32_t last_offset;  // offset into data_start
 
-  if (t == 0) {
+  cg::invoke_one(block, [&]() {
     uint8_t const* cur     = s->data_start;
     uint32_t length_offset = 0;
     auto const dict_size   = s->dict_size;
@@ -1246,7 +1242,7 @@ inline __device__ void read_string_offsets_sequential(page_state_s* s,
 
     // +4 for "stored" length of "next" string that we'll subtract off during decode
     last_offset = length_offset + sizeof(int32_t);
-  }
+  });
 
   block.sync();  // Ensure all threads see num_values_written
 

--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -1048,7 +1048,8 @@ void compute_page_string_sizes_pass2(cudf::detail::hostdevice_span<PageInfo> pag
  * @param prefetch_buffer Shared memory buffer for prefetching
  * @param[in,out] buffer_base Offset corresponding to the start of the prefetched buffer
  * @param[in,out] buffer_end Offset corresponding to the end of the prefetched buffer
- * @return Whether the buffer contains valid data
+ * @return True if the buffer holds at least a full length prefix (sizeof(int32_t) bytes) starting
+ * at next_length_offset; false if fewer bytes remain (i.e. we've reached the end of the data)
  */
 template <int32_t prefetch_size, int32_t block_size>
 inline __device__ bool prefetch_string_data(int t,
@@ -1063,7 +1064,10 @@ inline __device__ bool prefetch_string_data(int t,
   buffer_base = next_length_offset;
 
   int32_t const total_bytes_to_copy = cuda::std::min(prefetch_size, dict_size - buffer_base);
-  if (total_bytes_to_copy <= 0) { return false; }  // No data left to copy
+  // Callers read a 4-byte length prefix directly out of the prefetched buffer, so require a full
+  // prefix to be available. Fewer bytes than that means we've reached the end of the data: report
+  // failure so the caller stops rather than reading a partial (out-of-bounds) length.
+  if (total_bytes_to_copy < static_cast<int32_t>(sizeof(int32_t))) { return false; }
   buffer_end = buffer_base + total_bytes_to_copy;
 
   // Nominally, each thread will copy an equal number of bytes; this rounds up.
@@ -1125,9 +1129,10 @@ inline __device__ void read_string_offsets_buffered(page_state_s* s,
   size_t num_values_written = num_values_to_process;  // Will update below if run out of data
   for (size_t pos = 0; pos < num_values_to_process; pos++) {
     int32_t const string_offset = next_length_offset + sizeof(int32_t);
-    // Benign end-of-data: length prefix itself is past the end (nullable pages over-read).
+    // Natural end-of-data exit: we've consumed all the value bytes, so the next length prefix
+    // would begin at or past the end of the data -- it doesn't exist. Nothing left to read.
     if (string_offset > dict_size) {
-      num_values_written = pos;  // Can't read any more valid data
+      num_values_written = pos;  // Reached the end of the data
       break;
     }
 
@@ -1149,8 +1154,11 @@ inline __device__ void read_string_offsets_buffered(page_state_s* s,
                       reinterpret_cast<void const*>(&prefetch_buffer[prefetch_read_index]),
                       sizeof(int32_t));
 
-    // Genuine corruption: a valid length prefix claims more bytes than remain in the page.
-    if (string_offset + len > dict_size) {
+    // Genuine corruption: the length prefix is not a valid in-page size. This covers a length
+    // that claims more bytes than remain in the page, and a negative length (never valid in PLAIN,
+    // e.g. from a stray byte shifting the length window). The sum is widened to 64 bits so a
+    // near-INT_MAX corrupt length cannot overflow the comparison itself (int32 overflow is UB).
+    if (len < 0 || static_cast<int64_t>(string_offset) + len > dict_size) {
       num_values_written = pos;  // Data is corrupted or incomplete
       if (t == 0) {
         set_error(static_cast<kernel_error::value_type>(decode_error::STRING_DATA_OVERRUN),
@@ -1209,9 +1217,10 @@ inline __device__ void read_string_offsets_sequential(page_state_s* s,
     num_values_written = num_values_to_process;  // Will update below if run out of data
     for (size_t pos = 0; pos < num_values_to_process; pos++) {
       uint32_t const string_offset = length_offset + sizeof(int32_t);
-      // Benign end-of-data: length prefix itself is past the end (nullable pages over-read).
+      // Natural end-of-data exit: we've consumed all the value bytes, so the next length prefix
+      // would begin at or past the end of the data -- it doesn't exist. Nothing left to read.
       if (string_offset > dict_size) {
-        num_values_written = pos;  // Can't read any more valid data
+        num_values_written = pos;  // Reached the end of the data
         break;
       }
 
@@ -1221,8 +1230,11 @@ inline __device__ void read_string_offsets_sequential(page_state_s* s,
                         reinterpret_cast<void const*>(&cur[length_offset]),
                         sizeof(int32_t));
 
-      // Genuine corruption: a valid length prefix claims more bytes than remain in the page.
-      if (string_offset + len > dict_size) {
+      // Genuine corruption: the length prefix is not a valid in-page size. This covers a length
+      // that claims more bytes than remain in the page, and a negative length (never valid in
+      // PLAIN, e.g. from a stray byte shifting the length window). The sum is widened to 64 bits so
+      // a near-INT_MAX corrupt length cannot overflow the comparison itself (int32 overflow is UB).
+      if (len < 0 || static_cast<int64_t>(string_offset) + len > dict_size) {
         num_values_written = pos;  // Data is corrupted or incomplete
         set_error(static_cast<kernel_error::value_type>(decode_error::STRING_DATA_OVERRUN),
                   error_code);

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -114,6 +114,7 @@ enum class decode_error : kernel_error::value_type {
   INVALID_PAGE_TYPE              = 0x200,
   INVALID_PAGE_HEADER            = 0x400,
   INVALID_BYTE_STREAM_SPLIT_SIZE = 0x800,
+  STRING_DATA_OVERRUN            = 0x1000,
 };
 
 /**
@@ -981,6 +982,7 @@ void decode_delta_length_byte_array(cudf::detail::hostdevice_span<PageInfo> page
  * @param[in] page_mask Boolean vector indicating which pages need to be processed
  * @param[in] min_row Minimum row index to read
  * @param[in] num_rows Number of rows to read starting from min_row
+ * @param[out] error_code Error code to set if string data is corrupted
  * @param[in] stream CUDA stream to use
  */
 void preprocess_string_offsets(cudf::detail::hostdevice_span<PageInfo> pages,
@@ -989,6 +991,7 @@ void preprocess_string_offsets(cudf::detail::hostdevice_span<PageInfo> pages,
                                cudf::device_span<bool const> page_mask,
                                size_t min_row,
                                size_t num_rows,
+                               kernel_error::pointer error_code,
                                rmm::cuda_stream_view stream);
 
 /**

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -469,16 +469,21 @@ void reader_impl::compute_page_string_offset_indices(size_t skip_rows, size_t nu
   _stream.synchronize();
 
   // Pre-process string offsets for non-dictionary string columns
+  kernel_error error_code(_stream);
   detail::preprocess_string_offsets(subpass.pages,
                                     pass.chunks,
                                     subpass.page_string_offset_indices,
                                     subpass_page_mask_span(),
                                     skip_rows,
                                     num_rows,
+                                    error_code.data(),
                                     _stream);
 
   // Wait for string offset preprocessing to complete before launching decode kernels
-  _stream.synchronize();
+  if (auto const error = error_code.value_sync(_stream); error != 0) {
+    CUDF_FAIL("Parquet string offset preprocess failed with code(s) " +
+              kernel_error::to_string(error));
+  }
 }
 
 std::pair<bool, std::future<void>> reader_impl::read_column_chunks()

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -4540,6 +4540,48 @@ TEST_F(ParquetReaderTest, InvalidFooterMagic)
   EXPECT_THROW(cudf::io::read_parquet(read_opts), cudf::logic_error);
 }
 
+TEST_F(ParquetReaderTest, CorruptPlainStringLengthThrows)
+{
+  // A PLAIN BYTE_ARRAY length that overruns the page must fail loudly instead of
+  // silently decoding the corrupt tail as empty strings.
+  auto const col = cudf::test::strings_column_wrapper{
+    "unique_string_aaa", "unique_string_bbb", "unique_string_ccc", "unique_string_ddd"};
+  auto const expected = table_view{{col}};
+
+  std::vector<char> buffer;
+  cudf::io::parquet_writer_options out_opts =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&buffer}, expected)
+      .compression(cudf::io::compression_type::NONE)
+      .dictionary_policy(cudf::io::dictionary_policy::NEVER);
+  cudf::io::write_parquet(out_opts);
+
+  // PLAIN BYTE_ARRAY layout is [4-byte little-endian length][string bytes]... So the 4 bytes
+  // immediately preceding a known string value are that value's length prefix. Locate the third
+  // string's bytes, then step back sizeof(int32_t) to land on its length prefix.
+  std::string const target = "unique_string_ccc";
+  auto const it = std::search(buffer.begin(), buffer.end(), target.begin(), target.end());
+  ASSERT_NE(it, buffer.end());
+  auto const length_pos = static_cast<size_t>(std::distance(buffer.begin(), it) - sizeof(int32_t));
+
+  // Sanity check that we found the length prefix: it should hold the real string length.
+  int32_t orig_len{};
+  std::memcpy(&orig_len, buffer.data() + length_pos, sizeof(orig_len));
+  ASSERT_EQ(orig_len, static_cast<int32_t>(target.size()));
+
+  // Overwrite the length prefix with a value that runs past the end of the page. This mimics the
+  // real-world corruption where a stray byte shifts the length window, producing a bogus length.
+  // The offset preprocessor detects `string_offset + len > dict_size` and must raise
+  // decode_error::STRING_DATA_OVERRUN rather than truncating and back-filling empty strings.
+  int32_t const bad_len = 1'000'000;
+  std::memcpy(buffer.data() + length_pos, &bad_len, sizeof(bad_len));
+
+  auto const read_opts = cudf::io::parquet_reader_options::builder(
+                           cudf::io::source_info{cudf::host_span<std::byte const>{
+                             reinterpret_cast<std::byte const*>(buffer.data()), buffer.size()}})
+                           .build();
+  EXPECT_THROW(cudf::io::read_parquet(read_opts), cudf::logic_error);
+}
+
 TEST_F(ParquetReaderTest, DecimalTypeOption)
 {
   auto const data = std::vector<int32_t>{1000, 2000, 3000, 4000, 5000};


### PR DESCRIPTION
## Description

This raises an error when an error is detected in the parquet string decode.  Specifically, when a string length is encountered that is longer than the length of the string buffer.  Previously, we just truncated the read at that location and returned less data than was in the file, and did not indicate there was an error. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
