### PR TITLE
Pin pyarrow < 25 in Polars tests

### DIFF
--- a/ci/test_cudf_polars_polars_tests.sh
+++ b/ci/test_cudf_polars_polars_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -43,6 +43,8 @@ git clone https://github.com/pola-rs/polars.git --branch "${TAG}" --depth 1
 rapids-logger "Install polars test requirements"
 # We don't need to pick up dependencies from polars-cloud, so we remove it.
 sed -i '/^polars-cloud$/d' polars/py-polars/requirements-dev.txt
+# Pin pyarrow to avoid FutureWarning https://github.com/pola-rs/polars/pull/28323.
+sed -i 's/^pyarrow$/pyarrow<25/' polars/py-polars/requirements-dev.txt
 
 # notes:
 #


### PR DESCRIPTION
## Description
Polars tests use a feather API that has been deprecated in Pyarrow 25

A fix is in progress on the Polars side https://github.com/pola-rs/polars/pull/28323

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
