### PR TITLE
Minimum & maximum string length functions to string_column_view

### DIFF
--- a/cpp/include/cudf/detail/gather.cuh
+++ b/cpp/include/cudf/detail/gather.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -256,10 +256,10 @@ struct column_gatherer_impl<string_view> {
   {
     if (true == nullify_out_of_bounds) {
       return cudf::strings::detail::gather<true>(
-        strings_column_view(source_column), gather_map_begin, gather_map_end, stream, mr);
+        strings_column_view(source_column, stream), gather_map_begin, gather_map_end, stream, mr);
     } else {
       return cudf::strings::detail::gather<false>(
-        strings_column_view(source_column), gather_map_begin, gather_map_end, stream, mr);
+        strings_column_view(source_column, stream), gather_map_begin, gather_map_end, stream, mr);
     }
   }
 };

--- a/cpp/include/cudf/strings/detail/utilities.hpp
+++ b/cpp/include/cudf/strings/detail/utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -96,6 +96,19 @@ int64_t get_offset_value(cudf::column_view const& offsets,
  */
 std::pair<int64_t, int64_t> get_first_and_last_offset(cudf::strings_column_view const& input,
                                                       rmm::cuda_stream_view stream);
+
+/**
+ * @brief Compute the minimum and maximum string byte lengths in a strings column.
+ *
+ * Performs two device reductions over the column. Null entries are treated as
+ * zero-length strings. Returns {0, 0} for an empty column.
+ *
+ * @param input Strings column
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @return Pair of {min_length, max_length} in bytes
+ */
+std::pair<int64_t, int64_t> compute_min_max_string_lengths(cudf::strings_column_view const& input,
+                                                           rmm::cuda_stream_view stream);
 
 }  // namespace strings::detail
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -7,6 +7,8 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/export.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
 
 /**
  * @file
@@ -27,11 +29,27 @@ namespace CUDF_EXPORT cudf {
 class strings_column_view : private column_view {
  public:
   /**
-   * @brief Construct a new strings column view object from a column view.s
+   * @brief Construct a new strings column view object from a column view.
+   *
+   * The minimum and maximum string byte lengths are not computed by this constructor.
+   * Use the stream-taking overload to compute them at construction time.
    *
    * @param strings_column The column view to wrap.
    */
   strings_column_view(column_view strings_column);
+
+  /**
+   * @brief Construct a new strings column view and compute min/max string byte lengths.
+   *
+   * Minimum and maximum are computed once on the device using @p stream and cached.
+   * Subsequent calls to minimum() and maximum() return the cached values.
+   * Null entries are treated as zero-length strings.
+   *
+   * @param strings_column The column view to wrap.
+   * @param stream CUDA stream used for the min/max reduction.
+   */
+  strings_column_view(column_view strings_column, rmm::cuda_stream_view stream);
+
   // So we can use this from cython.
   strings_column_view()                           = default;
   strings_column_view(strings_column_view&&)      = default;  ///< Move constructor
@@ -111,6 +129,32 @@ class strings_column_view : private column_view {
    * @return Iterator pointing 1 past the last char byte.
    */
   [[nodiscard]] chars_iterator chars_end(rmm::cuda_stream_view stream) const;
+
+  /**
+   * @brief Returns the minimum string byte length in this view.
+   *
+   * Requires construction via strings_column_view(column_view, rmm::cuda_stream_view).
+   * Null entries are counted as zero-length.
+   *
+   * @throws cudf::logic_error if min/max were not computed at construction.
+   * @return Minimum byte length across all strings in the view.
+   */
+  [[nodiscard]] int64_t minimum() const;
+
+  /**
+   * @brief Returns the maximum string byte length in this view.
+   *
+   * Requires construction via strings_column_view(column_view, rmm::cuda_stream_view).
+   * Null entries are counted as zero-length.
+   *
+   * @throws cudf::logic_error if min/max were not computed at construction.
+   * @return Maximum byte length across all strings in the view.
+   */
+  [[nodiscard]] int64_t maximum() const;
+
+ private:
+  int64_t _min_length{-1};  ///< Cached minimum string byte length; -1 means not computed.
+  int64_t _max_length{-1};  ///< Cached maximum string byte length; -1 means not computed.
 };
 
 //! Strings column APIs.

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf/copying.hpp>
@@ -35,7 +35,7 @@ bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_vie
   // Cross-reference nullmask and offsets.
   auto const type    = input.type().id();
   auto const offsets = offsetalator_factory::make_input_iterator(
-    (type == type_id::STRING) ? strings_column_view{input}.offsets()
+    (type == type_id::STRING) ? strings_column_view{input, stream}.offsets()
                               : lists_column_view{input}.offsets(),
     input.offset());
   auto const d_input      = cudf::column_device_view::create(input, stream);

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -74,7 +74,7 @@ struct shift_functor {
     requires(std::is_same_v<cudf::string_view, T>)
   {
     auto output = cudf::strings::detail::shift(
-      cudf::strings_column_view(input), offset, fill_value, stream, mr);
+      cudf::strings_column_view(input, stream), offset, fill_value, stream, mr);
 
     if (input.nullable() || not fill_value.is_valid(stream)) {
       auto const d_input           = column_device_view::create(input, stream);

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -131,7 +131,7 @@ std::unique_ptr<cudf::column> out_of_place_fill_range_dispatch::operator()<cudf:
   using ScalarType = cudf::scalar_type_t<cudf::string_view>;
   auto p_scalar    = static_cast<ScalarType const*>(&value);
   return cudf::strings::detail::fill(
-    cudf::strings_column_view(input), begin, end, *p_scalar, stream, mr);
+    cudf::strings_column_view(input, stream), begin, end, *p_scalar, stream, mr);
 }
 
 template <>

--- a/cpp/src/interop/to_arrow_device.cu
+++ b/cpp/src/interop/to_arrow_device.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -404,7 +404,7 @@ int dispatch_to_arrow_device_view::operator()<cudf::string_view>(ArrowArray* out
 
   NANOARROW_RETURN_NOT_OK(set_null_mask(column, tmp.get()));
 
-  auto const scv = cudf::strings_column_view(column);
+  auto const scv = cudf::strings_column_view(column, stream);
   NANOARROW_RETURN_NOT_OK(set_view_to_buffer(scv.offsets(), tmp.get()));
   NANOARROW_RETURN_NOT_OK(
     set_buffer_view(scv.chars_begin(stream), scv.chars_size(stream), 2, tmp.get()));

--- a/cpp/src/interop/to_arrow_host.cu
+++ b/cpp/src/interop/to_arrow_host.cu
@@ -181,7 +181,7 @@ int dispatch_to_arrow_host::operator()<cudf::string_view>(ArrowArray* out) const
 
   NANOARROW_RETURN_NOT_OK(populate_validity_bitmap(ArrowArrayValidityBitmap(tmp.get())));
 
-  auto const scv     = cudf::strings_column_view(column);
+  auto const scv     = cudf::strings_column_view(column, stream);
   auto const offsets = scv.offsets();
   if (offsets.type().id() == cudf::type_id::INT64) {
     NANOARROW_RETURN_NOT_OK(populate_data_buffer(
@@ -463,7 +463,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
     auto longer_strings = cudf::strings::detail::make_strings_column(
       indices, indices + col.size(), stream, cudf::get_current_device_resource_ref());
     stream.synchronize();
-    auto const sv = cudf::strings_column_view(longer_strings->view());
+    auto const sv = cudf::strings_column_view(longer_strings->view(), stream);
     return std::pair{std::move(longer_strings), sv};
   }();
   auto [first, last] = cudf::strings::detail::get_first_and_last_offset(longer_strings, stream);

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -232,7 +232,7 @@ struct column_to_strings_fn {
     return cudf::strings::detail::from_timestamps(
       column,
       format,
-      strings_column_view(make_empty_column(type_id::STRING)->view()),
+      strings_column_view(make_empty_column(type_id::STRING)->view(), stream_),
       stream_,
       mr_);
   }

--- a/cpp/src/io/json/host_tree_algorithms.cu
+++ b/cpp/src/io/json/host_tree_algorithms.cu
@@ -120,7 +120,7 @@ std::vector<std::string> copy_strings_to_host_sync(
                                    cudf::get_current_device_resource_ref());
   auto to_host        = [stream](auto const& col) {
     if (col.is_empty()) return std::vector<std::string>{};
-    auto const scv     = cudf::strings_column_view(col);
+    auto const scv     = cudf::strings_column_view(col, stream);
     auto const h_chars = cudf::detail::make_host_vector_async<char>(
       cudf::device_span<char const>(scv.chars_begin(stream), scv.chars_size(stream)), stream);
     auto const h_offsets = cudf::detail::make_host_vector_async(

--- a/cpp/src/io/json/json_tree.cu
+++ b/cpp/src/io/json/json_tree.cu
@@ -561,7 +561,7 @@ std::pair<size_t, rmm::device_uvector<size_type>> remapped_field_nodes_after_uni
   // insert and find. -> array
   // store to static_map with keys as field key[index], and values as key[array[index]]
 
-  auto str_view         = strings_column_view{utf8_decoded_fields->view()};
+  auto str_view         = strings_column_view{utf8_decoded_fields->view(), stream};
   auto const char_ptr   = str_view.chars_begin(stream);
   auto const offset_ptr = str_view.offsets().begin<size_type>();
 

--- a/cpp/src/io/json/write_json.cpp
+++ b/cpp/src/io/json/write_json.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -111,7 +111,7 @@ std::unique_ptr<column> timestamp_to_strings(column_view const& column,
 
   auto empty_strings = make_empty_column(type_id::STRING);
   return cudf::strings::detail::from_timestamps(
-    column, format, strings_column_view(empty_strings->view()), stream, mr);
+    column, format, strings_column_view(empty_strings->view(), stream), stream, mr);
 }
 
 std::unique_ptr<column> duration_to_strings(column_view const& column,

--- a/cpp/src/io/json/write_json.cu
+++ b/cpp/src/io/json/write_json.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -365,7 +365,7 @@ std::unique_ptr<column> struct_to_strings(table_view const& strings_columns,
   auto joined_col = make_strings_column(d_strviews, string_view{nullptr, 0}, stream, mr);
 
   // gather from offset and create a new string column
-  auto old_offsets = strings_column_view(joined_col->view()).offsets();
+  auto old_offsets = strings_column_view(joined_col->view(), stream).offsets();
   rmm::device_uvector<size_type> row_string_offsets(num_rows + 1, stream, mr);
   auto const d_strview_offsets = cudf::detail::make_counting_transform_iterator(
     0, cuda::proclaim_return_type<size_type>([num_strviews_per_row] __device__(size_type const i) {
@@ -524,7 +524,7 @@ std::unique_ptr<column> join_list_of_strings(lists_column_view const& lists_stri
   auto joined_col = make_strings_column(d_strviews, string_view{nullptr, 0}, stream, mr);
 
   // gather from offset and create a new string column
-  auto old_offsets = strings_column_view(joined_col->view()).offsets();
+  auto old_offsets = strings_column_view(joined_col->view(), stream).offsets();
   rmm::device_uvector<size_type> row_string_offsets(num_offsets, stream, mr);
   thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  d_strview_offsets.begin(),

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -271,7 +271,7 @@ size_t column_size(column_view const& column, rmm::cuda_stream_view stream)
   if (is_fixed_width(column.type())) {
     return size_of(column.type()) * column.size();
   } else if (column.type().id() == type_id::STRING) {
-    auto const scol = strings_column_view(column);
+    auto const scol = strings_column_view(column, stream);
     return cudf::strings::detail::get_offset_value(
              scol.offsets(), column.size() + column.offset(), stream) -
            cudf::strings::detail::get_offset_value(scol.offsets(), column.offset(), stream);

--- a/cpp/src/io/parquet/writer_impl_helpers.cpp
+++ b/cpp/src/io/parquet/writer_impl_helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -44,7 +44,7 @@ void fill_table_meta(table_input_metadata& table_meta)
   if (is_fixed_width(column.type())) {
     return size_of(column.type()) * column.size();
   } else if (column.type().id() == type_id::STRING) {
-    auto const scol = strings_column_view(column);
+    auto const scol = strings_column_view(column, stream);
     return cudf::strings::detail::get_offset_value(
              scol.offsets(), column.size() + column.offset(), stream) -
            cudf::strings::detail::get_offset_value(scol.offsets(), column.offset(), stream);

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -428,7 +428,7 @@ std::unique_ptr<column> column_merger::operator()<cudf::string_view>(
   rmm::device_async_resource_ref mr) const
 {
   return strings::detail::merge(
-    strings_column_view(lcol), strings_column_view(rcol), row_order_, stream, mr);
+    strings_column_view(lcol, stream), strings_column_view(rcol, stream), row_order_, stream, mr);
 }
 
 // specialization for dictionary

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -120,7 +120,7 @@ struct byte_list_conversion_fn<T, std::enable_if_t<std::is_same_v<T, cudf::strin
         input.size(), output_type, stream, mr);
     }
 
-    auto const num_chars = strings_column_view(input).chars_size(stream);
+    auto const num_chars = strings_column_view(input, stream).chars_size(stream);
     CUDF_EXPECTS(num_chars < static_cast<int64_t>(std::numeric_limits<size_type>::max()),
                  "Cannot convert strings column to lists column due to size_type limit",
                  std::overflow_error);

--- a/cpp/src/strings/combine/join_list_elements.cu
+++ b/cpp/src/strings/combine/join_list_elements.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -182,7 +182,7 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
   // lists column, not `get_sliced_child()`. This is because calling to `offsets_begin()` on the
   // lists column returns a pointer to the offsets of the original lists column, which may not start
   // from `0`.
-  auto const strings_col     = strings_column_view(lists_strings_column.child());
+  auto const strings_col     = strings_column_view(lists_strings_column.child(), stream);
   auto const lists_dv_ptr    = column_device_view::create(lists_strings_column.parent(), stream);
   auto const strings_dv_ptr  = column_device_view::create(strings_col.parent(), stream);
   auto const sep_dv          = get_scalar_device_view(const_cast<string_scalar&>(separator));
@@ -256,7 +256,7 @@ std::unique_ptr<column> join_list_elements(lists_column_view const& lists_string
   // lists column, not `get_sliced_child()`. This is because calling to `offsets_begin()` on the
   // lists column returns a pointer to the offsets of the original lists column, which may not start
   // from `0`.
-  auto const strings_col     = strings_column_view(lists_strings_column.child());
+  auto const strings_col     = strings_column_view(lists_strings_column.child(), stream);
   auto const lists_dv_ptr    = column_device_view::create(lists_strings_column.parent(), stream);
   auto const strings_dv_ptr  = column_device_view::create(strings_col.parent(), stream);
   auto const string_narep_dv = get_scalar_device_view(const_cast<string_scalar&>(string_narep));

--- a/cpp/src/strings/reverse.cu
+++ b/cpp/src/strings/reverse.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -56,7 +56,7 @@ std::unique_ptr<column> reverse(strings_column_view const& input,
 
   // copy the column; replace data in the chars column
   auto result          = std::make_unique<column>(input.parent(), stream, mr);
-  auto sv              = strings_column_view(result->view());
+  auto sv              = strings_column_view(result->view(), stream);
   auto const d_offsets = cudf::detail::offsetalator_factory::make_input_iterator(sv.offsets());
   auto d_chars         = result->mutable_view().head<char>();
 

--- a/cpp/src/strings/strings_column_view.cpp
+++ b/cpp/src/strings/strings_column_view.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,6 +14,16 @@ namespace cudf {
 strings_column_view::strings_column_view(column_view strings_column) : column_view(strings_column)
 {
   CUDF_EXPECTS(type().id() == type_id::STRING, "strings_column_view only supports strings");
+}
+
+strings_column_view::strings_column_view(column_view strings_column, rmm::cuda_stream_view stream)
+  : column_view(strings_column)
+{
+  CUDF_EXPECTS(type().id() == type_id::STRING, "strings_column_view only supports strings");
+  auto const [min_len, max_len] =
+    cudf::strings::detail::compute_min_max_string_lengths(*this, stream);
+  _min_length = min_len;
+  _max_length = max_len;
 }
 
 column_view strings_column_view::parent() const { return static_cast<column_view>(*this); }
@@ -40,6 +50,20 @@ strings_column_view::chars_iterator strings_column_view::chars_end(
   rmm::cuda_stream_view stream) const
 {
   return chars_begin(stream) + chars_size(stream);
+}
+
+int64_t strings_column_view::minimum() const
+{
+  CUDF_EXPECTS(_min_length >= 0,
+               "minimum() requires construction via strings_column_view(column_view, stream)");
+  return _min_length;
+}
+
+int64_t strings_column_view::maximum() const
+{
+  CUDF_EXPECTS(_max_length >= 0,
+               "maximum() requires construction via strings_column_view(column_view, stream)");
+  return _max_length;
 }
 
 }  // namespace cudf

--- a/cpp/src/strings/utilities.cu
+++ b/cpp/src/strings/utilities.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,7 +22,9 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
+#include <thrust/functional.h>
 #include <thrust/transform.h>
+#include <thrust/transform_reduce.h>
 
 #include <cstdlib>
 #include <string>
@@ -191,6 +193,40 @@ std::pair<int64_t, int64_t> get_first_and_last_offset(cudf::strings_column_view 
   auto const last_offset =
     cudf::strings::detail::get_offset_value(input.offsets(), input.size() + input.offset(), stream);
   return {first_offset, last_offset};
+}
+
+std::pair<int64_t, int64_t> compute_min_max_string_lengths(cudf::strings_column_view const& input,
+                                                           rmm::cuda_stream_view stream)
+{
+  if (input.is_empty()) { return {0L, 0L}; }
+
+  auto d_strings_owner = column_device_view::create(input.parent(), stream);
+  auto const d_strings = *d_strings_owner;
+  auto const n         = input.size();
+
+  auto size_fn = [d_strings] __device__(cudf::size_type i) -> int64_t {
+    return d_strings.is_null(i)
+             ? int64_t{0}
+             : static_cast<int64_t>(d_strings.element<cudf::string_view>(i).size_bytes());
+  };
+
+  auto const itr     = cuda::counting_iterator<cudf::size_type>{0};
+  auto const max_len = thrust::transform_reduce(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    itr,
+    itr + n,
+    size_fn,
+    int64_t{0},
+    cuda::maximum<int64_t>{});
+  auto const min_len = thrust::transform_reduce(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    itr,
+    itr + n,
+    size_fn,
+    max_len,
+    cuda::minimum<int64_t>{});
+
+  return {min_len, max_len};
 }
 
 }  // namespace detail

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -231,11 +231,13 @@ character_normalizer::character_normalizer(bool do_lower_case,
     cudf::sort(cudf::table_view({special_tokens.parent()}), {}, {}, stream)->release().front());
   if (do_lower_case) {
     // lower-case the tokens so they will match the normalized input
-    sorted = cudf::strings::to_lower(cudf::strings_column_view(sorted->view()), stream);
+    sorted = cudf::strings::to_lower(cudf::strings_column_view(sorted->view(), stream), stream);
   }
 
   auto tokens_view = cudf::strings::detail::create_string_vector_from_column(
-    cudf::strings_column_view(sorted->view()), stream, cudf::get_current_device_resource_ref());
+    cudf::strings_column_view(sorted->view(), stream),
+    stream,
+    cudf::get_current_device_resource_ref());
 
   _impl = std::make_unique<character_normalizer_impl>(std::move(cp_metadata),
                                                       std::move(aux_table),

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -602,6 +602,7 @@ ConfigureTest(
   strings/integers_tests.cpp
   strings/ipv4_tests.cpp
   strings/like_tests.cpp
+  strings/max_min_tests.cpp
   strings/pad_tests.cpp
   strings/repeat_strings_tests.cpp
   strings/replace_regex_tests.cpp

--- a/cpp/tests/strings/max_min_tests.cpp
+++ b/cpp/tests/strings/max_min_tests.cpp
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+struct StringsMinMaxTest : public cudf::test::BaseFixture {};
+
+TEST_F(StringsMinMaxTest, Basic)
+{
+  cudf::test::strings_column_wrapper strings({"hello", "world!", "a", "four"});
+  auto view = cudf::strings_column_view(strings, cudf::get_default_stream());
+
+  // "a" is 1 byte, "world!" is 6 bytes
+  EXPECT_EQ(view.minimum(), 1L);
+  EXPECT_EQ(view.maximum(), 6L);
+}
+
+TEST_F(StringsMinMaxTest, AllSameLength)
+{
+  cudf::test::strings_column_wrapper strings({"abc", "def", "ghi"});
+  auto view = cudf::strings_column_view(strings, cudf::get_default_stream());
+
+  EXPECT_EQ(view.minimum(), 3L);
+  EXPECT_EQ(view.maximum(), 3L);
+}
+
+TEST_F(StringsMinMaxTest, WithNulls)
+{
+  // Null entries count as zero-length strings
+  cudf::test::strings_column_wrapper strings({"hello", "world", "!"}, {true, false, true});
+  auto view = cudf::strings_column_view(strings, cudf::get_default_stream());
+
+  EXPECT_EQ(view.minimum(), 0L);
+  EXPECT_EQ(view.maximum(), 5L);
+}
+
+TEST_F(StringsMinMaxTest, AllNulls)
+{
+  cudf::test::strings_column_wrapper strings({"a", "bb"}, {false, false});
+  auto view = cudf::strings_column_view(strings, cudf::get_default_stream());
+
+  EXPECT_EQ(view.minimum(), 0L);
+  EXPECT_EQ(view.maximum(), 0L);
+}
+
+TEST_F(StringsMinMaxTest, EmptyColumn)
+{
+  cudf::test::strings_column_wrapper strings{};
+  auto view = cudf::strings_column_view(strings, cudf::get_default_stream());
+
+  EXPECT_EQ(view.minimum(), 0L);
+  EXPECT_EQ(view.maximum(), 0L);
+}
+
+TEST_F(StringsMinMaxTest, SingleElement)
+{
+  cudf::test::strings_column_wrapper strings({"hello"});
+  auto view = cudf::strings_column_view(strings, cudf::get_default_stream());
+
+  EXPECT_EQ(view.minimum(), 5L);
+  EXPECT_EQ(view.maximum(), 5L);
+}
+
+TEST_F(StringsMinMaxTest, EmptyStrings)
+{
+  // Empty strings have 0 bytes
+  cudf::test::strings_column_wrapper strings({"", "abc", ""});
+  auto view = cudf::strings_column_view(strings, cudf::get_default_stream());
+
+  EXPECT_EQ(view.minimum(), 0L);
+  EXPECT_EQ(view.maximum(), 3L);
+}
+
+TEST_F(StringsMinMaxTest, UnicodeMulitbyteChars)
+{
+  // "é" is 2 bytes in UTF-8, "日" is 3 bytes
+  cudf::test::strings_column_wrapper strings({"é", "日", "a"});
+  auto view = cudf::strings_column_view(strings, cudf::get_default_stream());
+
+  EXPECT_EQ(view.minimum(), 1L);
+  EXPECT_EQ(view.maximum(), 3L);
+}
+
+TEST_F(StringsMinMaxTest, NotComputedThrows)
+{
+  // Constructing without a stream leaves min/max uncomputed; accessors must throw.
+  cudf::test::strings_column_wrapper strings({"hello", "world"});
+  auto view = cudf::strings_column_view(strings);
+
+  EXPECT_THROW((void)view.minimum(), cudf::logic_error);
+  EXPECT_THROW((void)view.maximum(), cudf::logic_error);
+}


### PR DESCRIPTION
## Description
This change adds minimum and maximum string length functions to string_column_view. This is to make the implementation of https://github.com/rapidsai/cudf/pull/21917 easier, as we want to case on the minimum and maximum lengths of the string.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
