### PR TITLE
fix(pre-commit): normalize SPDX handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -220,7 +220,7 @@ repos:
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.5.1
+    rev: v1.6.0
     hooks:
       - id: verify-copyright
         name: verify-copyright-cudf

--- a/cpp/libcudf_streaming/benchmarks/bench_pack.cpp
+++ b/cpp/libcudf_streaming/benchmarks/bench_pack.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "utils/random_data.hpp"

--- a/cpp/libcudf_streaming/benchmarks/bench_partition.cpp
+++ b/cpp/libcudf_streaming/benchmarks/bench_partition.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf/column/column.hpp>

--- a/cpp/libcudf_streaming/benchmarks/streaming/data_generator.hpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/data_generator.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/bench_read.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/bench_read.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 #include "utils.hpp"
 

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/concatenate.hpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/concatenate.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/groupby.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/groupby.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "groupby.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/groupby.hpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/groupby.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/join.hpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/join.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/parquet_writer.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/parquet_writer.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "parquet_writer.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/parquet_writer.hpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/parquet_writer.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q09.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q09.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "concatenate.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/sort.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/sort.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "sort.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/sort.hpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/sort.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/utils.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/utils.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "utils.hpp"

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/utils.hpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/utils.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/benchmarks/utils/comm.hpp
+++ b/cpp/libcudf_streaming/benchmarks/utils/comm.hpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/benchmarks/utils/misc.hpp
+++ b/cpp/libcudf_streaming/benchmarks/utils/misc.hpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 

--- a/cpp/libcudf_streaming/benchmarks/utils/random_data.cu
+++ b/cpp/libcudf_streaming/benchmarks/utils/random_data.cu
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "random_data.hpp"

--- a/cpp/libcudf_streaming/benchmarks/utils/random_data.hpp
+++ b/cpp/libcudf_streaming/benchmarks/utils/random_data.hpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 

--- a/cpp/libcudf_streaming/examples/example_shuffle.cpp
+++ b/cpp/libcudf_streaming/examples/example_shuffle.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../benchmarks/utils/random_data.hpp"

--- a/cpp/libcudf_streaming/include/cudf_streaming/bloom_filter.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/bloom_filter.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/include/cudf_streaming/detail/device_bloom_filter.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/detail/device_bloom_filter.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/include/cudf_streaming/parquet.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/parquet.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/include/cudf_streaming/partition.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/partition.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/include/cudf_streaming/partition_utils.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/partition_utils.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 

--- a/cpp/libcudf_streaming/include/cudf_streaming/table_chunk.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/table_chunk.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/include/cudf_streaming/utils.hpp
+++ b/cpp/libcudf_streaming/include/cudf_streaming/utils.hpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 

--- a/cpp/libcudf_streaming/src/detail/device_bloom_filter.cu
+++ b/cpp/libcudf_streaming/src/detail/device_bloom_filter.cu
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cuda_runtime_api.h>

--- a/cpp/libcudf_streaming/src/partition_utils.cpp
+++ b/cpp/libcudf_streaming/src/partition_utils.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf/concatenate.hpp>

--- a/cpp/libcudf_streaming/src/table_chunk.cpp
+++ b/cpp/libcudf_streaming/src/table_chunk.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf/contiguous_split.hpp>

--- a/cpp/libcudf_streaming/src/utils.cpp
+++ b/cpp/libcudf_streaming/src/utils.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf/contiguous_split.hpp>

--- a/cpp/libcudf_streaming/tests/main/mpi.cpp
+++ b/cpp/libcudf_streaming/tests/main/mpi.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../environment.hpp"

--- a/cpp/libcudf_streaming/tests/main/ucxx.cpp
+++ b/cpp/libcudf_streaming/tests/main/ucxx.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../environment.hpp"

--- a/cpp/libcudf_streaming/tests/streaming/base_streaming_fixture.hpp
+++ b/cpp/libcudf_streaming/tests/streaming/base_streaming_fixture.hpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/libcudf_streaming/tests/streaming/test_cudf_utils.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_cudf_utils.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf_test/base_fixture.hpp>

--- a/cpp/libcudf_streaming/tests/streaming/test_leaf_actor.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_leaf_actor.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../utils.hpp"

--- a/cpp/libcudf_streaming/tests/streaming/test_partition.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_partition.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../utils.hpp"

--- a/cpp/libcudf_streaming/tests/streaming/test_shuffler.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_shuffler.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../utils.hpp"

--- a/cpp/libcudf_streaming/tests/streaming/test_table_chunk.cpp
+++ b/cpp/libcudf_streaming/tests/streaming/test_table_chunk.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../utils.hpp"

--- a/cpp/libcudf_streaming/tests/test_partition.cpp
+++ b/cpp/libcudf_streaming/tests/test_partition.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "utils.hpp"

--- a/cpp/libcudf_streaming/tests/utils.hpp
+++ b/cpp/libcudf_streaming/tests/utils.hpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/303.

Standardizes clang-format's SPDX protection and ensures the repository uses `rapidsai/pre-commit-hooks` `v1.6.0`. It also restores malformed SPDX headers where present.

Validated with `pre-commit run --all-files`.
