### PR TITLE
Fix cuco::extent type for comparator_helper key_set in distinct_count

### DIFF
--- a/cpp/src/reductions/distinct_count.cu
+++ b/cpp/src/reductions/distinct_count.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -143,7 +143,7 @@ cudf::size_type distinct_count(table_view const& keys,
 
   auto const comparator_helper = [&](auto const row_equal) {
     using hasher_type = decltype(hash_key);
-    auto key_set      = cuco::static_set{cuco::extent{num_rows},
+    auto key_set      = cuco::static_set{cuco::extent{static_cast<std::size_t>(num_rows)},
                                     cudf::detail::CUCO_DESIRED_LOAD_FACTOR,
                                     cuco::empty_key<cudf::size_type>{-1},
                                     row_equal,


### PR DESCRIPTION
## Description
Fixes an integer overflow found in the `join_heuristic` JOIN_NVBENCH benchmark.

Reproducer: 
```
benchmarks/JOIN_NVBENCH -d 0 -b join_heuristics --axis Nullable=0 --axis DataType=INT64 --axis Method=DISTINCT_COUNT --axis Cardinality=LOW_UNIQUE --axis num_rows=100000000 --axis num_keys=3

```

This was causing OOB memory access which failed in the benchmark.
Reference: https://github.com/rapidsai/cudf/actions/runs/29230593320/job/86753754739

Adding a cast to `std::size_t` to the `cuco::extent` parameter in the `cuco::static_set` used by the `distinct_count` function fixes the error. The probing scheme used by cuco uses this type for slot indices. Some int32 hash values may be negative making the modulo result also negative.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
