### PR TITLE
Fix benchmark generate_input create_ascii_string_column function signature

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -1101,7 +1101,7 @@ std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
 
 std::unique_ptr<cudf::column> create_ascii_string_column(data_profile const& profile,
                                                          cudf::size_type num_rows,
-                                                         unsigned seed = 1)
+                                                         unsigned seed)
 {
   auto engine = deterministic_engine(seed);
   return create_random_utf8_string_column<string_encoding::ASCII>(profile, engine, num_rows);

--- a/cpp/benchmarks/common/generate_input.hpp
+++ b/cpp/benchmarks/common/generate_input.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -701,12 +701,12 @@ std::unique_ptr<cudf::column> create_string_column(cudf::size_type num_rows,
 /**
  * @brief Generates an string column filled with ASCII characters only
  *
- * @param num_rows Number of rows in the output column
  * @param profile Data profile for the output column
+ * @param num_rows Number of rows in the output column
  * @param seed Optional, seed for the pseudo-random engine
  */
-std::unique_ptr<cudf::column> create_ascii_string_column(cudf::size_type num_rows,
-                                                         data_profile const& profile,
+std::unique_ptr<cudf::column> create_ascii_string_column(data_profile const& profile,
+                                                         cudf::size_type num_rows,
                                                          unsigned seed = 1);
 
 /**


### PR DESCRIPTION
## Description
Fixes the `create_ascii_string_column()` function signature in `cpp/benchmarks/common/generate_input.hpp` to match the corresponding implementation signature in `generate_input.cu`.
This function is not yet being used but is planned for use in some nvtext functions in the future.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
