### PR TITLE
Change cuco::extent type usage from size_type to size_t

### DIFF
--- a/cpp/src/io/json/json_tree.cu
+++ b/cpp/src/io/json/json_tree.cu
@@ -682,7 +682,7 @@ rmm::device_uvector<size_type> hash_node_type_with_field_name(device_span<Symbol
   auto get_utf8_matched_field_nodes = [&]() {
     auto make_map = [&stream](auto num_keys) {
       using hasher_type3 = cudf::hashing::detail::default_hash<size_type>;
-      return cuco::static_map{cuco::extent{num_keys},
+      return cuco::static_map{cuco::extent{static_cast<std::size_t>(num_keys)},
                               1.0,  // 100% load factor
                               cuco::empty_key{empty_node_index_sentinel},
                               cuco::empty_value{empty_node_index_sentinel},

--- a/cpp/src/search/contains_table_impl.cuh
+++ b/cpp/src/search/contains_table_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -133,7 +133,7 @@ void perform_contains(table_view const& haystack,
       return lhs_index_type{idx};
     }));
 
-  auto set = cuco::static_set{cuco::extent{haystack.num_rows()},
+  auto set = cuco::static_set{cuco::extent{static_cast<std::size_t>(haystack.num_rows())},
                               cudf::detail::CUCO_DESIRED_LOAD_FACTOR,
                               cuco::empty_key{rhs_index_type{-1}},
                               d_equal,


### PR DESCRIPTION
## Description
Changes usages of `cuco::extent` to use `std::size_t` type instead of `cudf::size_type` to ensure slot indices do not overflow int.

Follow on to #23236 -- PR fixes a couple more places that match this though they do not currently manifest any errors.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
