### PR TITLE
Use batched memcpy instead of a custom copy kernel

### DIFF
--- a/cpp/src/io/comp/decompression.cpp
+++ b/cpp/src/io/comp/decompression.cpp
@@ -584,6 +584,7 @@ void host_decompress(compression_type compression,
     h_results[i] = {tasks[i].get(), codec_status::SUCCESS};
   }
 
+  cudf::detail::join_streams(streams, stream);
   cudf::detail::cuda_memcpy<codec_exec_result>(results, h_results, stream);
 }
 

--- a/cpp/src/io/comp/gpuinflate.cu
+++ b/cpp/src/io/comp/gpuinflate.cu
@@ -1145,65 +1145,6 @@ CUDF_KERNEL void __launch_bounds__(block_size)
   }
 }
 
-/**
- * @brief Copy a group of buffers
- *
- * blockDim {1024,1,1}
- *
- * @param inputs Source and destination information per block
- */
-CUDF_KERNEL void __launch_bounds__(1024)
-  copy_uncompressed_kernel(device_span<device_span<uint8_t const> const> inputs,
-                           device_span<device_span<uint8_t> const> outputs)
-{
-  __shared__ uint8_t const* volatile src_g;
-  __shared__ uint8_t* volatile dst_g;
-  __shared__ uint32_t volatile copy_len_g;
-
-  uint32_t t = threadIdx.x;
-  uint32_t z = blockIdx.x;
-  uint8_t const* src;
-  uint8_t* dst;
-  uint32_t len, src_align_bytes, src_align_bits, dst_align_bytes;
-
-  if (!t) {
-    src        = inputs[z].data();
-    dst        = outputs[z].data();
-    len        = static_cast<uint32_t>(min(inputs[z].size(), outputs[z].size()));
-    src_g      = src;
-    dst_g      = dst;
-    copy_len_g = len;
-  }
-  __syncthreads();
-  src = src_g;
-  dst = dst_g;
-  len = copy_len_g;
-  // Align output to 32-bit
-  dst_align_bytes = 3 & -reinterpret_cast<intptr_t>(dst);
-  if (dst_align_bytes != 0) {
-    uint32_t align_len = min(dst_align_bytes, len);
-    if (t < align_len) { dst[t] = src[t]; }
-    src += align_len;
-    dst += align_len;
-    len -= align_len;
-  }
-  src_align_bytes = (uint32_t)(3 & reinterpret_cast<uintptr_t>(src));
-  src_align_bits  = src_align_bytes << 3;
-  while (len >= 32) {
-    auto const* src32 = reinterpret_cast<uint32_t const*>(src - src_align_bytes);
-    uint32_t copy_cnt = min(len >> 2, 1024);
-    if (t < copy_cnt) {
-      uint32_t v = src32[t];
-      if (src_align_bits != 0) { v = __funnelshift_r(v, src32[t + 1], src_align_bits); }
-      reinterpret_cast<uint32_t*>(dst)[t] = v;
-    }
-    src += copy_cnt * 4;
-    dst += copy_cnt * 4;
-    len -= copy_cnt * 4;
-  }
-  if (t < len) { dst[t] = src[t]; }
-}
-
 enum class task_type { DECOMPRESSION, COMPRESSION };
 
 class cost_model {
@@ -1370,17 +1311,6 @@ void gpuinflate(device_span<device_span<uint8_t const> const> inputs,
   if (inputs.size() > 0) {
     inflate_kernel_no_racecheck<block_size>
       <<<inputs.size(), block_size, 0, stream.value()>>>(inputs, outputs, results, parse_hdr);
-    CUDF_CUDA_TRY(cudaGetLastError());
-  }
-}
-
-void gpu_copy_uncompressed_blocks(device_span<device_span<uint8_t const> const> inputs,
-                                  device_span<device_span<uint8_t> const> outputs,
-                                  rmm::cuda_stream_view stream)
-{
-  constexpr auto block_size = 1024;
-  if (inputs.size() > 0) {
-    copy_uncompressed_kernel<<<inputs.size(), block_size, 0, stream.value()>>>(inputs, outputs);
     CUDF_CUDA_TRY(cudaGetLastError());
   }
 }

--- a/cpp/src/io/comp/gpuinflate.hpp
+++ b/cpp/src/io/comp/gpuinflate.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/io/comp/gpuinflate.hpp
+++ b/cpp/src/io/comp/gpuinflate.hpp
@@ -40,17 +40,6 @@ void gpuinflate(device_span<device_span<uint8_t const> const> inputs,
                 rmm::cuda_stream_view stream);
 
 /**
- * @brief Interface for copying uncompressed byte blocks
- *
- * @param[in] inputs List of input buffers
- * @param[out] outputs List of output buffers
- * @param[in] stream CUDA stream to use
- */
-void gpu_copy_uncompressed_blocks(device_span<device_span<uint8_t const> const> inputs,
-                                  device_span<device_span<uint8_t> const> outputs,
-                                  rmm::cuda_stream_view stream);
-
-/**
  * @brief Interface for decompressing Snappy-compressed data
  *
  * Multiple, independent chunks of compressed data can be decompressed by using

--- a/cpp/src/io/orc/reader_impl_decode.cu
+++ b/cpp/src/io/orc/reader_impl_decode.cu
@@ -16,6 +16,7 @@
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/structs/utilities.hpp>
 #include <cudf/detail/transform.hpp>
+#include <cudf/detail/utilities/batched_memcpy.hpp>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/io/config_utils.hpp>
@@ -203,12 +204,23 @@ rmm::device_buffer decompress_stripe_data(
                    });
 
   if (num_uncompressed_blocks > 0) {
-    cudf::io::detail::gpu_copy_uncompressed_blocks(
-      device_span<device_span<uint8_t const>>{inflate_in.data() + num_compressed_blocks,
-                                              num_uncompressed_blocks},
-      device_span<device_span<uint8_t>>{inflate_out.data() + num_compressed_blocks,
-                                        num_uncompressed_blocks},
-      stream);
+    auto const inputs   = inflate_in.data() + num_compressed_blocks;
+    auto const outputs  = inflate_out.data() + num_compressed_blocks;
+    auto const src_iter = cuda::make_transform_iterator(
+      cuda::counting_iterator<std::size_t>{0},
+      cuda::proclaim_return_type<uint8_t const*>(
+        [inputs] __device__(std::size_t i) { return inputs[i].data(); }));
+    auto const dst_iter = cuda::make_transform_iterator(
+      cuda::counting_iterator<std::size_t>{0},
+      cuda::proclaim_return_type<uint8_t*>(
+        [outputs] __device__(std::size_t i) { return outputs[i].data(); }));
+    auto const size_iter = cuda::make_transform_iterator(
+      cuda::counting_iterator<std::size_t>{0},
+      cuda::proclaim_return_type<size_t>([inputs, outputs] __device__(std::size_t i) {
+        return inputs[i].size() < outputs[i].size() ? inputs[i].size() : outputs[i].size();
+      }));
+    cudf::detail::batched_memcpy_async(
+      src_iter, dst_iter, size_iter, num_uncompressed_blocks, stream);
   }
 
   // Copy without stream sync, thus need to wait for stream sync below to access.

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -13,6 +13,7 @@
 #include <cudf/detail/algorithms/reduce.cuh>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/utilities/batched_memcpy.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -622,7 +623,21 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
     auto const d_copy_out = cudf::detail::make_device_uvector_async(
       copy_out, stream, cudf::get_current_device_resource_ref());
 
-    cudf::io::detail::gpu_copy_uncompressed_blocks(d_copy_in, d_copy_out, stream);
+    auto const src_iter = cudf::detail::make_counting_transform_iterator(
+      size_type{0},
+      cuda::proclaim_return_type<uint8_t const*>(
+        [inputs = d_copy_in.data()] __device__(size_type i) { return inputs[i].data(); }));
+    auto const dst_iter = cudf::detail::make_counting_transform_iterator(
+      size_type{0},
+      cuda::proclaim_return_type<uint8_t*>(
+        [outputs = d_copy_out.data()] __device__(size_type i) { return outputs[i].data(); }));
+    auto const size_iter = cudf::detail::make_counting_transform_iterator(
+      size_type{0},
+      cuda::proclaim_return_type<size_t>(
+        [inputs = d_copy_in.data(), outputs = d_copy_out.data()] __device__(size_type i) {
+          return inputs[i].size() < outputs[i].size() ? inputs[i].size() : outputs[i].size();
+        }));
+    cudf::detail::batched_memcpy_async(src_iter, dst_iter, size_iter, d_copy_in.size(), stream);
   }
 
   CUDF_EXPECTS(

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -617,7 +617,7 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
     start_pos += codec.num_pages;
   }
   // now copy the uncompressed V2 def and rep level data
-  if (not copy_in.empty()) {
+  if (curr_copy_page > 0) {
     auto const d_copy_in = cudf::detail::make_device_uvector_async(
       copy_in, stream, cudf::get_current_device_resource_ref());
     auto const d_copy_out = cudf::detail::make_device_uvector_async(
@@ -637,7 +637,7 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
         [inputs = d_copy_in.data(), outputs = d_copy_out.data()] __device__(size_type i) {
           return inputs[i].size() < outputs[i].size() ? inputs[i].size() : outputs[i].size();
         }));
-    cudf::detail::batched_memcpy_async(src_iter, dst_iter, size_iter, d_copy_in.size(), stream);
+    cudf::detail::batched_memcpy_async(src_iter, dst_iter, size_iter, curr_copy_page, stream);
   }
 
   CUDF_EXPECTS(


### PR DESCRIPTION
## Description

This PR replaces the use of custom  `gpu_copy_uncompressed_blocks` kernel with the batched memcpy utility from CUB. See comments [1](https://github.com/rapidsai/cudf/pull/23266#issuecomment-4973348403) and [2](https://github.com/rapidsai/cudf/pull/23266#issuecomment-4973396753) for (no) performance impact from this change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
