### PR TITLE
Use setters in IO options builders instead of directly modifying the data members

### DIFF
--- a/cpp/include/cudf/io/avro.hpp
+++ b/cpp/include/cudf/io/avro.hpp
@@ -154,7 +154,7 @@ class avro_reader_options_builder {
    */
   avro_reader_options_builder& columns(std::vector<std::string> col_names)
   {
-    options._columns = std::move(col_names);
+    options.set_columns(std::move(col_names));
     return *this;
   }
 
@@ -166,7 +166,7 @@ class avro_reader_options_builder {
    */
   avro_reader_options_builder& skip_rows(size_type val)
   {
-    options._skip_rows = val;
+    options.set_skip_rows(val);
     return *this;
   }
 
@@ -178,7 +178,7 @@ class avro_reader_options_builder {
    */
   avro_reader_options_builder& num_rows(size_type val)
   {
-    options._num_rows = val;
+    options.set_num_rows(val);
     return *this;
   }
 

--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -535,7 +535,7 @@ class csv_reader_options {
    *
    * @param pfx String used as prefix in for each column name
    */
-  void set_prefix(std::string pfx) { _prefix = pfx; }
+  void set_prefix(std::string pfx) { _prefix = std::move(pfx); }
 
   /**
    * @brief Sets whether to rename duplicate column names.
@@ -867,7 +867,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& compression(compression_type comp)
   {
-    options._compression = comp;
+    options.set_compression(comp);
     return *this;
   }
 
@@ -903,7 +903,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& names(std::vector<std::string> col_names)
   {
-    options._names = std::move(col_names);
+    options.set_names(std::move(col_names));
     return *this;
   }
 
@@ -915,7 +915,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& prefix(std::string pfx)
   {
-    options._prefix = std::move(pfx);
+    options.set_prefix(std::move(pfx));
     return *this;
   }
 
@@ -927,7 +927,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& mangle_dupe_cols(bool val)
   {
-    options._mangle_dupe_cols = val;
+    options.enable_mangle_dupe_cols(val);
     return *this;
   }
 
@@ -939,7 +939,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& use_cols_names(std::vector<std::string> col_names)
   {
-    options._use_cols_names = std::move(col_names);
+    options.set_use_cols_names(std::move(col_names));
     return *this;
   }
 
@@ -951,7 +951,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& use_cols_indexes(std::vector<int> col_indices)
   {
-    options._use_cols_indexes = std::move(col_indices);
+    options.set_use_cols_indexes(std::move(col_indices));
     return *this;
   }
 
@@ -999,7 +999,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& header(size_type hdr)
   {
-    options._header = hdr;
+    options.set_header(hdr);
     return *this;
   }
 
@@ -1011,7 +1011,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& lineterminator(char term)
   {
-    options._lineterminator = term;
+    options.set_lineterminator(term);
     return *this;
   }
 
@@ -1023,7 +1023,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& delimiter(char delim)
   {
-    options._delimiter = delim;
+    options.set_delimiter(delim);
     return *this;
   }
 
@@ -1035,7 +1035,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& thousands(char val)
   {
-    options._thousands = val;
+    options.set_thousands(val);
     return *this;
   }
 
@@ -1047,7 +1047,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& decimal(char val)
   {
-    options._decimal = val;
+    options.set_decimal(val);
     return *this;
   }
 
@@ -1059,7 +1059,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& comment(char val)
   {
-    options._comment = val;
+    options.set_comment(val);
     return *this;
   }
 
@@ -1071,7 +1071,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& windowslinetermination(bool val)
   {
-    options._windowslinetermination = val;
+    options.enable_windowslinetermination(val);
     return *this;
   }
 
@@ -1083,7 +1083,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& delim_whitespace(bool val)
   {
-    options._delim_whitespace = val;
+    options.enable_delim_whitespace(val);
     return *this;
   }
 
@@ -1095,7 +1095,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& skipinitialspace(bool val)
   {
-    options._skipinitialspace = val;
+    options.enable_skipinitialspace(val);
     return *this;
   }
 
@@ -1107,7 +1107,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& skip_blank_lines(bool val)
   {
-    options._skip_blank_lines = val;
+    options.enable_skip_blank_lines(val);
     return *this;
   }
 
@@ -1119,7 +1119,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& quoting(quote_style style)
   {
-    options._quoting = style;
+    options.set_quoting(style);
     return *this;
   }
 
@@ -1131,7 +1131,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& quotechar(char ch)
   {
-    options._quotechar = ch;
+    options.set_quotechar(ch);
     return *this;
   }
 
@@ -1143,7 +1143,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& doublequote(bool val)
   {
-    options._doublequote = val;
+    options.enable_doublequote(val);
     return *this;
   }
 
@@ -1156,7 +1156,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& detect_whitespace_around_quotes(bool val)
   {
-    options._detect_whitespace_around_quotes = val;
+    options.enable_detect_whitespace_around_quotes(val);
     return *this;
   }
 
@@ -1168,7 +1168,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& parse_dates(std::vector<std::string> col_names)
   {
-    options._parse_dates_names = std::move(col_names);
+    options.set_parse_dates(std::move(col_names));
     return *this;
   }
 
@@ -1180,7 +1180,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& parse_dates(std::vector<int> col_indices)
   {
-    options._parse_dates_indexes = std::move(col_indices);
+    options.set_parse_dates(std::move(col_indices));
     return *this;
   }
 
@@ -1192,7 +1192,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& parse_hex(std::vector<std::string> col_names)
   {
-    options._parse_hex_names = std::move(col_names);
+    options.set_parse_hex(std::move(col_names));
     return *this;
   }
 
@@ -1204,7 +1204,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& parse_hex(std::vector<int> col_indices)
   {
-    options._parse_hex_indexes = std::move(col_indices);
+    options.set_parse_hex(std::move(col_indices));
     return *this;
   }
 
@@ -1216,7 +1216,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& dtypes(std::map<std::string, data_type> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -1228,7 +1228,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& dtypes(std::vector<data_type> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -1240,7 +1240,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& true_values(std::vector<std::string> vals)
   {
-    options._true_values.insert(options._true_values.end(), vals.begin(), vals.end());
+    options.set_true_values(std::move(vals));
     return *this;
   }
 
@@ -1252,7 +1252,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& false_values(std::vector<std::string> vals)
   {
-    options._false_values.insert(options._false_values.end(), vals.begin(), vals.end());
+    options.set_false_values(std::move(vals));
     return *this;
   }
 
@@ -1300,7 +1300,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& dayfirst(bool val)
   {
-    options._dayfirst = val;
+    options.enable_dayfirst(val);
     return *this;
   }
 
@@ -1312,7 +1312,7 @@ class csv_reader_options_builder {
    */
   csv_reader_options_builder& timestamp_type(data_type type)
   {
-    options._timestamp_type = type;
+    options.set_timestamp_type(type);
     return *this;
   }
 
@@ -1619,7 +1619,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& names(std::vector<std::string> names)
   {
-    options._names = names;
+    options.set_names(std::move(names));
     return *this;
   }
 
@@ -1631,7 +1631,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& na_rep(std::string val)
   {
-    options._na_rep = val;
+    options.set_na_rep(std::move(val));
     return *this;
   };
 
@@ -1643,7 +1643,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& include_header(bool val)
   {
-    options._include_header = val;
+    options.enable_include_header(val);
     return *this;
   }
 
@@ -1655,7 +1655,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& rows_per_chunk(int val)
   {
-    options._rows_per_chunk = val;
+    options.set_rows_per_chunk(val);
     return *this;
   }
 
@@ -1667,7 +1667,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& line_terminator(std::string term)
   {
-    options._line_terminator = term;
+    options.set_line_terminator(std::move(term));
     return *this;
   }
 
@@ -1679,7 +1679,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& inter_column_delimiter(char delim)
   {
-    options._inter_column_delimiter = delim;
+    options.set_inter_column_delimiter(delim);
     return *this;
   }
 
@@ -1691,7 +1691,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& true_value(std::string val)
   {
-    options._true_value = val;
+    options.set_true_value(std::move(val));
     return *this;
   }
 
@@ -1703,7 +1703,7 @@ class csv_writer_options_builder {
    */
   csv_writer_options_builder& false_value(std::string val)
   {
-    options._false_value = val;
+    options.set_false_value(std::move(val));
     return *this;
   }
 

--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -685,17 +685,16 @@ class csv_reader_options {
   /**
    * @brief Sets the expected quoting style used in the input CSV data.
    *
-   * Note: Only the following quoting styles are supported:
-   *   1. MINIMAL: String columns containing special characters like row-delimiters/
-   *               field-delimiter/quotes will be quoted.
-   *   2. NONE: No quoting is done for any columns.
+   * The reader accepts all defined quoting styles. `NONE` disables quotation parsing; all other
+   * styles enable it.
    *
    * @param quoting Quoting style used
    */
   void set_quoting(quote_style quoting)
   {
-    CUDF_EXPECTS(quoting == quote_style::MINIMAL || quoting == quote_style::NONE,
-                 "Only MINIMAL and NONE are supported for quoting.");
+    CUDF_EXPECTS(quoting == quote_style::MINIMAL || quoting == quote_style::ALL ||
+                   quoting == quote_style::NONNUMERIC || quoting == quote_style::NONE,
+                 "Unsupported quoting style.");
     _quoting = quoting;
   }
 

--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -614,7 +614,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& dtypes(std::vector<data_type> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -626,7 +626,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& dtypes(std::map<std::string, data_type> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -638,7 +638,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& dtypes(std::map<std::string, schema_element> types)
   {
-    options._dtypes = std::move(types);
+    options.set_dtypes(std::move(types));
     return *this;
   }
 
@@ -662,7 +662,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& compression(compression_type comp_type)
   {
-    options._compression = comp_type;
+    options.set_compression(comp_type);
     return *this;
   }
 
@@ -674,7 +674,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& byte_range_offset(size_type offset)
   {
-    options._byte_range_offset = offset;
+    options.set_byte_range_offset(offset);
     return *this;
   }
 
@@ -686,7 +686,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& byte_range_size(size_type size)
   {
-    options._byte_range_size = size;
+    options.set_byte_range_size(size);
     return *this;
   }
 
@@ -710,7 +710,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& lines(bool val)
   {
-    options._lines = val;
+    options.enable_lines(val);
     return *this;
   }
 
@@ -723,7 +723,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& mixed_types_as_string(bool val)
   {
-    options._mixed_types_as_string = val;
+    options.enable_mixed_types_as_string(val);
     return *this;
   }
 
@@ -739,7 +739,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& prune_columns(bool val)
   {
-    options._prune_columns = val;
+    options.enable_prune_columns(val);
     return *this;
   }
 
@@ -754,7 +754,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& experimental(bool val)
   {
-    options._experimental = val;
+    options.enable_experimental(val);
     return *this;
   }
 
@@ -766,7 +766,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& dayfirst(bool val)
   {
-    options._dayfirst = val;
+    options.enable_dayfirst(val);
     return *this;
   }
 
@@ -779,7 +779,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& keep_quotes(bool val)
   {
-    options._keep_quotes = val;
+    options.enable_keep_quotes(val);
     return *this;
   }
 
@@ -792,7 +792,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& normalize_single_quotes(bool val)
   {
-    options._normalize_single_quotes = val;
+    options.enable_normalize_single_quotes(val);
     return *this;
   }
 
@@ -805,7 +805,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& normalize_whitespace(bool val)
   {
-    options._normalize_whitespace = val;
+    options.enable_normalize_whitespace(val);
     return *this;
   }
 
@@ -817,7 +817,7 @@ class json_reader_options_builder {
    */
   json_reader_options_builder& recovery_mode(json_recovery_mode_t val)
   {
-    options._recovery_mode = val;
+    options.set_recovery_mode(val);
     return *this;
   }
 
@@ -1302,7 +1302,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& table(table_view tbl)
   {
-    options._table = tbl;
+    options.set_table(tbl);
     return *this;
   }
 
@@ -1314,7 +1314,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& compression(compression_type comptype)
   {
-    options._compression = comptype;
+    options.set_compression(comptype);
     return *this;
   }
 
@@ -1326,7 +1326,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& metadata(table_metadata metadata)
   {
-    options._metadata = std::move(metadata);
+    options.set_metadata(std::move(metadata));
     return *this;
   }
 
@@ -1338,7 +1338,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& na_rep(std::string val)
   {
-    options._na_rep = std::move(val);
+    options.set_na_rep(std::move(val));
     return *this;
   };
 
@@ -1350,7 +1350,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& include_nulls(bool val)
   {
-    options._include_nulls = val;
+    options.enable_include_nulls(val);
     return *this;
   }
 
@@ -1364,7 +1364,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& utf8_escaped(bool val)
   {
-    options._enable_utf8_escaped = val;
+    options.enable_utf8_escaped(val);
     return *this;
   }
 
@@ -1376,7 +1376,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& lines(bool val)
   {
-    options._lines = val;
+    options.enable_lines(val);
     return *this;
   }
 
@@ -1388,7 +1388,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& rows_per_chunk(int val)
   {
-    options._rows_per_chunk = val;
+    options.set_rows_per_chunk(val);
     return *this;
   }
 
@@ -1400,7 +1400,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& true_value(std::string val)
   {
-    options._true_value = std::move(val);
+    options.set_true_value(std::move(val));
     return *this;
   }
 
@@ -1412,7 +1412,7 @@ class json_writer_options_builder {
    */
   json_writer_options_builder& false_value(std::string val)
   {
-    options._false_value = std::move(val);
+    options.set_false_value(std::move(val));
     return *this;
   }
 

--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -288,6 +288,16 @@ class orc_reader_options {
   {
     _decimal128_columns = std::move(val);
   }
+
+  /**
+   * @brief Sets whether to ignore writer timezone in the stripe footer.
+   *
+   * @param val Boolean value to enable/disable ignoring writer timezone
+   */
+  void enable_ignore_timezone_in_stripe_footer(bool val)
+  {
+    _ignore_timezone_in_stripe_footer = val;
+  }
 };
 
 /**
@@ -319,7 +329,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& columns(std::vector<std::string> col_names)
   {
-    options._columns = std::move(col_names);
+    options.set_columns(std::move(col_names));
     return *this;
   }
 
@@ -367,7 +377,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& use_index(bool use)
   {
-    options._use_index = use;
+    options.enable_use_index(use);
     return *this;
   }
 
@@ -379,7 +389,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& use_np_dtypes(bool use)
   {
-    options._use_np_dtypes = use;
+    options.enable_use_np_dtypes(use);
     return *this;
   }
 
@@ -391,7 +401,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& timestamp_type(data_type type)
   {
-    options._timestamp_type = type;
+    options.set_timestamp_type(type);
     return *this;
   }
 
@@ -403,7 +413,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& decimal128_columns(std::vector<std::string> val)
   {
-    options._decimal128_columns = std::move(val);
+    options.set_decimal128_columns(std::move(val));
     return *this;
   }
 
@@ -415,7 +425,7 @@ class orc_reader_options_builder {
    */
   orc_reader_options_builder& ignore_timezone_in_stripe_footer(bool ignore)
   {
-    options._ignore_timezone_in_stripe_footer = ignore;
+    options.enable_ignore_timezone_in_stripe_footer(ignore);
     return *this;
   }
 
@@ -932,7 +942,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& enable_statistics(statistics_freq val)
   {
-    options._stats_freq = val;
+    options.enable_statistics(val);
     return *this;
   }
 
@@ -980,7 +990,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& table(table_view tbl)
   {
-    options._table = tbl;
+    options.set_table(tbl);
     return *this;
   }
 
@@ -992,7 +1002,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& metadata(table_input_metadata meta)
   {
-    options._metadata = std::move(meta);
+    options.set_metadata(std::move(meta));
     return *this;
   }
 
@@ -1004,7 +1014,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& key_value_metadata(std::map<std::string, std::string> metadata)
   {
-    options._user_data = std::move(metadata);
+    options.set_key_value_metadata(std::move(metadata));
     return *this;
   }
 
@@ -1017,7 +1027,7 @@ class orc_writer_options_builder {
   orc_writer_options_builder& compression_statistics(
     std::shared_ptr<writer_compression_statistics> const& comp_stats)
   {
-    options._compression_stats = comp_stats;
+    options.set_compression_statistics(comp_stats);
     return *this;
   }
 
@@ -1029,7 +1039,7 @@ class orc_writer_options_builder {
    */
   orc_writer_options_builder& enable_dictionary_sort(bool val)
   {
-    options._enable_dictionary_sort = val;
+    options.set_enable_dictionary_sort(val);
     return *this;
   }
 
@@ -1352,7 +1362,7 @@ class chunked_orc_writer_options_builder {
    */
   chunked_orc_writer_options_builder& enable_statistics(statistics_freq val)
   {
-    options._stats_freq = val;
+    options.enable_statistics(val);
     return *this;
   }
 
@@ -1400,7 +1410,7 @@ class chunked_orc_writer_options_builder {
    */
   chunked_orc_writer_options_builder& metadata(table_input_metadata meta)
   {
-    options._metadata = std::move(meta);
+    options.metadata(std::move(meta));
     return *this;
   }
 
@@ -1413,7 +1423,7 @@ class chunked_orc_writer_options_builder {
   chunked_orc_writer_options_builder& key_value_metadata(
     std::map<std::string, std::string> metadata)
   {
-    options._user_data = std::move(metadata);
+    options.set_key_value_metadata(std::move(metadata));
     return *this;
   }
 
@@ -1426,7 +1436,7 @@ class chunked_orc_writer_options_builder {
   chunked_orc_writer_options_builder& compression_statistics(
     std::shared_ptr<writer_compression_statistics> const& comp_stats)
   {
-    options._compression_stats = comp_stats;
+    options.set_compression_statistics(comp_stats);
     return *this;
   }
 
@@ -1438,7 +1448,7 @@ class chunked_orc_writer_options_builder {
    */
   chunked_orc_writer_options_builder& enable_dictionary_sort(bool val)
   {
-    options._enable_dictionary_sort = val;
+    options.set_enable_dictionary_sort(val);
     return *this;
   }
 


### PR DESCRIPTION
## Description

Route IO builders through option setters because they are responsible for validation.
Also fixed validation in `set_quoting`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.