### PR TITLE
Add assert to appropriate cudf::host_span member functions

### DIFF
--- a/cpp/include/cudf/utilities/span.hpp
+++ b/cpp/include/cudf/utilities/span.hpp
@@ -156,6 +156,7 @@ struct host_span {
   constexpr reference operator[](size_type idx) const
   {
     static_assert(sizeof(idx) >= sizeof(size_t), "index type must not be smaller than size_t");
+    assert(idx < _span.size());
     return _span[idx];
   }
 
@@ -235,6 +236,7 @@ struct host_span {
    */
   [[nodiscard]] constexpr host_span first(size_type count) const noexcept
   {
+    assert(count <= _span.size());
     return host_span{_span.data(), count, _is_device_accessible};
   }
 
@@ -246,6 +248,7 @@ struct host_span {
    */
   [[nodiscard]] constexpr host_span last(size_type count) const noexcept
   {
+    assert(count <= _span.size());
     return host_span{_span.data() + _span.size() - count, count, _is_device_accessible};
   }
 
@@ -266,6 +269,7 @@ struct host_span {
   [[nodiscard]] CUDF_HOST_DEVICE constexpr host_span subspan(size_type offset,
                                                              size_type count) const noexcept
   {
+    assert(offset + count <= _span.size());
     return host_span{_span.data() + offset, count, _is_device_accessible};
   }
 

--- a/cpp/include/cudf/utilities/span.hpp
+++ b/cpp/include/cudf/utilities/span.hpp
@@ -269,7 +269,7 @@ struct host_span {
   [[nodiscard]] CUDF_HOST_DEVICE constexpr host_span subspan(size_type offset,
                                                              size_type count) const noexcept
   {
-    assert(offset + count <= _span.size());
+    assert(offset <= _span.size() && count <= _span.size() - offset);
     return host_span{_span.data() + offset, count, _is_device_accessible};
   }
 


### PR DESCRIPTION
## Description
Adds `assert()` calls to the `cudf::host_span` member functions that accept index values to check that the input does not exceed the span size. This is in parity to the `cuda::std::span` and `std::span` implementations which have been helpful in finding bugs. The `assert()` is only active in a debug compile/build so there is no penalty on a release build.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
