### PR TITLE
Add memory resource parameter to cudf::mark_join constructors

### DIFF
--- a/cpp/include/cudf/join/mark_join.hpp
+++ b/cpp/include/cudf/join/mark_join.hpp
@@ -78,6 +78,7 @@ class mark_join {
    * @param compare_nulls Controls whether null join-key values should match or not
    * @param prefilter Controls whether an optional probe-side prefilter is enabled
    * @param stream CUDA stream used for device memory operations and kernel launches
+   * @param mr Device memory resource used to allocate the internal hash table and prefilter
    */
   mark_join(cudf::table_view const& left,
             cudf::null_equality compare_nulls,
@@ -94,6 +95,7 @@ class mark_join {
    * @param compare_nulls Controls whether null join-key values should match or not
    * @param prefilter Controls whether an optional probe-side prefilter is enabled
    * @param stream CUDA stream used for device memory operations and kernel launches
+   * @param mr Device memory resource used to allocate the internal hash table and prefilter
    */
   mark_join(cudf::table_view const& left,
             double load_factor,

--- a/cpp/include/cudf/join/mark_join.hpp
+++ b/cpp/include/cudf/join/mark_join.hpp
@@ -82,7 +82,9 @@ class mark_join {
   mark_join(cudf::table_view const& left,
             cudf::null_equality compare_nulls,
             cudf::join_prefilter prefilter,
-            rmm::cuda_stream_view stream = cudf::get_default_stream());
+            rmm::cuda_stream_view stream = cudf::get_default_stream(),
+            cuda::mr::any_resource<cuda::mr::device_accessible> mr =
+              cudf::get_current_device_resource_ref());
 
   /**
    * @brief Constructs a mark join object with explicit prefilter selection.
@@ -97,7 +99,9 @@ class mark_join {
             double load_factor,
             cudf::null_equality compare_nulls = cudf::null_equality::EQUAL,
             cudf::join_prefilter prefilter    = cudf::join_prefilter::NO,
-            rmm::cuda_stream_view stream      = cudf::get_default_stream());
+            rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+            cuda::mr::any_resource<cuda::mr::device_accessible> mr =
+              cudf::get_current_device_resource_ref());
 
   /**
    * @brief Returns left row indices that have at least one match in the right table.

--- a/cpp/src/join/mark_join.cu
+++ b/cpp/src/join/mark_join.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -591,14 +591,15 @@ mark_join::mark_join(cudf::table_view const& left,
                      cudf::null_equality compare_nulls,
                      double load_factor,
                      cudf::join_prefilter prefilter,
-                     rmm::cuda_stream_view stream)
+                     rmm::cuda_stream_view stream,
+                     cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _has_nested_columns{cudf::has_nested_columns(left)},
     _left{left},
     _nulls_equal{compare_nulls},
     _prefilter{prefilter},
     _preprocessed_left{cudf::detail::row::equality::preprocessed_table::create(left, stream)},
     _bucket_storage{cuco::extent<std::size_t>{compute_mark_join_capacity(left, load_factor)},
-                    rmm::mr::polymorphic_allocator<char>{},
+                    rmm::mr::polymorphic_allocator<char>{mr},
                     stream.value()}
 {
   cudf::scoped_range range{"mark_join::mark_join"};
@@ -609,7 +610,7 @@ mark_join::mark_join(cudf::table_view const& left,
       get_bloom_filter_blocks<bloom_filter_type>(_left.num_rows()),
       cuco::cuda_thread_scope<cuda::thread_scope_device>{},
       bloom_filter_policy_type{},
-      bloom_filter_allocator_type{},
+      bloom_filter_allocator_type{std::move(mr)},
       stream.value());
   }
 
@@ -816,9 +817,10 @@ mark_join::~mark_join() = default;
 mark_join::mark_join(cudf::table_view const& left,
                      cudf::null_equality compare_nulls,
                      cudf::join_prefilter prefilter,
-                     rmm::cuda_stream_view stream)
+                     rmm::cuda_stream_view stream,
+                     cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _impl{std::make_unique<detail::mark_join>(
-      left, compare_nulls, detail::CUCO_DESIRED_LOAD_FACTOR, prefilter, stream)}
+      left, compare_nulls, detail::CUCO_DESIRED_LOAD_FACTOR, prefilter, stream, std::move(mr))}
 {
 }
 
@@ -826,8 +828,10 @@ mark_join::mark_join(cudf::table_view const& left,
                      double load_factor,
                      cudf::null_equality compare_nulls,
                      cudf::join_prefilter prefilter,
-                     rmm::cuda_stream_view stream)
-  : _impl{std::make_unique<detail::mark_join>(left, compare_nulls, load_factor, prefilter, stream)}
+                     rmm::cuda_stream_view stream,
+                     cuda::mr::any_resource<cuda::mr::device_accessible> mr)
+  : _impl{std::make_unique<detail::mark_join>(
+      left, compare_nulls, load_factor, prefilter, stream, std::move(mr))}
 {
 }
 

--- a/cpp/src/join/mark_join.cuh
+++ b/cpp/src/join/mark_join.cuh
@@ -183,7 +183,8 @@ class mark_join {
             cudf::null_equality compare_nulls,
             double load_factor,
             cudf::join_prefilter prefilter,
-            rmm::cuda_stream_view stream);
+            rmm::cuda_stream_view stream,
+            cuda::mr::any_resource<cuda::mr::device_accessible> mr);
 
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> semi_join(
     cudf::table_view const& right, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr);

--- a/cpp/tests/join/semi_anti_join_tests.cpp
+++ b/cpp/tests/join/semi_anti_join_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,6 +22,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/statistics_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <thrust/iterator/transform_iterator.h>
@@ -513,6 +514,19 @@ TEST_F(SemiAntiJoinTest, MarkJoinPrefilterLoadFactorOverload)
   auto sorted_expected     = cudf::gather(expected, *expected_sort_order);
 
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*sorted_expected, *sorted_result);
+}
+
+TEST_F(SemiAntiJoinTest, MarkJoinMemoryResource)
+{
+  column_wrapper<int32_t> left_col{0, 1, 1, 2, 3, 5};
+  auto left = cudf::table_view{{left_col}};
+
+  auto mr = rmm::mr::statistics_resource_adaptor(cudf::get_current_device_resource_ref());
+
+  cudf::mark_join obj(
+    left, cudf::null_equality::EQUAL, cudf::join_prefilter::YES, cudf::get_default_stream(), mr);
+
+  EXPECT_GT(mr.get_bytes_counter().peak, 0);
 }
 
 std::string test_name(join_implementation implementation)


### PR DESCRIPTION
## Description

Follow-up to #23264 and #23277.

This PR adds an `mr` parameter to the `cudf::mark_join` constructors to control allocations for the persistent cuco hash table and optional bloom-filter prefilter, aligning the wrapper with the temporary MR effort (#20780).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
