### PR TITLE
Use provided memory resource for tokenize_vocabulary map

### DIFF
--- a/cpp/src/text/vocabulary_tokenize.cu
+++ b/cpp/src/text/vocabulary_tokenize.cu
@@ -144,7 +144,7 @@ tokenize_vocabulary::tokenize_vocabulary(cudf::strings_column_view const& input,
     detail::probe_scheme{detail::vocab_hasher{*d_vocabulary}},
     cuco::thread_scope_device,
     detail::cuco_storage{},
-    rmm::mr::polymorphic_allocator<char>{},
+    rmm::mr::polymorphic_allocator<char>{mr},
     stream.value());
 
   // the row index is the token id (value for each key in the map)


### PR DESCRIPTION
## Description

This PR uses the `mr` provided to `nvtext::tokenize_vocabulary` for its persistent cuco vocabulary map instead of the default allocator, aligning the wrapper with the temporary MR effort (#20780).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
