### PR TITLE
Remove redundant type dispatch from column contains

### DIFF
--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -62,9 +62,7 @@ std::unique_ptr<column> contains(column_view const& haystack,
                                  rmm::cuda_stream_view stream,
                                  rmm::device_async_resource_ref mr)
 {
-  // `contains` is already type-erased below the dictionary normalization boundary. Dispatch only
-  // on the operation-specific distinction that changes the algorithm instead of instantiating the
-  // same implementation for every cudf type.
+  // Dictionary columns require key normalization; all other types share the type-erased path.
   if (haystack.type().id() == type_id::DICTIONARY32) {
     return contains_dictionary(haystack, needles, stream, mr);
   }

--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -19,21 +19,6 @@ namespace detail {
 
 namespace {
 
-std::unique_ptr<column> contains_non_dictionary(column_view const& haystack,
-                                                column_view const& needles,
-                                                rmm::cuda_stream_view stream,
-                                                rmm::device_async_resource_ref mr)
-{
-  auto result_v = detail::contains(table_view{{haystack}},
-                                   table_view{{needles}},
-                                   null_equality::EQUAL,
-                                   nan_equality::ALL_EQUAL,
-                                   stream,
-                                   mr);
-  return std::make_unique<column>(
-    std::move(result_v), detail::copy_bitmask(needles, stream, mr), needles.null_count());
-}
-
 std::unique_ptr<column> contains_dictionary(column_view const& haystack_in,
                                             column_view const& needles_in,
                                             rmm::cuda_stream_view stream,
@@ -52,7 +37,15 @@ std::unique_ptr<column> contains_dictionary(column_view const& haystack_in,
   // now just use the indices for the contains
   column_view const haystack_indices = haystack_view.get_indices_annotated();
   column_view const needles_indices  = needles_view.get_indices_annotated();
-  return contains_non_dictionary(haystack_indices, needles_indices, stream, mr);
+  auto result_v                      = detail::contains(table_view{{haystack_indices}},
+                                   table_view{{needles_indices}},
+                                   null_equality::EQUAL,
+                                   nan_equality::ALL_EQUAL,
+                                   stream,
+                                   mr);
+  return std::make_unique<column>(std::move(result_v),
+                                  detail::copy_bitmask(needles_indices, stream, mr),
+                                  needles_indices.null_count());
 }
 
 }  // namespace
@@ -66,7 +59,14 @@ std::unique_ptr<column> contains(column_view const& haystack,
   if (haystack.type().id() == type_id::DICTIONARY32) {
     return contains_dictionary(haystack, needles, stream, mr);
   }
-  return contains_non_dictionary(haystack, needles, stream, mr);
+  auto result_v = detail::contains(table_view{{haystack}},
+                                   table_view{{needles}},
+                                   null_equality::EQUAL,
+                                   nan_equality::ALL_EQUAL,
+                                   stream,
+                                   mr);
+  return std::make_unique<column>(
+    std::move(result_v), detail::copy_bitmask(needles, stream, mr), needles.null_count());
 }
 
 }  // namespace detail

--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,30 +19,25 @@ namespace detail {
 
 namespace {
 
-struct contains_column_dispatch {
-  template <typename Element>
-  std::unique_ptr<column> operator()(column_view const& haystack,
-                                     column_view const& needles,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::device_async_resource_ref mr) const
-  {
-    auto result_v = detail::contains(table_view{{haystack}},
-                                     table_view{{needles}},
-                                     null_equality::EQUAL,
-                                     nan_equality::ALL_EQUAL,
-                                     stream,
-                                     mr);
-    return std::make_unique<column>(
-      std::move(result_v), detail::copy_bitmask(needles, stream, mr), needles.null_count());
-  }
-};
+std::unique_ptr<column> contains_non_dictionary(column_view const& haystack,
+                                                column_view const& needles,
+                                                rmm::cuda_stream_view stream,
+                                                rmm::device_async_resource_ref mr)
+{
+  auto result_v = detail::contains(table_view{{haystack}},
+                                   table_view{{needles}},
+                                   null_equality::EQUAL,
+                                   nan_equality::ALL_EQUAL,
+                                   stream,
+                                   mr);
+  return std::make_unique<column>(
+    std::move(result_v), detail::copy_bitmask(needles, stream, mr), needles.null_count());
+}
 
-template <>
-std::unique_ptr<column> contains_column_dispatch::operator()<dictionary32>(
-  column_view const& haystack_in,
-  column_view const& needles_in,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) const
+std::unique_ptr<column> contains_dictionary(column_view const& haystack_in,
+                                            column_view const& needles_in,
+                                            rmm::cuda_stream_view stream,
+                                            rmm::device_async_resource_ref mr)
 {
   dictionary_column_view const haystack(haystack_in);
   dictionary_column_view const needles(needles_in);
@@ -57,12 +52,7 @@ std::unique_ptr<column> contains_column_dispatch::operator()<dictionary32>(
   // now just use the indices for the contains
   column_view const haystack_indices = haystack_view.get_indices_annotated();
   column_view const needles_indices  = needles_view.get_indices_annotated();
-  return cudf::type_dispatcher(haystack_indices.type(),
-                               contains_column_dispatch{},
-                               haystack_indices,
-                               needles_indices,
-                               stream,
-                               mr);
+  return contains_non_dictionary(haystack_indices, needles_indices, stream, mr);
 }
 
 }  // namespace
@@ -72,8 +62,13 @@ std::unique_ptr<column> contains(column_view const& haystack,
                                  rmm::cuda_stream_view stream,
                                  rmm::device_async_resource_ref mr)
 {
-  return cudf::type_dispatcher(
-    haystack.type(), contains_column_dispatch{}, haystack, needles, stream, mr);
+  // `contains` is already type-erased below the dictionary normalization boundary. Dispatch only
+  // on the operation-specific distinction that changes the algorithm instead of instantiating the
+  // same implementation for every cudf type.
+  if (haystack.type().id() == type_id::DICTIONARY32) {
+    return contains_dictionary(haystack, needles, stream, mr);
+  }
+  return contains_non_dictionary(haystack, needles, stream, mr);
 }
 
 }  // namespace detail


### PR DESCRIPTION
## Description

This PR removes the redundant `type_dispatcher` calls from `cudf::contains(column_view, column_view)`.

The non-dictionary dispatch did not use the dispatched C++ type: every supported cuDF type instantiated the same type-erased table contains path. Dictionary columns are the only exception because their keys must be normalized before comparing their indices. This PR handles that exception with a direct `DICTIONARY32` check and sends all other columns to the shared type-erased implementation.

In an uncached CUDA 13.0 build, this reduces the compile time for `contains_column.cu` from 67.9 seconds to 23.9 seconds and the object size from 360,392 bytes to 268,224 bytes. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.