### PR TITLE
Support `pl.argwhere/pl.Expr.arg_true`

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
@@ -106,6 +106,7 @@ class UnaryFunction(Expr):
     }
     _supported_misc_fns = frozenset(
         {
+            "argwhere",
             "as_struct",
             "arg_max",
             "arg_min",
@@ -294,6 +295,20 @@ class UnaryFunction(Expr):
             )
             return Column(indices, dtype=DataType(pl.Int32())).astype(
                 self.dtype, stream=df.stream
+            )
+        if self.name == "argwhere":
+            (column,) = (child.evaluate(df, context=context) for child in self.children)
+            indices = plc.filling.sequence(
+                column.size,
+                plc.Scalar.from_py(0, self.dtype.plc_type, stream=df.stream),
+                plc.Scalar.from_py(1, self.dtype.plc_type, stream=df.stream),
+                stream=df.stream,
+            )
+            return Column(
+                plc.stream_compaction.apply_boolean_mask(
+                    plc.Table([indices]), column.obj, stream=df.stream
+                ).columns()[0],
+                dtype=self.dtype,
             )
         if self.name == "null_count":
             (column,) = (child.evaluate(df, context=context) for child in self.children)

--- a/python/cudf_polars/tests/expressions/test_arg_where.py
+++ b/python/cudf_polars/tests/expressions/test_arg_where.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+from cudf_polars.testing.asserts import assert_gpu_result_equal
+
+
+@pytest.mark.parametrize(
+    "series",
+    [
+        pl.Series("a", [1, 2, 3, 4, 5]),
+        pl.Series("a", [10, 20, 30]),
+        pl.Series("a", [1, None, 3, None, 5]),
+        pl.Series("a", [1.5, float("nan"), 3.0, 0.0]),
+        pl.Series("a", [], dtype=pl.Int64),
+    ],
+)
+def test_arg_where(engine: pl.GPUEngine, series: pl.Series) -> None:
+    lf = pl.LazyFrame({"a": series})
+    q = lf.select(pl.arg_where(pl.col("a") % 2 == 0))
+    assert_gpu_result_equal(q, engine=engine)
+
+
+@pytest.mark.parametrize(
+    "series",
+    [
+        pl.Series("a", [True, False, True, True, False]),
+        pl.Series("a", [True, False, None, True, None]),
+        pl.Series("a", [False, False, False]),
+        pl.Series("a", [True, True, True]),
+        pl.Series("a", [None, None], dtype=pl.Boolean),
+    ],
+)
+def test_arg_where_boolean(engine: pl.GPUEngine, series: pl.Series) -> None:
+    lf = pl.LazyFrame({"a": series})
+    q = lf.select(pl.arg_where(pl.col("a")))
+    assert_gpu_result_equal(q, engine=engine)
+
+
+def test_arg_true(engine: pl.GPUEngine) -> None:
+    lf = pl.LazyFrame({"a": [1, 1, 2, 1]})
+    q = lf.select((pl.col("a") == 1).arg_true())
+    assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
## Description
xref https://github.com/rapidsai/cudf/issues/23151

https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.arg_true.html
https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.arg_where.html

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
