### PR TITLE
Pin pyarrow<24 in the cudf and pylibcudf conda recipes

### DIFF
--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -96,7 +96,7 @@ requirements:
     # lives in `dependencies.yaml::depends_on_numba_cuda_mlir`.
     - numba >=0.60.0,<0.65.0
     - numpy >=2.0,<3.0
-    - pyarrow>=19.0.0
+    - pyarrow>=19.0.0,<24  # https://github.com/rapidsai/cudf/issues/22229
     - libcudf =${{ version }}
     - pylibcudf =${{ version }}
     - ${{ pin_compatible("rmm", upper_bound="x.x") }}

--- a/conda/recipes/pylibcudf/recipe.yaml
+++ b/conda/recipes/pylibcudf/recipe.yaml
@@ -95,7 +95,7 @@ requirements:
     - nvtx >=0.2.1
   run_constraints:
     - numpy >=2.0,<3.0
-    - pyarrow>=19.0.0
+    - pyarrow>=19.0.0,<24  # https://github.com/rapidsai/cudf/issues/22229
   ignore_run_exports:
     from_package:
       - cuda-cudart-dev


### PR DESCRIPTION
## Description

The latest-deps conda CI jobs started failing on every PR (e.g. [this run on #23272](https://github.com/rapidsai/cudf/actions/runs/29585048860)) with pyarrow 25.0.0 in the environment — feather tests/doctests (`pyarrow.feather` deprecated as of 24), pylibcudf quantiles (`SortOptions(null_placement=)` deprecated in 25), ORC tests (out-of-ns-range timestamps now raise `ArrowInvalid` instead of silently overflowing), and the narwhals suite.

cudf pins `pyarrow>=19.0.0,<24` (#22229) in `dependencies.yaml` for the conda, requirements, and pyproject outputs — but the hand-maintained conda recipes only declare `pyarrow>=19.0.0` with **no upper bound** (`conda/recipes/cudf/recipe.yaml` run dependency and `conda/recipes/pylibcudf/recipe.yaml` run constraint). The conda test environments don't list pyarrow directly (only the oldest-deps matrix pins `pyarrow==19.*`), so the env solve takes the bound from the built packages, and with the recipes unbounded the solver picked pyarrow 25.0.0. This is also how the narwhals job got pyarrow 25: its env installs the built cudf conda package in the same solve.

This mirrors the `dependencies.yaml` bound into both recipes, which constrains every conda test environment that installs the built packages.

Note: the wheel jobs were unaffected because the pip/pyproject metadata carries the `<24` bound. The remaining failure in the linked run (`conda-python-other-tests`) was a runner infra flake (`nvidia-smi`: "No devices were found") — retry only.

For whenever the pin is actually lifted (#22229): the test-suite adaptations needed for pyarrow 24/25 (feather→`pyarrow.ipc` migration, per-sort-key `null_placement`, ORC timestamp-range handling, narwhals deselects) were worked out and verified in [9a3a288019](https://github.com/galipremsagar/cudf/commit/9a3a288019) (previous head of this branch).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
