### PR TITLE
Add timeout stacktrace utility for cudf-polars tests, remove pytest-timeout

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -72,7 +72,6 @@ python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
        -n 4 \
        --dist=worksteal \
        --tb=native \
-       --timeout=240 \
        --durations 10 --durations-min 10 \
        -ra \
        $DESELECTED_TESTS_STR \
@@ -95,7 +94,6 @@ python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
        -n 4 \
        --dist=worksteal \
        --tb=native \
-       --timeout=240 \
        --durations 10 --durations-min 10 \
        -ra \
        $DESELECTED_TESTS_STR \

--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
+
 # Support invoking run_cudf_polars_pytests.sh outside the script directory
 # Assumption, polars has been cloned in the root of the repo.
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../polars/
@@ -61,7 +63,8 @@ DESELECTED_TESTS_STR=$(printf -- " --deselect %s" "${DESELECTED_TESTS[@]}")
 # multiple quoted arguments inline
 # shellcheck disable=SC2086
 echo "Run polars tests with injected in-memory GPU engine"
-python -m pytest \
+python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
+   python -m pytest \
        --import-mode=importlib \
        --cache-clear \
        -m "" \
@@ -81,7 +84,8 @@ python -m pytest \
 echo "Run polars tests with injected SPMD GPU engine, small blocksize"
 CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE=805306368 \
 CUDF_POLARS__EXECUTOR__FALLBACK_MODE=silent \
-    python -m pytest \
+python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
+   python -m pytest \
        --import-mode=importlib \
        --cache-clear \
        -v \

--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -62,11 +62,13 @@ DESELECTED_TESTS_STR=$(printf -- " --deselect %s" "${DESELECTED_TESTS[@]}")
 # Don't quote the `DESELECTED_...` variable because `pytest` can't handle
 # multiple quoted arguments inline
 # shellcheck disable=SC2086
+# Fail fast (-x) because failed tests pollute the state
 echo "Run polars tests with injected in-memory GPU engine"
 python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
    python -m pytest \
        --import-mode=importlib \
        --cache-clear \
+       -x \
        -m "" \
        -p cudf_polars.testing.inject_gpu_engine \
        -n 4 \
@@ -87,6 +89,7 @@ python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
    python -m pytest \
        --import-mode=importlib \
        --cache-clear \
+       -x \
        -v \
        -m "" \
        -p cudf_polars.testing.inject_gpu_engine \

--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
 # It is essential to cd into python/cudf_polars as `pytest-xdist` + `coverage` seem to work only at this directory level.
 # Support invoking run_cudf_polars_pytests.sh outside the script directory
+TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
+
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 
-python -m pytest --cache-clear "$@" tests
+python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
+       python -m pytest --cache-clear "$@" tests

--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -89,12 +89,14 @@ for version in "${VERSIONS[@]}"; do
         COVERAGE_ARGS=(--no-cov)
     fi
 
+    # Fail fast (-x) rather than trying to continue because failed tests pollute the state
     ./ci/run_cudf_polars_pytests.sh \
         -vv \
         "${COVERAGE_ARGS[@]}" \
         --numprocesses=4 \
         --dist=worksteal \
         --durations 10 --durations-min 10 \
+        -x \
         -ra \
         --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars-${version}.xml"
 
@@ -106,6 +108,7 @@ for version in "${VERSIONS[@]}"; do
         EXITCODE=1
         FAILED+=("${version}")
         rapids-logger "Tests failed for polars ${version}.*"
+        break
     else
         PASSED+=("${version}")
         rapids-logger "Tests passed for polars ${version}.*"

--- a/ci/timeout_with_stack.py
+++ b/ci/timeout_with_stack.py
@@ -36,6 +36,7 @@ import psutil
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from types import FrameType
 
 
 class StackType(IntEnum):
@@ -115,25 +116,30 @@ def capture_stack_trace(pid: int, stack_type=StackType.C) -> None:
         print(f"Skipping stack trace for process {pid}: gdb not found")
         return
 
-    proc = subprocess.run(
-        [
-            gdb,
-            "--quiet",
-            "--pid",
-            str(pid),
-            "-ex",
-            "set pagination off",
-            "-ex",
-            "set confirm off",
-            "-ex",
-            bt_command,
-            "-ex",
-            "quit",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            [
+                gdb,
+                "--quiet",
+                "--pid",
+                str(pid),
+                "-ex",
+                "set pagination off",
+                "-ex",
+                "set confirm off",
+                "-ex",
+                bt_command,
+                "-ex",
+                "quit",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"Timed out capturing stack trace for process {pid}")
+        return
 
     print(proc.stdout)
     if proc.stderr:
@@ -234,6 +240,20 @@ def terminate_process_tree(pid: int) -> None:
         pass
 
 
+def install_signal_handler(pid: int, *signals: signal.Signals) -> None:
+    """
+    Install signal handler that terminates the given pid on receiving any of signals
+    """
+
+    def handler(signum: int, frame: FrameType | None) -> None:
+        print(f"Received {signum=}, terminating process tree")
+        terminate_process_tree(pid)
+        sys.exit(signum)
+
+    for sig in signals:
+        signal.signal(sig, handler)
+
+
 def run_with_timeout(
     cmd: Sequence[str], timeout: float, *, enable_python: bool = False
 ) -> int:
@@ -275,6 +295,13 @@ def run_with_timeout(
     process = subprocess.Popen(
         cmd,
         preexec_fn=os.setsid,
+    )
+    install_signal_handler(
+        process.pid,
+        signal.SIGTERM,
+        signal.SIGABRT,
+        signal.SIGHUP,
+        signal.SIGQUIT,
     )
     start_time = time.time()
 

--- a/ci/timeout_with_stack.py
+++ b/ci/timeout_with_stack.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Module for running commands with timeout and capturing stack traces.
+
+This module provides functionality to run commands with a timeout, capture stack traces
+of processes that exceed the timeout, and properly terminate process trees.
+
+See Also
+--------
+subprocess.Popen : For running subprocesses without timeout.
+psutil.Process : For process management and information.
+
+Examples
+--------
+>>> from timeout_with_stack import run_with_timeout
+>>> exit_code = run_with_timeout(["sleep", "10"], timeout=5)
+>>> print(f"Process exited with code: {exit_code}")
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from enum import IntEnum
+from typing import TYPE_CHECKING
+
+import psutil
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class StackType(IntEnum):
+    """Enum representing the type of stack trace to capture."""
+
+    C = 0
+    Python = 1
+
+
+def get_child_pids(pid: int) -> list[int]:
+    """
+    Get all child PIDs of a given process.
+
+    This function retrieves all child process IDs (PIDs) of a given process,
+    including recursively nested child processes.
+
+    Parameters
+    ----------
+    pid
+        The process ID of the parent process.
+
+    Returns
+    -------
+    A list of child process IDs. Returns an empty list if the parent process
+    does not exist.
+
+    See Also
+    --------
+    psutil.Process.children : For getting child processes.
+
+    Examples
+    --------
+    >>> from timeout_with_stack import get_child_pids
+    >>> child_pids = get_child_pids(1234)
+    >>> print(f"Child PIDs: {child_pids}")
+    """
+    try:
+        parent = psutil.Process(pid)
+        children = parent.children(recursive=True)
+        return [p.pid for p in children]
+    except psutil.NoSuchProcess:
+        return []
+
+
+def capture_stack_trace(pid: int, stack_type=StackType.C) -> None:
+    """
+    Capture stack trace for a given process.
+
+    This function captures the stack trace of a process using GDB. It prints the
+    stack trace to stdout, which can be useful for debugging hanging or long-running
+    processes.
+
+    Parameters
+    ----------
+    pid
+        The process ID of the process to capture stack trace for.
+    stack_type
+        The stack type to extract, either C or Python.
+
+    See Also
+    --------
+    capture_all_stacks : For capturing stack traces of a process and its children.
+
+    Examples
+    --------
+    >>> from timeout_with_stack import capture_stack_trace
+    >>> capture_stack_trace(1234)
+    """
+    if stack_type is StackType.C:
+        bt_command = "thread apply all bt"
+        print(f"\nCapturing C stack trace for process {pid}:")
+    else:
+        bt_command = "thread apply all py-bt"
+        print(f"\nCapturing Python stack trace for process {pid}:")
+    gdb = shutil.which("gdb")
+    if gdb is None:
+        print(f"Skipping stack trace for process {pid}: gdb not found")
+        return
+
+    proc = subprocess.run(
+        [
+            gdb,
+            "--quiet",
+            "--pid",
+            str(pid),
+            "-ex",
+            "set pagination off",
+            "-ex",
+            "set confirm off",
+            "-ex",
+            bt_command,
+            "-ex",
+            "quit",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    print(proc.stdout)
+    if proc.stderr:
+        print(proc.stderr, file=sys.stderr)
+
+
+def capture_all_stacks(pid: int, *, enable_python: bool = False) -> None:
+    """
+    Capture stack traces for parent and all child processes.
+
+    This function captures stack traces for both the parent process and all its
+    child processes. It first captures the parent's stack trace, then recursively
+    captures stack traces for all child processes.
+
+    Parameters
+    ----------
+    pid
+        The process ID of the parent process.
+    enable_python
+        Whether to capture Python stack traces.
+
+    See Also
+    --------
+    capture_stack_trace : For capturing stack trace of a single process.
+    get_child_pids : For getting child process IDs.
+
+    Examples
+    --------
+    >>> from timeout_with_stack import capture_all_stacks
+    >>> capture_all_stacks(1234, enable_python=True)
+    """
+    # Capture parent process stack
+    if enable_python:
+        capture_stack_trace(pid, stack_type=StackType.Python)
+    capture_stack_trace(pid, stack_type=StackType.C)
+
+    # Get and capture all child processes
+    child_pids = get_child_pids(pid)
+    for child_pid in child_pids:
+        if enable_python:
+            capture_stack_trace(child_pid, stack_type=StackType.Python)
+        capture_stack_trace(child_pid, stack_type=StackType.C)
+
+
+def terminate_process_tree(pid: int) -> None:
+    """
+    Terminate a process and all its children.
+
+    This function terminates a process and all its child processes. It first
+    attempts to gracefully terminate all processes, then forcefully kills any
+    remaining processes after a timeout.
+
+    Parameters
+    ----------
+    pid
+        The process ID of the parent process to terminate.
+
+    See Also
+    --------
+    psutil.Process.terminate : For gracefully terminating a process.
+    psutil.Process.kill : For forcefully killing a process.
+
+    Examples
+    --------
+    >>> from timeout_with_stack import terminate_process_tree
+    >>> terminate_process_tree(1234)
+    """
+    try:
+        parent = psutil.Process(pid)
+        children = parent.children(recursive=True)
+
+        # Terminate children first
+        for child in children:
+            with suppress(psutil.NoSuchProcess):
+                child.terminate()
+
+        # Create a copy of children list
+        terminated_children = list(children)
+
+        # Wait for all children to terminate
+        for child in terminated_children:
+            with suppress(psutil.TimeoutExpired):
+                child.wait(timeout=3)
+
+        # Kill any remaining children
+        for child in terminated_children:
+            with suppress(psutil.NoSuchProcess):
+                child.kill()
+
+        # Terminate parent
+        parent.terminate()
+        try:
+            parent.wait(timeout=3)
+        except psutil.TimeoutExpired:
+            parent.kill()
+
+    except psutil.NoSuchProcess:
+        pass
+
+
+def run_with_timeout(
+    cmd: Sequence[str], timeout: float, *, enable_python: bool = False
+) -> int:
+    """
+    Run a command with a timeout and capture stack traces if it exceeds the timeout.
+
+    This function runs a command with a specified timeout. If the command exceeds
+    the timeout, it captures stack traces of the process and its children before
+    terminating them. It handles keyboard interrupts gracefully.
+
+    Parameters
+    ----------
+    cmd
+        The command and its arguments to run.
+    timeout
+        Maximum time in seconds to allow the command to run.
+    enable_python
+        Whether to capture Python stack traces.
+
+    Returns
+    -------
+    Return code of the command, or 124 if timeout occurred, or signal.SIGINT
+    if interrupted by keyboard.
+
+    See Also
+    --------
+    subprocess.Popen : For running subprocesses without timeout.
+    capture_all_stacks : For capturing stack traces of processes.
+
+    Examples
+    --------
+    >>> from timeout_with_stack import run_with_timeout
+    >>> exit_code = run_with_timeout(["sleep", "10"], timeout=5, enable_python=True)
+    >>> print(f"Process exited with code: {exit_code}")
+    """
+    # Start the process with a new process group
+    # Note: preexec_fn is used here as we need to create a new process group
+    # for proper termination of child processes
+    process = subprocess.Popen(
+        cmd,
+        preexec_fn=os.setsid,
+    )
+    start_time = time.time()
+
+    try:
+        while time.time() - start_time < timeout:
+            if process.poll() is not None:
+                return process.returncode
+            time.sleep(0.1)
+
+        print(f"\nProcess timed out after {timeout} seconds")
+        print("Capturing stack traces for all processes...")
+
+        # Capture stacks for parent and all children
+        capture_all_stacks(process.pid, enable_python=enable_python)
+
+        # Terminate the entire process tree
+        print("\nTerminating process tree...")
+        terminate_process_tree(process.pid)
+    except KeyboardInterrupt:
+        print("\nReceived keyboard interrupt")
+        terminate_process_tree(process.pid)
+        return signal.SIGINT
+    else:
+        return 124
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run a command with timeout and capture stack traces"
+    )
+    parser.add_argument("timeout", type=float, help="Timeout in seconds")
+    parser.add_argument(
+        "--enable-python",
+        action="store_true",
+        help="Enable Python stack trace capture",
+    )
+    parser.add_argument(
+        "command", nargs=argparse.REMAINDER, help="Command to run"
+    )
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.error("No command specified")
+
+    exit_code = run_with_timeout(
+        args.command, args.timeout, enable_python=args.enable_python
+    )
+    sys.exit(exit_code)

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -76,6 +76,7 @@ dependencies:
 - pandoc
 - polars>=1.35,<1.43
 - pre-commit
+- psutil
 - pyarrow>=19.0.0,<24
 - pytables
 - pytest-benchmark

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - flatbuffers==24.3.25
 - fsspec>=0.6.0
 - gcc_linux-aarch64=14.*
+- gdb
 - hypothesis>=6.131.7
 - identify>=2.5.20
 - include-what-you-use==0.24.0
@@ -84,7 +85,6 @@ dependencies:
 - pytest-cov
 - pytest-httpserver
 - pytest-rerunfailures!=16.0.0
-- pytest-timeout
 - pytest-xdist
 - pytest<9.1.0
 - python-calamine

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -76,6 +76,7 @@ dependencies:
 - pandoc
 - polars>=1.35,<1.43
 - pre-commit
+- psutil
 - pyarrow>=19.0.0,<24
 - pytables
 - pytest-benchmark

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - flatbuffers==24.3.25
 - fsspec>=0.6.0
 - gcc_linux-64=14.*
+- gdb
 - hypothesis>=6.131.7
 - identify>=2.5.20
 - include-what-you-use==0.24.0
@@ -84,7 +85,6 @@ dependencies:
 - pytest-cov
 - pytest-httpserver
 - pytest-rerunfailures!=16.0.0
-- pytest-timeout
 - pytest-xdist
 - pytest<9.1.0
 - python-calamine

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -76,6 +76,7 @@ dependencies:
 - pandoc
 - polars>=1.35,<1.43
 - pre-commit
+- psutil
 - pyarrow>=19.0.0,<24
 - pytables
 - pytest-benchmark

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - flatbuffers==24.3.25
 - fsspec>=0.6.0
 - gcc_linux-aarch64=14.*
+- gdb
 - hypothesis>=6.131.7
 - identify>=2.5.20
 - include-what-you-use==0.24.0
@@ -84,7 +85,6 @@ dependencies:
 - pytest-cov
 - pytest-httpserver
 - pytest-rerunfailures!=16.0.0
-- pytest-timeout
 - pytest-xdist
 - pytest<9.1.0
 - python-calamine

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -76,6 +76,7 @@ dependencies:
 - pandoc
 - polars>=1.35,<1.43
 - pre-commit
+- psutil
 - pyarrow>=19.0.0,<24
 - pytables
 - pytest-benchmark

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - flatbuffers==24.3.25
 - fsspec>=0.6.0
 - gcc_linux-64=14.*
+- gdb
 - hypothesis>=6.131.7
 - identify>=2.5.20
 - include-what-you-use==0.24.0
@@ -84,7 +85,6 @@ dependencies:
 - pytest-cov
 - pytest-httpserver
 - pytest-rerunfailures!=16.0.0
-- pytest-timeout
 - pytest-xdist
 - pytest<9.1.0
 - python-calamine

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1174,6 +1174,8 @@ dependencies:
           - pytest-httpserver
           - pytest-timeout
           - zstandard
+          # Used by ci/timeout_with_stack.py utility
+          - psutil
           # The polars test suite constructs pandas objects for interop and
           # dask-cuda pulls pandas in transitively (unbounded), so constrain it
           # here to exclude the 3.0.4 release that segfaults on pd.Timedelta

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1172,7 +1172,6 @@ dependencies:
         packages:
           - rich
           - pytest-httpserver
-          - pytest-timeout
           - zstandard
           # Used by ci/timeout_with_stack.py utility
           - psutil
@@ -1181,6 +1180,10 @@ dependencies:
           # here to exclude the 3.0.4 release that segfaults on pd.Timedelta
           # (https://github.com/pandas-dev/pandas/issues/66086).
           - *pandas
+      - output_types: conda
+        packages:
+          # Used by timeout_with_stack.py utility
+          - gdb
   test_python_narwhals:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/cudf_polars/pyproject.toml
+++ b/python/cudf_polars/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
 test = [
     "dask-cuda==26.8.*,>=0.0.0a0",
     "pandas>=3.0.0,<3.0.4a0",
+    "psutil",
     "pytest-cov",
     "pytest-httpserver",
     "pytest-timeout",

--- a/python/cudf_polars/pyproject.toml
+++ b/python/cudf_polars/pyproject.toml
@@ -48,7 +48,6 @@ test = [
     "psutil",
     "pytest-cov",
     "pytest-httpserver",
-    "pytest-timeout",
     "pytest-xdist",
     "pytest<9.1.0",
     "rich",
@@ -92,7 +91,6 @@ filterwarnings = [
     "error",
     "ignore:Port .* is already in use.:UserWarning",
 ]
-timeout = 45
 xfail_strict = true
 
 [tool.coverage.report]

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -339,9 +339,6 @@ def engine_raise_on_fail() -> pl.GPUEngine:
 def timeout_seconds() -> int:
     """
     Conservative timeout for APIs that accept a timeout parameter.
-
-    Since pytest-timeout is installed, ensure this value is less than timeout
-    in python/cudf_polars/pyproject.toml.
     """
     return 30
 

--- a/python/cudf_polars/tests/expressions/test_rolling.py
+++ b/python/cudf_polars/tests/expressions/test_rolling.py
@@ -358,7 +358,6 @@ def test_rank_over_with_null_values(
 @pytest.mark.parametrize("method", ["ordinal", "dense", "min", "max", "average"])
 @pytest.mark.parametrize("descending", [False, True])
 @pytest.mark.parametrize("order_by", [None, ["g2", pl.col("x2") * 2]])
-@pytest.mark.timeout(120)
 def test_rank_over_with_null_group_keys(
     engine: pl.GPUEngine,
     df: pl.LazyFrame,

--- a/python/cudf_polars/tests/streaming/test_scan.py
+++ b/python/cudf_polars/tests/streaming/test_scan.py
@@ -73,7 +73,6 @@ def df():
         ("parquet", pl.scan_parquet),
     ],
 )
-@pytest.mark.timeout(90)
 def test_parallel_scan(
     tmp_path: Path,
     df: pl.DataFrame,

--- a/python/cudf_polars/tests/streaming/test_sort.py
+++ b/python/cudf_polars/tests/streaming/test_sort.py
@@ -87,7 +87,6 @@ def large_frames():
     )
 
 
-@pytest.mark.timeout(120)
 def test_sort(df, engine):
     q = df.sort(by=["y", "z"])
     assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
## Description
Timing out an individual test is actually not useful since it is not safe
to cancel a test at an arbitrary point in execution: that might leave a
collective dangling.

Moreover, many of the Polars tests run quite close to the, arbitrarily
chosen, timeout limit on CI runners if they are heavily loaded.

Since the signal we actually want is the state of a hanging process,
instead just add a test-suite level timeout with a utility to print the
state of the hanging processes.

closes https://github.com/rapidsai/cudf/issues/22948

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
