### PR TITLE
improvement: refactor cudf::strings::detail::gather

### DIFF
--- a/cpp/include/cudf/strings/detail/gather.cuh
+++ b/cpp/include/cudf/strings/detail/gather.cuh
@@ -14,8 +14,8 @@
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/strings/detail/utilities.hpp>
-#include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/string_view.hpp>
+#include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/prefetch.hpp>
@@ -272,13 +272,11 @@ std::unique_ptr<cudf::column> gather(strings_column_view const& strings,
                                            strings.size()};
 
   auto sizes_itr = thrust::make_transform_iterator(
-    begin,
-    cuda::proclaim_return_type<size_type>(
-      [source] __device__(size_type idx) {
-        if (NullifyOutOfBounds && (idx < 0 || idx >= source.size)) { return 0; }
-        if (not source.is_valid(idx)) { return 0; }
-        return source.size_bytes(idx);
-      }));
+    begin, cuda::proclaim_return_type<size_type>([source] __device__(size_type idx) {
+      if (NullifyOutOfBounds && (idx < 0 || idx >= source.size)) { return 0; }
+      if (not source.is_valid(idx)) { return 0; }
+      return source.size_bytes(idx);
+    }));
 
   auto [out_offsets_column, out_char_bytes] = cudf::strings::detail::make_offsets_child_column(
     sizes_itr, sizes_itr + output_count, stream, mr);
@@ -301,9 +299,9 @@ std::unique_ptr<cudf::column> gather(strings_column_view const& strings,
   int64_t const average_string_length = out_char_bytes / output_count;
 
   auto const strings_begin = cudf::detail::make_counting_transform_iterator(
-    size_type{0},
-    cuda::proclaim_return_type<string_view>(
-      [source] __device__(size_type idx) { return source.element(idx); }));
+    size_type{0}, cuda::proclaim_return_type<string_view>([source] __device__(size_type idx) {
+      return source.element(idx);
+    }));
 
   if (average_string_length > string_parallel_threshold) {
     constexpr int max_threadblocks = 65536;
@@ -332,8 +330,7 @@ std::unique_ptr<cudf::column> gather(strings_column_view const& strings,
     } else {
       // Iterator over the character column of input strings to gather
       auto in_chars_itr = thrust::make_transform_iterator(
-        begin,
-        cuda::proclaim_return_type<char const*>([source] __device__(size_type idx) {
+        begin, cuda::proclaim_return_type<char const*>([source] __device__(size_type idx) {
           if (NullifyOutOfBounds && (idx < 0 || idx >= source.size)) {
             return static_cast<char const*>(nullptr);
           }
@@ -343,11 +340,9 @@ std::unique_ptr<cudf::column> gather(strings_column_view const& strings,
 
       // Iterator over the output locations to write the output
       auto out_chars_itr = cudf::detail::make_counting_transform_iterator(
-        0,
-        cuda::proclaim_return_type<char*>(
-          [offsets_view, d_out_chars] __device__(size_type idx) {
-            return d_out_chars + offsets_view[idx];
-          }));
+        0, cuda::proclaim_return_type<char*>([offsets_view, d_out_chars] __device__(size_type idx) {
+          return d_out_chars + offsets_view[idx];
+        }));
 
       // Determine temporary device storage requirements
       size_t temp_storage_bytes = 0;

--- a/cpp/include/cudf/strings/detail/gather.cuh
+++ b/cpp/include/cudf/strings/detail/gather.cuh
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <cudf/column/column.hpp>
-#include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/detail/iterator.cuh>
 #include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
@@ -15,6 +15,8 @@
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/strings/string_view.hpp>
+#include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/prefetch.hpp>
 
@@ -34,6 +36,37 @@
 namespace cudf {
 namespace strings {
 namespace detail {
+
+/**
+ * @brief Non-owning device-access descriptor for a strings column.
+ *
+ * `offsets` is adjusted to the slice, while `chars` and `null_mask` point to
+ * their base allocations.
+ */
+struct string_gather_source {
+  cudf::detail::input_offsetalator offsets;
+  char const* chars;
+  bitmask_type const* null_mask;
+  size_type null_mask_offset;
+  size_type size;
+
+  __device__ bool is_valid(size_type idx) const
+  {
+    return null_mask == nullptr || bit_is_set(null_mask, null_mask_offset + idx);
+  }
+
+  __device__ size_type size_bytes(size_type idx) const
+  {
+    return static_cast<size_type>(offsets[idx + 1] - offsets[idx]);
+  }
+
+  __device__ string_view element(size_type idx) const
+  {
+    auto const offset = offsets[idx];
+    auto const bytes  = static_cast<size_type>(offsets[idx + 1] - offset);
+    return bytes == 0 ? string_view{} : string_view{chars + offset, bytes};
+  }
+};
 
 // Helper function for loading 16B from a potentially unaligned memory location to registers.
 __forceinline__ __device__ uint4 load_uint4(char const* ptr)
@@ -229,18 +262,22 @@ std::unique_ptr<cudf::column> gather(strings_column_view const& strings,
   if (output_count == 0) return make_empty_column(type_id::STRING);
 
   // build offsets column
-  auto const d_strings    = column_device_view::create(strings.parent(), stream);
   auto const d_in_offsets = cudf::detail::offsetalator_factory::make_input_iterator(
     strings.is_empty() ? make_empty_column(type_id::INT32)->view() : strings.offsets(),
     strings.offset());
+  auto const source = string_gather_source{d_in_offsets,
+                                           strings.chars_begin(stream),
+                                           strings.null_mask(),
+                                           strings.offset(),
+                                           strings.size()};
 
   auto sizes_itr = thrust::make_transform_iterator(
     begin,
     cuda::proclaim_return_type<size_type>(
-      [d_strings = *d_strings, d_in_offsets] __device__(size_type idx) {
-        if (NullifyOutOfBounds && (idx < 0 || idx >= d_strings.size())) { return 0; }
-        if (not d_strings.is_valid(idx)) { return 0; }
-        return static_cast<size_type>(d_in_offsets[idx + 1] - d_in_offsets[idx]);
+      [source] __device__(size_type idx) {
+        if (NullifyOutOfBounds && (idx < 0 || idx >= source.size)) { return 0; }
+        if (not source.is_valid(idx)) { return 0; }
+        return source.size_bytes(idx);
       }));
 
   auto [out_offsets_column, out_char_bytes] = cudf::strings::detail::make_offsets_child_column(
@@ -263,6 +300,11 @@ std::unique_ptr<cudf::column> gather(strings_column_view const& strings,
 
   int64_t const average_string_length = out_char_bytes / output_count;
 
+  auto const strings_begin = cudf::detail::make_counting_transform_iterator(
+    size_type{0},
+    cuda::proclaim_return_type<string_view>(
+      [source] __device__(size_type idx) { return source.element(idx); }));
+
   if (average_string_length > string_parallel_threshold) {
     constexpr int max_threadblocks = 65536;
     auto const grid_size =
@@ -273,7 +315,7 @@ std::unique_ptr<cudf::column> gather(strings_column_view const& strings,
                                       warps_per_threadblock * cudf::detail::warp_size,
                                       0,
                                       stream.value()>>>(
-      d_strings->begin<string_view>(), d_out_chars, offsets_view, begin, output_count);
+      strings_begin, d_out_chars, offsets_view, begin, output_count);
   } else {
     // Threshold is based on empirical data on H100.
     // If row count is above this threshold we use the cub::DeviceMemcpy::Batched API, otherwise we
@@ -286,24 +328,24 @@ std::unique_ptr<cudf::column> gather(strings_column_view const& strings,
         static_cast<int64_t>(output_count), static_cast<int64_t>(strings_per_threadblock));
       gather_chars_fn_char_parallel<strings_per_threadblock>
         <<<grid_size, warps_per_threadblock * cudf::detail::warp_size, 0, stream.value()>>>(
-          d_strings->begin<string_view>(), d_out_chars, offsets_view, begin, output_count);
+          strings_begin, d_out_chars, offsets_view, begin, output_count);
     } else {
       // Iterator over the character column of input strings to gather
       auto in_chars_itr = thrust::make_transform_iterator(
         begin,
-        cuda::proclaim_return_type<char const*>([d_strings = *d_strings] __device__(size_type idx) {
-          if (NullifyOutOfBounds && (idx < 0 || idx >= d_strings.size())) {
+        cuda::proclaim_return_type<char const*>([source] __device__(size_type idx) {
+          if (NullifyOutOfBounds && (idx < 0 || idx >= source.size)) {
             return static_cast<char const*>(nullptr);
           }
-          if (not d_strings.is_valid(idx)) { return static_cast<char const*>(nullptr); }
-          return d_strings.element<string_view>(idx).data();
+          if (not source.is_valid(idx)) { return static_cast<char const*>(nullptr); }
+          return source.element(idx).data();
         }));
 
       // Iterator over the output locations to write the output
       auto out_chars_itr = cudf::detail::make_counting_transform_iterator(
         0,
         cuda::proclaim_return_type<char*>(
-          [d_strings = *d_strings, offsets_view, d_out_chars] __device__(size_type idx) {
+          [offsets_view, d_out_chars] __device__(size_type idx) {
             return d_out_chars + offsets_view[idx];
           }));
 

--- a/cpp/tests/copying/gather_str_tests.cpp
+++ b/cpp/tests/copying/gather_str_tests.cpp
@@ -13,6 +13,8 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
+#include <cuda/iterator>
+
 #include <random>
 
 class GatherTestStr : public cudf::test::BaseFixture {};
@@ -64,6 +66,48 @@ TEST_F(GatherTestStr, GatherSlicedStringsColumn)
     auto result = cudf::gather(cudf::table_view{{sliced_strings[2]}}, gather_map);
     CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result->view());
   }
+}
+
+TEST_F(GatherTestStr, GatherLongSlicedNullableStrings)
+{
+  std::string const a(80, 'a');
+  std::string const b(80, 'b');
+  std::string const c(80, 'c');
+
+  cudf::test::strings_column_wrapper strings{
+    {"prefix", a, b, c, "suffix"}, {true, true, false, true, true}};
+
+  std::vector<cudf::size_type> const slice_indices{1, 4};
+  auto const sliced_strings = cudf::slice(strings, slice_indices);
+
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> gather_map{{2, 0, 1}};
+  auto result = cudf::gather(cudf::table_view{{sliced_strings[0]}}, gather_map);
+
+  cudf::test::strings_column_wrapper expected{{c, a, b}, {true, true, false}};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view().column(0));
+}
+
+TEST_F(GatherTestStr, GatherCubBatchedCopy)
+{
+  constexpr cudf::size_type output_count = 512 * 1024;
+  auto const zeros                       = cuda::constant_iterator<cudf::size_type>{0};
+
+  cudf::test::strings_column_wrapper valid_strings({"x"});
+  cudf::test::strings_column_wrapper null_strings({""}, {false});
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> gather_map(
+    zeros, zeros + output_count);
+
+  auto result = cudf::gather(cudf::table_view{{valid_strings, null_strings}}, gather_map);
+
+  auto const x_values = cuda::constant_iterator<std::string>{"x"};
+  auto const empty    = cuda::constant_iterator<std::string>{""};
+  auto const invalid  = cuda::constant_iterator<bool>{false};
+  cudf::test::strings_column_wrapper expected_valid(x_values, x_values + output_count);
+  cudf::test::strings_column_wrapper expected_null(
+    empty, empty + output_count, invalid);
+
+  cudf::table_view expected{{expected_valid, expected_null}};
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result->view());
 }
 
 TEST_F(GatherTestStr, Gather)

--- a/cpp/tests/copying/gather_str_tests.cpp
+++ b/cpp/tests/copying/gather_str_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf_test/base_fixture.hpp>
@@ -74,8 +74,8 @@ TEST_F(GatherTestStr, GatherLongSlicedNullableStrings)
   std::string const b(80, 'b');
   std::string const c(80, 'c');
 
-  cudf::test::strings_column_wrapper strings{
-    {"prefix", a, b, c, "suffix"}, {true, true, false, true, true}};
+  cudf::test::strings_column_wrapper strings{{"prefix", a, b, c, "suffix"},
+                                             {true, true, false, true, true}};
 
   std::vector<cudf::size_type> const slice_indices{1, 4};
   auto const sliced_strings = cudf::slice(strings, slice_indices);
@@ -94,8 +94,7 @@ TEST_F(GatherTestStr, GatherCubBatchedCopy)
 
   cudf::test::strings_column_wrapper valid_strings({"x"});
   cudf::test::strings_column_wrapper null_strings({""}, {false});
-  cudf::test::fixed_width_column_wrapper<cudf::size_type> gather_map(
-    zeros, zeros + output_count);
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> gather_map(zeros, zeros + output_count);
 
   auto result = cudf::gather(cudf::table_view{{valid_strings, null_strings}}, gather_map);
 
@@ -103,8 +102,7 @@ TEST_F(GatherTestStr, GatherCubBatchedCopy)
   auto const empty    = cuda::constant_iterator<std::string>{""};
   auto const invalid  = cuda::constant_iterator<bool>{false};
   cudf::test::strings_column_wrapper expected_valid(x_values, x_values + output_count);
-  cudf::test::strings_column_wrapper expected_null(
-    empty, empty + output_count, invalid);
+  cudf::test::strings_column_wrapper expected_null(empty, empty + output_count, invalid);
 
   cudf::table_view expected{{expected_valid, expected_null}};
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result->view());

--- a/cpp/tests/streams/copying_test.cpp
+++ b/cpp/tests/streams/copying_test.cpp
@@ -36,6 +36,17 @@ TEST_F(CopyingTest, Gather)
                cudf::test::get_default_stream());
 }
 
+TEST_F(CopyingTest, GatherStrings)
+{
+  cudf::test::strings_column_wrapper source_column{"a", "bb", "ccc"};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> gather_map{2, 0, 1};
+
+  cudf::gather(cudf::table_view{{source_column}},
+               gather_map,
+               cudf::out_of_bounds_policy::DONT_CHECK,
+               cudf::test::get_default_stream());
+}
+
 TEST_F(CopyingTest, ReverseTable)
 {
   constexpr cudf::size_type num_values{10};


### PR DESCRIPTION
## Description

This change is a small refactor to the `gather()` implementation for strings.

It removes a `column_device_view::create` which eliminates an H->D copy and stream sync for child column metadata. When `gather()` is called, we already have the relevant buffers on the GPU (offsets, chars) to perform the gather, so the `column_device_view::create` is unnecessary.

Note that the `gather()` still has a sync and `D->H` transfer for `make_offsets_child_column`. This one is pretty unavoidable. Because we produce a `cudf::column` for the `gather()` output which needs the size of the underlying device allocation, we have to report the output size back to the host.

This change was inspired by https://github.com/gabotechs/libcudf-rs/issues/75. We're experimenting with an execution layer on top of cudf. Stream syncs within the library make it hard to pipeline / schedule work. Regardless of performance issues in that project, this change is a small refactor which I think would be beneficial.  

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
