### PR TITLE
Fix RMM ABI namespace device buffer forward declaration

### DIFF
--- a/cpp/include/cudf/types.hpp
+++ b/cpp/include/cudf/types.hpp
@@ -28,6 +28,7 @@
 #include <cudf/utilities/export.hpp>
 
 #include <cuda/std/iterator>
+#include <rmm/detail/export.hpp>
 
 #include <cassert>
 #include <cstddef>
@@ -41,7 +42,9 @@
 // Forward declarations
 /// @cond
 namespace rmm {
+inline namespace RMM_ABI_NAMESPACE {
 class device_buffer;
+}  // namespace RMM_ABI_NAMESPACE
 /// @endcond
 
 }  // namespace rmm

--- a/cpp/include/cudf/types.hpp
+++ b/cpp/include/cudf/types.hpp
@@ -27,8 +27,9 @@
 
 #include <cudf/utilities/export.hpp>
 
-#include <cuda/std/iterator>
 #include <rmm/detail/export.hpp>
+
+#include <cuda/std/iterator>
 
 #include <cassert>
 #include <cstddef>


### PR DESCRIPTION
## Description

Updates cuDF’s `rmm::device_buffer` forward declaration to use RMM’s versioned ABI namespace. This restores compatibility with https://github.com/rapidsai/rmm/pull/2462, which introduced the versioned RMM ABI namespace on `release/26.08`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
