### PR TITLE
Fix lazy quantifier priority handling in Glushkov regex engine

### DIFF
--- a/cpp/src/strings/regex/glushkov_regcomp.cpp
+++ b/cpp/src/strings/regex/glushkov_regcomp.cpp
@@ -278,9 +278,9 @@ bool positions_chars_overlap(gkprog const& gp, uint32_t const p, uint32_t const 
  *        Glushkov's bit-order cannot represent.
  *
  * Two rules:
- *   Rule 1 – END before char: an ACCEPT item appears before the first CHAR_POS
- *             item in Thompson priority order → the pattern can empty-match in a way
- *             that priority_kill cannot handle correctly.
+ *   Rule 1 – ACCEPT before later char: an ACCEPT item appears before a CHAR_POS
+ *             item in Thompson priority order → the accepted path has higher
+ *             priority than a continuation that Glushkov cannot kill correctly.
  *   Rule 2 – non-monotone gpos + char overlap: two CHAR_POS items appear with
  *             the higher-priority one at a larger gpos (inverted bit order), AND
  *             they can match a common character → priority_kill picks the wrong
@@ -288,19 +288,13 @@ bool positions_chars_overlap(gkprog const& gp, uint32_t const p, uint32_t const 
  */
 bool frontier_has_priority_conflict(std::vector<frontier_item> const& items, gkprog const& gp)
 {
-  // Rule 1: ACCEPT before any CHAR_POS, but only when the frontier also
-  // contains at least one CHAR_POS.  An ACCEPT-only frontier (the normal
-  // "end of pattern" case) is not a priority conflict.
-  bool seen_char          = false;
-  bool accept_before_char = false;
+  // Rule 1: ACCEPT before a later CHAR_POS. A frontier ending in ACCEPT (the
+  // normal "end of pattern" case) is not a priority conflict.
+  bool seen_accept = false;
   for (auto const& item : items) {
-    if (item.kind == frontier_item::CHAR_POS) {
-      seen_char = true;
-    } else if (item.kind == frontier_item::ACCEPT && !seen_char) {
-      accept_before_char = true;
-    }
+    if (item.kind == frontier_item::ACCEPT) { seen_accept = true; }
+    if (item.kind == frontier_item::CHAR_POS && seen_accept) { return true; }
   }
-  if (accept_before_char && seen_char) { return true; }
 
   // Rule 2: non-monotone gpos pair with character overlap
   for (size_t i = 0; i < items.size(); ++i) {

--- a/cpp/src/strings/regex/glushkov_regcomp.hpp
+++ b/cpp/src/strings/regex/glushkov_regcomp.hpp
@@ -102,6 +102,8 @@ struct gkprog {
  *   - Pattern has more than GLUSHKOV_MAX_STATES character-consuming positions.
  *   - Pattern is nullable (matches the empty string): priority semantics cannot
  *     be faithfully represented without an ε-position for the empty match.
+ *   - Pattern has a Thompson-priority frontier that Glushkov's bit ordering
+ *     cannot represent faithfully.
  *
  * @param prog  Compiled Thompson NFA (after reprog::finalize()).
  * @return      Host-side Glushkov program, or nullptr on failure.

--- a/cpp/tests/strings/split_tests.cpp
+++ b/cpp/tests/strings/split_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -514,6 +514,35 @@ TEST_F(StringsSplitTest, SplitRecordRegex)
     // rsplit == split when using default parameters
     result = cudf::strings::rsplit_record_re(sv, *prog);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result->view(), expected);
+  }
+}
+
+TEST_F(StringsSplitTest, SplitRecordRegexLazyQuantifier)
+{
+  auto const input = cudf::test::strings_column_wrapper({"\rbaab\r\ra"});
+  auto const sv    = cudf::strings_column_view(input);
+  using LCW        = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  {
+    LCW expected({LCW{"\rbaa", "\ra"}});
+    auto const prog =
+      cudf::strings::regex_program::create("[^ \v\n\t\r\f]\\r+?\\n*",
+                                           cudf::strings::regex_flags::EXT_NEWLINE,
+                                           cudf::strings::capture_groups::NON_CAPTURE);
+    auto const result = cudf::strings::split_record_re(sv, *prog);
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
+  }
+
+  {
+    LCW expected({LCW{"\rbaa", "a"}});
+    auto const prog =
+      cudf::strings::regex_program::create("[^ \v\n\t\r\f]\\r+\\n*",
+                                           cudf::strings::regex_flags::EXT_NEWLINE,
+                                           cudf::strings::capture_groups::NON_CAPTURE);
+    auto const result = cudf::strings::split_record_re(sv, *prog);
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
   }
 }
 


### PR DESCRIPTION
## Description

Closes #23287.

The Glushkov eligibility checker previously rejected an `ACCEPT` item only when it appeared before the first character-consuming frontier item. This missed Thompson-priority frontiers such as `[LF, ACCEPT, CR-repeat]`, where a successful accept has higher priority than a later continuation. Flattening that ordering into Glushkov bit positions caused a reluctant `\r+?` delimiter to consume a second `\r`, producing greedy behavior in `split_record_re`.

This PR:

- rejects a Glushkov frontier whenever an `ACCEPT` item is followed by a later `CHAR_POS`, conservatively falling back to the Thompson engine;
- preserves safe frontiers that end in `ACCEPT`;
- adds `StringsSplitTest.SplitRecordRegexLazyQuantifier` to verify the delimiter length and resulting split records.

The change affects only patterns whose Thompson-priority ordering cannot be represented faithfully by the Glushkov fast path. Supported patterns continue to use Glushkov.

### Validation

- Focused `StringsSplitTest.SplitRecordRegexLazyQuantifier`: 1/1 passed.
- Focused regression with `LIBCUDF_DISABLE_GLUSHKOV=1`: 1/1 passed.
- Full `STRINGS_TEST`: 540/540 passed.
- Clean local `spark-rapids-jni` package using this cuDF checkout: `BUILD SUCCESS`; a second same-toolchain rebuild also completed successfully.
- NVIDIA/cudf-spark, Scala 2.13 / Spark 4.0.1, `RegularExpressionTranspilerSuite`: 97 succeeded, 0 failed, 6 pre-existing canceled tests; Maven `BUILD SUCCESS`. The original `string split fuzz - anchor focused` failure passed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
