### PR TITLE
Fix 26.10 versions

### DIFF
--- a/.agents/skills/reproduce-ci/SKILL.md
+++ b/.agents/skills/reproduce-ci/SKILL.md
@@ -94,7 +94,7 @@ Use this option when the user already knows the container image and CI script.
 
 The container image tag corresponds to the current RAPIDS version. Derive it from the `VERSION` file at the repo root:
 ```bash
-RAPIDS_VERSION=$(head -1 VERSION | cut -d. -f1,2)  # e.g., "26.08"
+RAPIDS_VERSION=$(head -1 VERSION | cut -d. -f1,2)
 ```
 
 All CI job definitions live in `.github/workflows/pr.yaml`. Each job specifies:
@@ -123,7 +123,7 @@ Invoke `run.sh` with the parameters determined in Step 1:
 Use `--dry-run` first to preview the exact docker command before executing:
 
 ```bash
-.agents/skills/reproduce-ci/run.sh rapidsai/ci-conda:26.08-latest ci/build_cpp.sh 22538 --dry-run
+.agents/skills/reproduce-ci/run.sh rapidsai/ci-conda:${RAPIDS_VERSION}-latest ci/build_cpp.sh 22538 --dry-run
 ```
 
 Examples:

--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-mambaforge"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/cudf/devcontainer:26.08-cuda12.9-conda"
+      "ghcr.io/rapidsai/cudf/devcontainer:26.10-cuda12.9-conda"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-cuda12.9-ucx1.19.0-openmpi5.0.10"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/cudf/devcontainer:26.08-cuda12.9-pip"
+      "ghcr.io/rapidsai/cudf/devcontainer:26.10-cuda12.9-pip"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda13.3-conda/devcontainer.json
+++ b/.devcontainer/cuda13.3-conda/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-mambaforge"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/cudf/devcontainer:26.08-cuda13.3-conda"
+      "ghcr.io/rapidsai/cudf/devcontainer:26.10-cuda13.3-conda"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda13.3-pip/devcontainer.json
+++ b/.devcontainer/cuda13.3-pip/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-cuda13.3-ucx1.19.0-openmpi5.0.10"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/cudf/devcontainer:26.08-cuda13.3-pip"
+      "ghcr.io/rapidsai/cudf/devcontainer:26.10-cuda13.3-pip"
     ]
   },
   "runArgs": [

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -237,6 +237,7 @@ sed_runner "s|/blob/\\bmain\\b/|/blob/${RAPIDS_BRANCH_NAME}/|g" python/custreamz
 # .devcontainer files
 find .devcontainer/ -type f -name devcontainer.json -print0 | while IFS= read -r -d '' filename; do
     sed_runner "s@rapidsai/devcontainers:[0-9.]*@rapidsai/devcontainers:${NEXT_SHORT_TAG}@g" "${filename}"
+    sed_runner "s@ghcr.io/rapidsai/cudf/devcontainer:[0-9.]*@ghcr.io/rapidsai/cudf/devcontainer:${NEXT_SHORT_TAG}@g" "${filename}"
     sed_runner "s@rapidsai/devcontainers/features/cuda:[0-9.]*@rapidsai/devcontainers/features/cuda:${NEXT_SHORT_TAG_PEP440}@" "${filename}"
     sed_runner "s@rapidsai/devcontainers/features/rapids-build-utils:[0-9.]*@rapidsai/devcontainers/features/rapids-build-utils:${NEXT_SHORT_TAG_PEP440}@" "${filename}"
     sed_runner "s@rapids-\${localWorkspaceFolderBasename}-[0-9.]*@rapids-\${localWorkspaceFolderBasename}-${NEXT_SHORT_TAG}@g" "${filename}"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -221,6 +221,7 @@ done
 NEXT_FULL_JAVA_TAG="${NEXT_SHORT_TAG}.${PATCH_PEP440}-SNAPSHOT"
 sed_runner "s|<version>.*-SNAPSHOT</version>|<version>${NEXT_FULL_JAVA_TAG}</version>|g" java/pom.xml
 sed_runner "s|cudf-.*-SNAPSHOT|cudf-${NEXT_FULL_JAVA_TAG}|g" java/ci/README.md
+sed_runner "s|/ai/rapids/cudf/[0-9]\+\.[0-9]\+\.[0-9]\+-SNAPSHOT/|/ai/rapids/cudf/${NEXT_FULL_JAVA_TAG}/|g" java/ci/README.md
 
 # Java documentation references
 sed_runner "s|release/[0-9]\+\.[0-9]\+|${RAPIDS_BRANCH_NAME}|g" java/ci/README.md

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -41,13 +41,13 @@ so plain `rm -rf` works.
 ```
 
 This compiles the JNI layer against the static libcudf from Step 1 and emits a
-single classifier JAR (e.g. `cudf-26.08.0-SNAPSHOT-cuda12.jar`) plus its POM
+single classifier JAR (e.g. `cudf-26.10.0-SNAPSHOT-cuda12.jar`) plus its POM
 into a classifier-named subdirectory under `--output-dir`:
 
 ```
 /tmp/jars/cuda12/
-    cudf-26.08.0-SNAPSHOT-cuda12.jar
-    cudf-26.08.0-SNAPSHOT.pom
+    cudf-26.10.0-SNAPSHOT-cuda12.jar
+    cudf-26.10.0-SNAPSHOT.pom
 ```
 
 The classifier is derived from `--cuda-version` (major) + host arch (`uname
@@ -73,10 +73,10 @@ artifact version from the JAR filenames (requiring a single unique version
 across subdirs), and lays them out as:
 
 ```
-/tmp/maven-repo/ai/rapids/cudf/26.08.0-SNAPSHOT/
-    cudf-26.08.0-SNAPSHOT-cuda12.jar
-    cudf-26.08.0-SNAPSHOT-cuda13.jar
-    cudf-26.08.0-SNAPSHOT.pom
+/tmp/maven-repo/ai/rapids/cudf/26.10.0-SNAPSHOT/
+    cudf-26.10.0-SNAPSHOT-cuda12.jar
+    cudf-26.10.0-SNAPSHOT-cuda13.jar
+    cudf-26.10.0-SNAPSHOT.pom
 ```
 
 The set of classifiers is whatever subdirectories are present under


### PR DESCRIPTION
## Description
There were a few locations that `ci/release/update-version.sh` wasn't updating correctly.

This updates the Java README, devcontainers, and skills.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
