### PR TITLE
Bump cudf-polars test suite timeouts

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -64,7 +64,7 @@ DESELECTED_TESTS_STR=$(printf -- " --deselect %s" "${DESELECTED_TESTS[@]}")
 # shellcheck disable=SC2086
 # Fail fast (-x) because failed tests pollute the state
 echo "Run polars tests with injected in-memory GPU engine"
-python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
+python "${TIMEOUT_TOOL_PATH}" --enable-python 4800 \
    python -m pytest \
        --import-mode=importlib \
        --cache-clear \
@@ -85,7 +85,7 @@ python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
 echo "Run polars tests with injected SPMD GPU engine, small blocksize"
 CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE=805306368 \
 CUDF_POLARS__EXECUTOR__FALLBACK_MODE=silent \
-python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
+python "${TIMEOUT_TOOL_PATH}" --enable-python 4800 \
    python -m pytest \
        --import-mode=importlib \
        --cache-clear \

--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -10,5 +10,5 @@ TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_st
 
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 
-python "${TIMEOUT_TOOL_PATH}" --enable-python 3600 \
+python "${TIMEOUT_TOOL_PATH}" --enable-python 4800 \
        python -m pytest --cache-clear "$@" tests


### PR DESCRIPTION
## Description

We've observed some cudf-polars runs taking >1 hour to complete, while runs on different, but similar, hardware take <15 minutes.

We've resolved most of the outright hangs now. Under the assumption that it's preferable to wait for a job to complete rather than restarting, we'll bump the timeout here.
