### PR TITLE
Optimize Python overheads in Parquet metadata preprocessing 

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/io.py
+++ b/python/cudf_polars/cudf_polars/streaming/io.py
@@ -895,12 +895,8 @@ def _columnchunk_metadata_from_footers(
 ) -> dict[str, list[int]]:
     columnchunk_metadata: dict[str, list[int]] = {}
     for fmd in footers:
-        for rg in fmd.row_groups:
-            for col in rg.columns:
-                name = ".".join(col.meta_data.path_in_schema)
-                columnchunk_metadata.setdefault(name, []).append(
-                    col.meta_data.total_uncompressed_size
-                )
+        for name, uncompressed_sizes in fmd.columnchunk_metadata.items():
+            columnchunk_metadata.setdefault(name, []).extend(uncompressed_sizes)
     return columnchunk_metadata
 
 
@@ -987,7 +983,7 @@ class ParquetMetadata:
             row_count = num_rows_per_sampled_file * self.total_file_count
 
         num_row_groups_per_sampled_file = [
-            len(fmd.row_groups) for fmd in sample_footers
+            len(fmd.row_group_num_rows) for fmd in sample_footers
         ]
         rowgroup_offsets_per_file = list(
             itertools.accumulate(num_row_groups_per_sampled_file, initial=0)

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pyi
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pyi
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from pylibcudf.io.types import SourceInfo
@@ -54,6 +54,8 @@ class FileMetaData:
     def row_groups(self) -> list[RowGroup]: ...
     @property
     def row_group_num_rows(self) -> list[int]: ...
+    @property
+    def columnchunk_metadata(self) -> dict[str, list[int]]: ...
 
 class SortingColumn:
     @property

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from libc.stdint cimport uint8_t
@@ -514,6 +514,54 @@ cdef class FileMetaData:
         cdef Py_ssize_t i
         cdef Py_ssize_t n = self.c_obj.row_groups.size()
         return [self.c_obj.row_groups[i].num_rows for i in range(n)]
+
+    @property
+    def columnchunk_metadata(self):
+        """
+        Get a map of dotted column paths to lists of
+        `total_uncompressed_size` values from every column chunk in
+        this file.
+
+        Returns
+        -------
+        columnchunk_metadata
+            Map of dotted column paths (``".".join(path_in_schema)``)
+            to lists of `total_uncompressed_size` metadata from all
+            their column chunks.
+
+        Notes
+        -----
+        Equivalent to, but faster than, walking each row group's columns:
+
+        .. code-block:: python
+
+           >>> result: dict[str, list[int]] = {}
+           >>> for rg in file_metadata.row_groups:
+           ...     for col in rg.columns:
+           ...         name = ".".join(col.meta_data.path_in_schema)
+           ...         result.setdefault(name, []).append(
+           ...             col.meta_data.total_uncompressed_size
+           ...         )
+        """
+        cdef Py_ssize_t i, j, k, n_path
+        cdef Py_ssize_t n_rg = self.c_obj.row_groups.size()
+        cdef Py_ssize_t n_col
+        cdef dict result = {}
+        cdef str name
+        cdef list path_parts
+        for i in range(n_rg):
+            n_col = self.c_obj.row_groups[i].columns.size()
+            for j in range(n_col):
+                n_path = self.c_obj.row_groups[i].columns[j].meta_data.path_in_schema.size()
+                path_parts = [
+                    self.c_obj.row_groups[i].columns[j].meta_data.path_in_schema[k].decode("utf-8")
+                    for k in range(n_path)
+                ]
+                name = ".".join(path_parts)
+                result.setdefault(name, []).append(
+                    self.c_obj.row_groups[i].columns[j].meta_data.total_uncompressed_size
+                )
+        return result
 
     @classmethod
     def from_bytes(cls, const uint8_t[::1] footer_bytes):

--- a/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet_metadata.pyx
@@ -500,7 +500,7 @@ cdef class FileMetaData:
 
         Returns
         -------
-        row_counts
+        list
             A list with the row count per row group in this file.
 
         Notes
@@ -524,7 +524,7 @@ cdef class FileMetaData:
 
         Returns
         -------
-        columnchunk_metadata
+        dict[str, list[int]]
             Map of dotted column paths (``".".join(path_in_schema)``)
             to lists of `total_uncompressed_size` metadata from all
             their column chunks.
@@ -543,9 +543,8 @@ cdef class FileMetaData:
            ...             col.meta_data.total_uncompressed_size
            ...         )
         """
-        cdef Py_ssize_t i, j, k, n_path
+        cdef Py_ssize_t i, j, k, n_path, n_col
         cdef Py_ssize_t n_rg = self.c_obj.row_groups.size()
-        cdef Py_ssize_t n_col
         cdef dict result = {}
         cdef str name
         cdef list path_parts

--- a/python/pylibcudf/tests/io/test_parquet.py
+++ b/python/pylibcudf/tests/io/test_parquet.py
@@ -546,6 +546,40 @@ def test_file_metadata_row_group_sorting_columns(tmp_path) -> None:
             assert sorting_column.nulls_first == pa_sorting_column.nulls_first
 
 
+def test_file_metadata_columnchunk_metadata() -> None:
+    table = pa.table(
+        {
+            "a": list(range(100)),
+            "b": [x * 10 for x in range(100)],
+        }
+    )
+    sink = io.BytesIO()
+    write_table(table, sink, row_group_size=25)
+    sink.seek(0)
+    parquet_file = pq.ParquetFile(sink)
+    sink.seek(0)
+
+    source_info = plc.io.SourceInfo([sink])
+    file_metadata = plc.io.parquet_metadata.read_parquet_footers(source_info)[
+        0
+    ]
+
+    result = file_metadata.columnchunk_metadata
+    assert set(result) == {"a", "b"}
+
+    expected: dict[str, list[int]] = {"a": [], "b": []}
+    for rg_idx in range(parquet_file.metadata.num_row_groups):
+        pa_row_group = parquet_file.metadata.row_group(rg_idx)
+        for col_idx in range(pa_row_group.num_columns):
+            pa_col = pa_row_group.column(col_idx)
+            expected[pa_col.path_in_schema].append(
+                pa_col.total_uncompressed_size
+            )
+
+    for name, sizes in expected.items():
+        assert result[name] == sizes
+
+
 # TODO: Test these options
 # list row_groups = None,
 # ^^^ This one is not tested since it's not in pyarrow/pandas, deprecate?


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
When reading in the parquet metadata cudf-polars was doing a couple of inefficient things, particularly effecting statistics calculation. The main issue is that iterating over row groups and column chunks in Python to extract the metadata is inefficient. It requires constructing many Python objects from C++ objects, which has meaningful overhead, and it also means we are constantly grabbing the GIL, which can lead to GIL thrashing across different threads. To avoid this, this PR introduces a bulk Cython API for accessing all the column chunk metadata.

On viking the result is that TPC-H SF1k goes from 191s to 185s, so ~a 3% improvement.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
