### PR TITLE
Disable join filter pushdown rewrites by default

### DIFF
--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -752,6 +752,9 @@ class StreamingExecutor:
         Options controlling the logical join-domain prefilter rewrite. See
         :class:`~cudf_polars.utils.config.JoinFilterPushdownOptions` for more.
         ``None`` disables the rewrite.
+
+        Enable through environment variables with
+        ``CUDF_POLARS__EXECUTOR__JOIN_FILTER_PUSHDOWN=1``.
     max_io_threads
         Maximum number of IO threads. Default is 4.
         This controls the parallelism of IO operations when reading data.
@@ -1102,7 +1105,7 @@ class ConfigOptions(Generic[ExecutorType]):
                 )
                 if user_join_filter_pushdown is None:
                     env_join_filter_pushdown = os.environ.get(
-                        "CUDF_POLARS__EXECUTOR__JOIN_FILTER_PUSHDOWN", "1"
+                        "CUDF_POLARS__EXECUTOR__JOIN_FILTER_PUSHDOWN", "0"
                     )
                     if not _bool_converter(env_join_filter_pushdown):
                         user_executor_options["join_filter_pushdown"] = None

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -615,9 +615,7 @@ def test_dynamic_planning_defaults() -> None:
     assert config.executor.dynamic_planning.join_prefilter_threshold == 0.5
     assert config.executor.dynamic_planning.join_prefilter_max_key_columns == 1
     assert not config.executor.dynamic_planning.join_prefilter_trace
-    assert config.executor.join_filter_pushdown is not None
-    assert config.executor.join_filter_pushdown.threshold == 0.5
-    assert not config.executor.join_filter_pushdown.trace
+    assert config.executor.join_filter_pushdown is None
 
 
 def test_dynamic_planning_disabled_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -642,6 +640,7 @@ def test_dynamic_planning_sample_chunk_count_from_env(
 
 
 def test_join_prefilter_options_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CUDF_POLARS__EXECUTOR__JOIN_FILTER_PUSHDOWN", "1")
     monkeypatch.setenv(
         "CUDF_POLARS__EXECUTOR__DYNAMIC_PLANNING__JOIN_PREFILTER_THRESHOLD", "0.25"
     )
@@ -665,6 +664,7 @@ def test_join_prefilter_options_from_env(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_join_filter_pushdown_options_from_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("CUDF_POLARS__EXECUTOR__JOIN_FILTER_PUSHDOWN", "1")
     monkeypatch.setenv(
         "CUDF_POLARS__EXECUTOR__JOIN_FILTER_PUSHDOWN__THRESHOLD", "0.125"
     )


### PR DESCRIPTION
## Description

This changes the cudf-polars default configuration to disable the join filter pushdown rewrite added in
https://github.com/rapidsai/cudf/pull/22996. It can be re-enabled through an env var with CUDF_POLARS__EXECUTOR__JOIN_FILTER_PUSHDOWN=1, or through python by passing
`join_filter_pushdown=JoinFilterPushdownOptions()`

I'm proposing to disable this for the 26.08 release based on some slowdowns in our pds-h benchmarks at smaller scales (SF-1K on a single H100 GPU).

<img width="1694" height="391" alt="image" src="https://github.com/user-attachments/assets/67766d4c-6d35-4afc-9751-29a98344943b" />

Eventually, I think that the join filter pushdown optimization should be on by default. But I'd like to understand a bit more about the slowdowns observed in that benchmark before turning it on by default.