### PR TITLE
Label profiling thread names in libcudf and cudf-polars

### DIFF
--- a/cpp/include/cudf/detail/utilities/host_worker_pool.hpp
+++ b/cpp/include/cudf/detail/utilities/host_worker_pool.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,6 +32,18 @@ static_assert(THREAD_POOL_LEVEL_NONE == -1, "THREAD_POOL_LEVEL_NONE must be -1")
  * Used by `host_worker_pool()` to route tasks to the correct nesting level.
  */
 CUDF_EXPORT extern thread_local int thread_pool_level;
+
+/**
+ * @brief Set the OS thread name for a host worker pool thread.
+ *
+ * Called once per worker thread the first time it executes a task, so that
+ * profilers (nsys, `top -H`, `/proc/<pid>/task/<tid>/comm`) show a meaningful
+ * name like `cudf-hwp-L1` instead of the parent process name. POSIX only;
+ * a no-op on platforms without `pthread_setname_np`.
+ *
+ * @param level Pool level assigned to this thread.
+ */
+CUDF_EXPORT void set_thread_name_for_pool_level(int level);
 
 /**
  * @brief Thread pool wrapper that marks its threads with ownership.
@@ -77,7 +89,10 @@ class CUDF_EXPORT hierarchical_thread_pool {
 
     return pool_.submit_task([task_ptr, level = level_, device_id]() {
       // Mark this thread as owned by this pool's level (happens once per thread)
-      if (thread_pool_level == THREAD_POOL_LEVEL_NONE) { thread_pool_level = level; }
+      if (thread_pool_level == THREAD_POOL_LEVEL_NONE) {
+        thread_pool_level = level;
+        set_thread_name_for_pool_level(level);
+      }
 
       cudaSetDevice(device_id);
 

--- a/cpp/src/utilities/host_worker_pool.cpp
+++ b/cpp/src/utilities/host_worker_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,9 +7,16 @@
 #include <cudf/detail/utilities/host_worker_pool.hpp>
 #include <cudf/utilities/error.hpp>
 
+#include <pthread.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -22,6 +29,14 @@ thread_local int thread_pool_level = THREAD_POOL_LEVEL_NONE;
 hierarchical_thread_pool::hierarchical_thread_pool(std::size_t num_threads, int level)
   : pool_(num_threads), level_(level)
 {
+}
+
+void set_thread_name_for_pool_level(int level)
+{
+  // Linux caps thread names (comm) at 15 chars + NUL. Keep the name short.
+  std::array<char, 16> name{};
+  std::snprintf(name.data(), name.size(), "cudf-hwp-L%d", level);
+  pthread_setname_np(pthread_self(), name.data());
 }
 
 namespace {

--- a/python/cudf_polars/cudf_polars/dsl/utils/io.py
+++ b/python/cudf_polars/cudf_polars/dsl/utils/io.py
@@ -158,7 +158,9 @@ def prefetch_parquet_file_metadata_for_ir(
     cm: contextlib.AbstractContextManager[concurrent.futures.Executor | None]
 
     if py_executor is None:
-        cm = py_executor = concurrent.futures.ThreadPoolExecutor()
+        cm = py_executor = concurrent.futures.ThreadPoolExecutor(
+            thread_name_prefix="cudf-polars-io"
+        )
     else:
         # We didn't create the executor, so we don't close it.
         cm = contextlib.nullcontext()

--- a/python/cudf_polars/cudf_polars/streaming/explain.py
+++ b/python/cudf_polars/cudf_polars/streaming/explain.py
@@ -112,7 +112,9 @@ def explain_query(
     cm: contextlib.AbstractContextManager[concurrent.futures.Executor]
 
     if executor is None:
-        cm = executor = concurrent.futures.ThreadPoolExecutor()
+        cm = executor = concurrent.futures.ThreadPoolExecutor(
+            thread_name_prefix="cudf-polars-explain"
+        )
     else:
         # we only shut down the executor if we created it.
         cm = contextlib.nullcontext(executor)
@@ -150,7 +152,9 @@ def collect_partition_plan(
     config = ConfigOptions.from_polars_engine(engine)
     ir = Translator(q._ldf.visit(), engine).translate_ir()
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(
+        thread_name_prefix="cudf-polars-explain"
+    ) as executor:
         stats = collect_statistics(ir, config, executor)
     lowered = lower_ir_graph(ir, config, stats)
     lowered_ir = lowered.lowered
@@ -752,7 +756,9 @@ class SerializablePlan:
         cm: contextlib.AbstractContextManager[concurrent.futures.Executor]
 
         if executor is None:
-            cm = executor = concurrent.futures.ThreadPoolExecutor()
+            cm = executor = concurrent.futures.ThreadPoolExecutor(
+                thread_name_prefix="cudf-polars-explain"
+            )
         else:
             cm = contextlib.nullcontext(executor)
 


### PR DESCRIPTION
Give libcudf's host-worker-pool threads (`cudf-hwp-L<level>`) and cudf-polars's `ThreadPoolExecutor` workers (`cudf-polars-io`, `cudf-polars-explain`) real, recognizable thread names by wiring `pthread_setname_np` into the pool init path and passing `thread_name_prefix=` to the Python executors. This makes them attributable in profilers like nsys, `py-spy`, and `/proc/<pid>/task/<tid>/comm` instead of showing up as the parent process name or the truncated `ThreadPoolExecu`.
