### PR TITLE
Add parallel native library extraction

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -13,23 +13,37 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.zip.CRC32;
 
 /**
  * This class will load the native dependencies.
  */
 public class NativeDepsLoader {
   private static final Logger log = LoggerFactory.getLogger(NativeDepsLoader.class);
+  private static final int COPY_BUFFER_SIZE = 1024 * 1024;
+  // Positional extraction uses one copy buffer per worker.
+  private static final int MAX_CONCURRENT_CHUNK_READS =
+      Math.max(1, Math.min(12, Runtime.getRuntime().availableProcessors()));
+  private static final String CHUNK_MANIFEST_SUFFIX = ".chunks.properties";
+  private static final String CHUNK_DIRECTORY_SUFFIX = ".chunks/";
+  private static final String CHUNK_FORMAT_VERSION = "1";
 
   /**
    * Set this system property to true to prevent unpacked dependency files from
@@ -285,6 +299,9 @@ public class NativeDepsLoader {
    * @throws IOException on any error trying to load the libraries.
    */
   public static File loadNativeDep(String depName, boolean preserveDep) throws IOException {
+    if (libNativeDir != null) {
+      validateLibNativeDir(new String[]{depName});
+    }
     String os = System.getProperty("os.name");
     String arch = System.getProperty("os.arch");
     return loadDep(os, arch, depName, preserveDep);
@@ -338,8 +355,8 @@ public class NativeDepsLoader {
     return loc;
   }
 
-  /** Extract the contents of a library resource into a temporary file */
-  private static File createFile(String os, String arch, String baseName) throws IOException {
+  /** Extract the contents of a library resource into a temporary file. */
+  static File createFile(String os, String arch, String baseName) throws IOException {
     String mappedName = System.mapLibraryName(baseName);
     // Fast path: when ai.rapids.cudf.lib-native-dir is set, the loader skips
     // JAR extraction entirely and uses the pre-unpacked file from the
@@ -354,21 +371,25 @@ public class NativeDepsLoader {
       return loc;
     }
     String path = arch + "/" + os + "/" + mappedName;
-    File loc;
-    URL resource = loader.getResource(path);
-    if (resource == null) {
+    URL chunkManifestResource = loader.getResource(path + CHUNK_MANIFEST_SUFFIX);
+    URL resource = chunkManifestResource == null ? loader.getResource(path) : null;
+    if (chunkManifestResource == null && resource == null) {
       throw new FileNotFoundException("Could not locate native dependency " + path);
     }
     long t0 = System.currentTimeMillis();
-    try (InputStream in = resource.openStream()) {
-      loc = File.createTempFile(baseName, ".so");
-      loc.deleteOnExit();
-      try (OutputStream out = new FileOutputStream(loc)) {
-        byte[] buffer = new byte[1024 * 16];
-        int read = 0;
-        while ((read = in.read(buffer)) >= 0) {
-          out.write(buffer, 0, read);
-        }
+    File loc = File.createTempFile(baseName, ".so");
+    loc.deleteOnExit();
+    boolean success = false;
+    try {
+      if (chunkManifestResource == null) {
+        extractConventionalResource(resource, loc);
+      } else {
+        extractChunkedResource(chunkManifestResource, mappedName, loc);
+      }
+      success = true;
+    } finally {
+      if (!success && loc.exists() && !loc.delete()) {
+        log.warn("Could not delete partial native dependency {}", loc);
       }
     }
     if (libLogLoadTiming) {
@@ -377,6 +398,263 @@ public class NativeDepsLoader {
       log.info("Extracted {} in {} ms (size={} MB)", mappedName, elapsed, sizeMB);
     }
     return loc;
+  }
+
+  private static void extractConventionalResource(URL resource, File loc) throws IOException {
+    try (InputStream in = resource.openStream();
+         OutputStream out = new FileOutputStream(loc)) {
+      copy(in, out, new byte[COPY_BUFFER_SIZE]);
+    }
+  }
+
+  private static void extractChunkedResource(URL manifestResource, String mappedName, File loc)
+      throws IOException {
+    extractChunkedResource(
+        manifestResource, mappedName, loc, MAX_CONCURRENT_CHUNK_READS);
+  }
+
+  static void extractChunkedResource(URL manifestResource, String mappedName, File loc,
+                                     int maxConcurrentReads) throws IOException {
+    if (maxConcurrentReads <= 0) {
+      throw new IllegalArgumentException("maxConcurrentReads must be positive");
+    }
+    ChunkManifest manifest = ChunkManifest.load(manifestResource);
+    int concurrentReads = Math.min(maxConcurrentReads, manifest.chunkCount);
+    ExecutorService executor = Executors.newFixedThreadPool(concurrentReads);
+    List<Future<?>> chunkFutures = new ArrayList<>(manifest.chunkCount);
+    try (RandomAccessFile out = new RandomAccessFile(loc, "rw")) {
+      out.setLength(manifest.librarySize);
+      FileChannel outputChannel = out.getChannel();
+      try {
+        for (int i = 0; i < manifest.chunkCount; i++) {
+          chunkFutures.add(submitChunkExtraction(
+              executor, manifestResource, mappedName, manifest, outputChannel, i));
+        }
+        executor.shutdown();
+        awaitChunks(chunkFutures, mappedName);
+      } finally {
+        shutdownAndAwait(executor);
+      }
+    }
+  }
+
+  private static Future<?> submitChunkExtraction(
+      ExecutorService executor, URL manifestResource, String mappedName,
+      ChunkManifest manifest, FileChannel outputChannel, int chunkIndex) throws IOException {
+    String chunkName = String.format(Locale.ROOT, "%05d", chunkIndex);
+    URL chunkResource = new URL(
+        manifestResource, mappedName + CHUNK_DIRECTORY_SUFFIX + chunkName);
+    long outputOffset = manifest.chunkSize * chunkIndex;
+    long expectedSize = manifest.expectedChunkSize(chunkIndex);
+    long expectedCrc32 = manifest.expectedChunkCrc32(chunkIndex);
+    return executor.submit(() -> {
+      extractChunk(chunkResource, outputChannel, outputOffset, expectedSize, expectedCrc32);
+      return null;
+    });
+  }
+
+  private static void awaitChunks(List<Future<?>> futures, String mappedName)
+      throws IOException {
+    IOException failure = null;
+    for (int i = 0; i < futures.size(); i++) {
+      try {
+        futures.get(i).get();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException(String.format(Locale.ROOT,
+            "Interrupted while extracting native dependency chunk %s/%05d",
+            mappedName, i), e);
+      } catch (ExecutionException e) {
+        Throwable cause = e.getCause();
+        IOException chunkFailure = cause instanceof IOException
+            ? (IOException) cause
+            : new IOException(String.format(Locale.ROOT,
+                "Could not extract native dependency chunk %s/%05d", mappedName, i), cause);
+        if (failure == null) {
+          failure = chunkFailure;
+        } else {
+          failure.addSuppressed(chunkFailure);
+        }
+      }
+    }
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  private static void shutdownAndAwait(ExecutorService executor) {
+    executor.shutdownNow();
+    boolean interrupted = Thread.interrupted();
+    while (!executor.isTerminated()) {
+      try {
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static void extractChunk(
+      URL resource, FileChannel outputChannel, long outputOffset,
+      long expectedSize, long expectedCrc32) throws IOException {
+    byte[] buffer = new byte[COPY_BUFFER_SIZE];
+    ByteBuffer bytes = ByteBuffer.wrap(buffer);
+    CRC32 crc = new CRC32();
+    long totalBytes = 0;
+    try (InputStream in = resource.openStream()) {
+      int read;
+      while ((read = in.read(buffer)) != -1) {
+        if (read == 0) {
+          continue;
+        }
+        if (read > expectedSize - totalBytes) {
+          throw new IOException(String.format(Locale.ROOT,
+              "Native dependency chunk %s exceeds expected size of %d bytes",
+              resource, expectedSize));
+        }
+
+        crc.update(buffer, 0, read);
+        bytes.clear();
+        bytes.limit(read);
+        long writeOffset = outputOffset + totalBytes;
+        while (bytes.hasRemaining()) {
+          int written = outputChannel.write(bytes, writeOffset);
+          if (written <= 0) {
+            throw new IOException("Could not make progress writing native dependency " + resource);
+          }
+          writeOffset += written;
+        }
+        totalBytes += read;
+      }
+    } catch (FileNotFoundException e) {
+      throw new IOException("Could not locate native dependency chunk " + resource, e);
+    }
+
+    if (totalBytes != expectedSize) {
+      throw new IOException(String.format(Locale.ROOT,
+          "Native dependency chunk %s has size %d bytes, expected %d",
+          resource, totalBytes, expectedSize));
+    }
+    if (crc.getValue() != expectedCrc32) {
+      throw new IOException(String.format(Locale.ROOT,
+          "Native dependency chunk CRC32 mismatch for %s: expected %08x but extracted %08x",
+          resource, expectedCrc32, crc.getValue()));
+    }
+  }
+
+  private static void copy(InputStream in, OutputStream out, byte[] buffer)
+      throws IOException {
+    int read;
+    while ((read = in.read(buffer)) != -1) {
+      if (read > 0) {
+        out.write(buffer, 0, read);
+      }
+    }
+  }
+
+  private static final class ChunkManifest {
+    private static final String FORMAT_VERSION_KEY = "format.version";
+    private static final String LIBRARY_SIZE_KEY = "library.size";
+    private static final String LIBRARY_CRC32_KEY = "library.crc32";
+    private static final String CHUNK_SIZE_KEY = "chunk.size";
+    private static final String CHUNK_COUNT_KEY = "chunk.count";
+
+    private final long librarySize;
+    private final long chunkSize;
+    private final int chunkCount;
+    private final long[] chunkCrc32;
+
+    private ChunkManifest(long librarySize, long chunkSize, int chunkCount, long[] chunkCrc32) {
+      this.librarySize = librarySize;
+      this.chunkSize = chunkSize;
+      this.chunkCount = chunkCount;
+      this.chunkCrc32 = chunkCrc32;
+    }
+
+    private static ChunkManifest load(URL resource) throws IOException {
+      Properties properties = new Properties();
+      try (InputStream in = resource.openStream()) {
+        properties.load(in);
+      } catch (IllegalArgumentException e) {
+        throw new IOException("Malformed native dependency chunk manifest " + resource, e);
+      }
+      String version = require(properties, FORMAT_VERSION_KEY, resource);
+      if (!CHUNK_FORMAT_VERSION.equals(version)) {
+        throw new IOException("Unsupported native dependency chunk manifest version " + version
+            + " in " + resource);
+      }
+      long librarySize = parsePositiveLong(properties, LIBRARY_SIZE_KEY, resource);
+      long chunkSize = parsePositiveLong(properties, CHUNK_SIZE_KEY, resource);
+      long chunkCountLong = parsePositiveLong(properties, CHUNK_COUNT_KEY, resource);
+      if (chunkCountLong > Integer.MAX_VALUE) {
+        throw new IOException("Native dependency chunk count is too large in " + resource);
+      }
+      long expectedChunkCount = 1 + ((librarySize - 1) / chunkSize);
+      if (chunkCountLong != expectedChunkCount) {
+        throw new IOException(String.format(Locale.ROOT,
+            "Invalid native dependency chunk count in %s: expected %d but found %d",
+            resource, expectedChunkCount, chunkCountLong));
+      }
+      parseCrc32(properties, LIBRARY_CRC32_KEY, resource);
+      int chunkCount = (int) chunkCountLong;
+      long[] chunkCrc32 = new long[chunkCount];
+      for (int i = 0; i < chunkCount; i++) {
+        String key = String.format(Locale.ROOT, "chunk.%05d.crc32", i);
+        chunkCrc32[i] = parseCrc32(properties, key, resource);
+      }
+      return new ChunkManifest(librarySize, chunkSize, chunkCount, chunkCrc32);
+    }
+
+    private static long parseCrc32(Properties properties, String key, URL resource)
+        throws IOException {
+      String value = require(properties, key, resource);
+      if (!value.matches("[0-9a-fA-F]{8}")) {
+        throw new IOException("Invalid " + key + " in " + resource + ": " + value);
+      }
+      try {
+        return Long.parseLong(value, 16);
+      } catch (NumberFormatException e) {
+        throw new IOException("Invalid " + key + " in " + resource + ": " + value, e);
+      }
+    }
+
+    private static long parsePositiveLong(Properties properties, String key, URL resource)
+        throws IOException {
+      String value = require(properties, key, resource);
+      try {
+        long parsed = Long.parseLong(value);
+        if (parsed <= 0) {
+          throw new NumberFormatException("value must be positive");
+        }
+        return parsed;
+      } catch (NumberFormatException e) {
+        throw new IOException("Invalid " + key + " in " + resource + ": " + value, e);
+      }
+    }
+
+    private static String require(Properties properties, String key, URL resource)
+        throws IOException {
+      String value = properties.getProperty(key);
+      if (value == null || value.trim().isEmpty()) {
+        throw new IOException("Missing " + key + " in native dependency chunk manifest "
+            + resource);
+      }
+      return value.trim();
+    }
+
+    private long expectedChunkSize(int chunkIndex) {
+      if (chunkIndex == chunkCount - 1) {
+        return librarySize - (chunkSize * chunkIndex);
+      }
+      return chunkSize;
+    }
+
+    private long expectedChunkCrc32(int chunkIndex) {
+      return chunkCrc32[chunkIndex];
+    }
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -558,7 +558,6 @@ public class NativeDepsLoader {
   private static final class ChunkManifest {
     private static final String FORMAT_VERSION_KEY = "format.version";
     private static final String LIBRARY_SIZE_KEY = "library.size";
-    private static final String LIBRARY_CRC32_KEY = "library.crc32";
     private static final String CHUNK_SIZE_KEY = "chunk.size";
     private static final String CHUNK_COUNT_KEY = "chunk.count";
 
@@ -598,7 +597,6 @@ public class NativeDepsLoader {
             "Invalid native dependency chunk count in %s: expected %d but found %d",
             resource, expectedChunkCount, chunkCountLong));
       }
-      parseCrc32(properties, LIBRARY_CRC32_KEY, resource);
       int chunkCount = (int) chunkCountLong;
       long[] chunkCrc32 = new long[chunkCount];
       for (int i = 0; i < chunkCount; i++) {

--- a/java/src/test/java/ai/rapids/cudf/NativeDepsLoaderExtractionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/NativeDepsLoaderExtractionTest.java
@@ -1,0 +1,358 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.rapids.cudf;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.CRC32;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class NativeDepsLoaderExtractionTest {
+  private static final String TEST_ARCH = "native-deps-loader-tests";
+  private static final String TEST_OS = "TestOS";
+
+  private Path resourceDir;
+
+  @BeforeEach
+  void setupResources() throws IOException, URISyntaxException {
+    Path classPathRoot = Paths.get(
+        NativeDepsLoaderExtractionTest.class.getProtectionDomain()
+            .getCodeSource().getLocation().toURI());
+    resourceDir = classPathRoot.resolve(TEST_ARCH).resolve(TEST_OS);
+    Files.createDirectories(resourceDir);
+  }
+
+  @AfterEach
+  void removeResources() throws IOException {
+    Path testRoot = resourceDir.getParent();
+    if (Files.exists(testRoot)) {
+      try (Stream<Path> paths = Files.walk(testRoot)) {
+        for (Path path : paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList())) {
+          Files.delete(path);
+        }
+      }
+    }
+  }
+
+  @Test
+  void extractsConventionalResource() throws IOException {
+    String baseName = "conventionaltest";
+    byte[] expected = "conventional native library".getBytes(StandardCharsets.UTF_8);
+    Files.write(libraryPath(baseName), expected);
+
+    File extracted = NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName);
+    try {
+      assertArrayEquals(expected, Files.readAllBytes(extracted.toPath()));
+    } finally {
+      Files.deleteIfExists(extracted.toPath());
+    }
+  }
+
+  @Test
+  void extractsChunkedResourceAndPrefersManifest() throws IOException {
+    String baseName = "chunkedtest";
+    byte[] expected = "chunked native library contents".getBytes(StandardCharsets.UTF_8);
+    Files.write(libraryPath(baseName),
+        "wrong conventional contents".getBytes(StandardCharsets.UTF_8));
+    writeChunkedResource(baseName, expected, 8, "1", null, null);
+
+    File extracted = NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName);
+    try {
+      assertArrayEquals(expected, Files.readAllBytes(extracted.toPath()));
+    } finally {
+      Files.deleteIfExists(extracted.toPath());
+    }
+  }
+
+  @Test
+  void extractsChunksConcurrently() throws Exception {
+    String mappedName = "libconcurrent.so";
+    byte[] expected = "0123456789abcdef".getBytes(StandardCharsets.UTF_8);
+    int chunkSize = 4;
+    CRC32 crc = new CRC32();
+    crc.update(expected);
+    Map<String, byte[]> resources = new HashMap<>();
+    String resourceRoot = "/native/" + mappedName;
+    StringBuilder chunkCrcProperties = new StringBuilder();
+    for (int i = 0; i < expected.length / chunkSize; i++) {
+      byte[] chunk = new byte[chunkSize];
+      System.arraycopy(expected, i * chunkSize, chunk, 0, chunkSize);
+      resources.put(String.format(Locale.ROOT, "%s.chunks/%05d", resourceRoot, i), chunk);
+      CRC32 chunkCrc = new CRC32();
+      chunkCrc.update(chunk);
+      chunkCrcProperties.append(String.format(
+          Locale.ROOT, "chunk.%05d.crc32=%08x%n", i, chunkCrc.getValue()));
+    }
+    String manifest = String.format(Locale.ROOT,
+        "format.version=1%n"
+            + "library.size=%d%n"
+            + "library.crc32=%08x%n"
+            + "chunk.size=%d%n"
+            + "chunk.count=%d%n",
+        expected.length, crc.getValue(), chunkSize, expected.length / chunkSize)
+        + chunkCrcProperties;
+    resources.put(resourceRoot + ".chunks.properties",
+        manifest.getBytes(StandardCharsets.ISO_8859_1));
+
+    CountDownLatch concurrentReaders = new CountDownLatch(2);
+    AtomicInteger activeReaders = new AtomicInteger();
+    AtomicInteger maxReaders = new AtomicInteger();
+    URL manifestUrl = new URL(null, "memory:" + resourceRoot + ".chunks.properties",
+        new URLStreamHandler() {
+          @Override
+          protected URLConnection openConnection(URL url) {
+            return new URLConnection(url) {
+              @Override
+              public void connect() {
+              }
+
+              @Override
+              public InputStream getInputStream() throws IOException {
+                byte[] contents = resources.get(url.getPath());
+                if (contents == null) {
+                  throw new FileNotFoundException(url.toString());
+                }
+                if (url.getPath().contains(".chunks/")) {
+                  return coordinatedStream(
+                      contents, concurrentReaders, activeReaders, maxReaders);
+                }
+                return new ByteArrayInputStream(contents);
+              }
+            };
+          }
+        });
+
+    File extracted = File.createTempFile("concurrent-chunks", ".so");
+    try {
+      NativeDepsLoader.extractChunkedResource(manifestUrl, mappedName, extracted, 2);
+      assertArrayEquals(expected, Files.readAllBytes(extracted.toPath()));
+      assertEquals(0, concurrentReaders.getCount());
+      assertEquals(2, maxReaders.get());
+    } finally {
+      Files.deleteIfExists(extracted.toPath());
+    }
+  }
+
+  @Test
+  void rejectsUnsupportedManifestVersionAndDeletesPartialFile() throws IOException {
+    String baseName = "badversiontest";
+    byte[] expected = "versioned contents".getBytes(StandardCharsets.UTF_8);
+    writeChunkedResource(baseName, expected, 8, "2", null, null);
+    Set<Path> before = temporaryFiles(baseName);
+
+    assertThrows(IOException.class,
+        () -> NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName));
+
+    assertEquals(before, temporaryFiles(baseName));
+  }
+
+  @Test
+  void rejectsInvalidChunkCount() throws IOException {
+    String baseName = "badcounttest";
+    byte[] expected = "invalid chunk count".getBytes(StandardCharsets.UTF_8);
+    writeChunkedResource(baseName, expected, 8, "1", null, 99L);
+
+    assertThrows(IOException.class,
+        () -> NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName));
+  }
+
+  @Test
+  void rejectsMissingChunkCrc() throws IOException {
+    String baseName = "missingcrctest";
+    byte[] expected = "missing chunk crc".getBytes(StandardCharsets.UTF_8);
+    writeChunkedResource(baseName, expected, 8, "1", null, null);
+    Path manifestPath = resourceDir.resolve(
+        System.mapLibraryName(baseName) + ".chunks.properties");
+    Properties manifest = new Properties();
+    try (InputStream in = Files.newInputStream(manifestPath)) {
+      manifest.load(in);
+    }
+    manifest.remove("chunk.00000.crc32");
+    try (OutputStream out = Files.newOutputStream(manifestPath)) {
+      manifest.store(out, null);
+    }
+
+    assertThrows(IOException.class,
+        () -> NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName));
+  }
+
+  @Test
+  void rejectsMissingChunkAndDeletesPartialFile() throws IOException {
+    String baseName = "missingchunktest";
+    byte[] expected = "a library with three chunks".getBytes(StandardCharsets.UTF_8);
+    writeChunkedResource(baseName, expected, 10, "1", null, null);
+    Files.delete(chunkDirectory(baseName).resolve("00002"));
+    Set<Path> before = temporaryFiles(baseName);
+
+    assertThrows(IOException.class,
+        () -> NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName));
+
+    assertEquals(before, temporaryFiles(baseName));
+  }
+
+  @Test
+  void rejectsOversizedChunk() throws IOException {
+    String baseName = "longchunktest";
+    byte[] expected = "a library with long data".getBytes(StandardCharsets.UTF_8);
+    writeChunkedResource(baseName, expected, 8, "1", null, null);
+    Files.write(chunkDirectory(baseName).resolve("00000"),
+        new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+    assertThrows(IOException.class,
+        () -> NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName));
+  }
+
+  @Test
+  void rejectsShortChunk() throws IOException {
+    String baseName = "shortchunktest";
+    byte[] expected = "a library with short data".getBytes(StandardCharsets.UTF_8);
+    writeChunkedResource(baseName, expected, 8, "1", null, null);
+    Files.write(chunkDirectory(baseName).resolve("00000"), new byte[]{1, 2, 3});
+
+    assertThrows(IOException.class,
+        () -> NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName));
+  }
+
+  @Test
+  void rejectsCrcMismatch() throws IOException {
+    String baseName = "badcrctest";
+    byte[] expected = "crc checked contents".getBytes(StandardCharsets.UTF_8);
+    writeChunkedResource(baseName, expected, 8, "1", 0L, null);
+
+    assertThrows(IOException.class,
+        () -> NativeDepsLoader.createFile(TEST_OS, TEST_ARCH, baseName));
+  }
+
+  private static InputStream coordinatedStream(
+      byte[] contents, CountDownLatch concurrentReaders,
+      AtomicInteger activeReaders, AtomicInteger maxReaders) {
+    return new InputStream() {
+      private final InputStream delegate = new ByteArrayInputStream(contents);
+      private boolean entered;
+
+      private void awaitConcurrentReader() throws IOException {
+        if (!entered) {
+          entered = true;
+          int active = activeReaders.incrementAndGet();
+          maxReaders.updateAndGet(previous -> Math.max(previous, active));
+          concurrentReaders.countDown();
+          try {
+            if (!concurrentReaders.await(5, TimeUnit.SECONDS)) {
+              throw new IOException("Timed out waiting for concurrent chunk extraction");
+            }
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted waiting for concurrent chunk extraction", e);
+          }
+        }
+      }
+
+      @Override
+      public int read() throws IOException {
+        awaitConcurrentReader();
+        return delegate.read();
+      }
+
+      @Override
+      public int read(byte[] buffer, int offset, int length) throws IOException {
+        awaitConcurrentReader();
+        return delegate.read(buffer, offset, length);
+      }
+
+      @Override
+      public void close() throws IOException {
+        delegate.close();
+        if (entered) {
+          entered = false;
+          activeReaders.decrementAndGet();
+        }
+      }
+    };
+  }
+
+  private Path libraryPath(String baseName) {
+    return resourceDir.resolve(System.mapLibraryName(baseName));
+  }
+
+  private Path chunkDirectory(String baseName) {
+    return resourceDir.resolve(System.mapLibraryName(baseName) + ".chunks");
+  }
+
+  private void writeChunkedResource(String baseName, byte[] contents, int chunkSize,
+                                    String version, Long firstChunkCrcOverride,
+                                    Long countOverride) throws IOException {
+    String mappedName = System.mapLibraryName(baseName);
+    Path chunks = chunkDirectory(baseName);
+    Files.createDirectories(chunks);
+    int chunkCount = (contents.length + chunkSize - 1) / chunkSize;
+    StringBuilder chunkCrcProperties = new StringBuilder();
+    for (int i = 0; i < chunkCount; i++) {
+      int offset = i * chunkSize;
+      int length = Math.min(chunkSize, contents.length - offset);
+      byte[] chunk = new byte[length];
+      System.arraycopy(contents, offset, chunk, 0, length);
+      Files.write(chunks.resolve(String.format(Locale.ROOT, "%05d", i)), chunk);
+      CRC32 chunkCrc = new CRC32();
+      chunkCrc.update(chunk);
+      long crcValue = i == 0 && firstChunkCrcOverride != null
+          ? firstChunkCrcOverride : chunkCrc.getValue();
+      chunkCrcProperties.append(String.format(
+          Locale.ROOT, "chunk.%05d.crc32=%08x%n", i, crcValue));
+    }
+
+    CRC32 crc = new CRC32();
+    crc.update(contents);
+    long manifestCount = countOverride == null ? chunkCount : countOverride;
+    String manifest = String.format(Locale.ROOT,
+        "format.version=%s%n"
+            + "library.size=%d%n"
+            + "library.crc32=%08x%n"
+            + "chunk.size=%d%n"
+            + "chunk.count=%d%n",
+        version, contents.length, crc.getValue(), chunkSize, manifestCount)
+        + chunkCrcProperties;
+    Files.write(resourceDir.resolve(mappedName + ".chunks.properties"),
+        manifest.getBytes(StandardCharsets.ISO_8859_1));
+  }
+
+  private static Set<Path> temporaryFiles(String prefix) throws IOException {
+    Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
+    try (Stream<Path> paths = Files.list(tempDir)) {
+      return paths
+          .filter(path -> path.getFileName().toString().startsWith(prefix))
+          .collect(Collectors.toSet());
+    }
+  }
+}

--- a/java/src/test/java/ai/rapids/cudf/NativeDepsLoaderExtractionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/NativeDepsLoaderExtractionTest.java
@@ -101,8 +101,6 @@ class NativeDepsLoaderExtractionTest {
     String mappedName = "libconcurrent.so";
     byte[] expected = "0123456789abcdef".getBytes(StandardCharsets.UTF_8);
     int chunkSize = 4;
-    CRC32 crc = new CRC32();
-    crc.update(expected);
     Map<String, byte[]> resources = new HashMap<>();
     String resourceRoot = "/native/" + mappedName;
     StringBuilder chunkCrcProperties = new StringBuilder();
@@ -118,10 +116,9 @@ class NativeDepsLoaderExtractionTest {
     String manifest = String.format(Locale.ROOT,
         "format.version=1%n"
             + "library.size=%d%n"
-            + "library.crc32=%08x%n"
             + "chunk.size=%d%n"
             + "chunk.count=%d%n",
-        expected.length, crc.getValue(), chunkSize, expected.length / chunkSize)
+        expected.length, chunkSize, expected.length / chunkSize)
         + chunkCrcProperties;
     resources.put(resourceRoot + ".chunks.properties",
         manifest.getBytes(StandardCharsets.ISO_8859_1));
@@ -332,16 +329,13 @@ class NativeDepsLoaderExtractionTest {
           Locale.ROOT, "chunk.%05d.crc32=%08x%n", i, crcValue));
     }
 
-    CRC32 crc = new CRC32();
-    crc.update(contents);
     long manifestCount = countOverride == null ? chunkCount : countOverride;
     String manifest = String.format(Locale.ROOT,
         "format.version=%s%n"
             + "library.size=%d%n"
-            + "library.crc32=%08x%n"
             + "chunk.size=%d%n"
             + "chunk.count=%d%n",
-        version, contents.length, crc.getValue(), chunkSize, manifestCount)
+        version, contents.length, chunkSize, manifestCount)
         + chunkCrcProperties;
     Files.write(resourceDir.resolve(mappedName + ".chunks.properties"),
         manifest.getBytes(StandardCharsets.ISO_8859_1));

--- a/java/src/test/java/ai/rapids/cudf/NativeDepsLoaderTest.java
+++ b/java/src/test/java/ai/rapids/cudf/NativeDepsLoaderTest.java
@@ -96,6 +96,14 @@ class NativeDepsLoaderTest {
   }
 
   @Test
+  void singleLoad_throws_whenDirIsEmpty() {
+    IOException ex = assertThrows(IOException.class,
+        () -> NativeDepsLoader.loadNativeDep("cudf", false));
+    assertTrue(ex.getMessage().contains("libcudf.so"),
+        "expected message to mention libcudf.so, got: " + ex.getMessage());
+  }
+
+  @Test
   void flatLoad_throws_whenLibIsMissing() throws IOException {
     Files.createFile(libDir.resolve("libnvcomp.so"));
     IOException ex = assertThrows(IOException.class,


### PR DESCRIPTION
## Description

Add an internal chunk-manifest resource format for large native libraries and extract those chunks concurrently. The loader:

- preserves conventional single-resource loading and `ai.rapids.cudf.lib-native-dir`
- reads up to 12 JAR entries concurrently
- writes directly to the pre-sized output with positional `FileChannel` writes
- validates manifest structure, exact chunk sizes, and per-chunk CRC32 values
- removes partial output after extraction failures

Related issue: [NVIDIA/cudf-spark#15145](https://github.com/NVIDIA/cudf-spark/issues/15145) identifies synchronous, single-threaded native JAR extraction as a major executor startup cost.

This allows distribution JARs containing 900+ MiB CUDA native libraries to trade a measured 0.0087% increase in archive size for substantially faster startup and JAR creation. NVIDIA/cudf-spark#15356 is the companion producer PR.

### Performance

#### Native extraction

Measured the exact pre-change and PR paths on the same host with JDK 17 and the same 1,504,051,352-byte CUDA12 `libcudf.so`. Each case ran six extractions in one JVM; the first invocation was treated as warm-up and the remaining five were used for the median.

| Path | First invocation | Post-warm-up range | Median |
| --- | ---: | ---: | ---: |
| Pre-change conventional DEFLATED resource, 16 KiB sequential copy | 6.411 s | 6.370-6.426 s | 6.371 s |
| 45 DEFLATED chunks, 12-worker positional extraction | 1.164 s | 1.078-1.124 s | 1.113 s |

The post-warm-up median improves by **5.72x**, reducing extraction latency by **82.5%**. The first measured invocation improves by 5.51x. Both paths produced exactly 1,504,051,352 bytes.

#### Archive size and creation time

Using matched resource trees and forcing the existing `jar:jar@create-parallel-worlds-jar` execution:

| Input representation | Median | Output JAR size |
| --- | ---: | ---: |
| One conventional DEFLATED `libcudf.so` entry | 55.07 s | 952,504,790 bytes |
| 45 DEFLATED chunks plus manifest | 5.47 s | 952,587,551 bytes |

Chunking increased the archive by 82,761 bytes (**0.0087%**) while making focused JAR creation **10.07x faster**, a **90.1%** wall-time reduction. The full benchmark methodology and measured ranges are in NVIDIA/cudf-spark#15356.

### Validation

- `mvn compiler:compile compiler:testCompile`
- `mvn surefire:test -Dtest=NativeDepsLoaderExtractionTest` (10 tests)
- `mvn surefire:test@native-deps-loader-test` (5 tests)
- Cross-repository production JAR benchmark described above

The full native Maven lifecycle was not run locally because the installed CMake is 3.28 and this branch requires CMake 4.0; the Java sources and focused tests were compiled and run directly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
