### PR TITLE
Make nvCOMP linkage configurable

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -68,6 +68,14 @@ set(CUDF_BUILD_STATIC_DEPS
 )
 set_property(CACHE CUDF_BUILD_STATIC_DEPS PROPERTY STRINGS "ON" "OFF" "FORCE")
 
+# nvCOMP is also distributed as a shared library by cuDF Java. Allow downstream packages that
+# already ship that library to avoid embedding a second, static copy in libcudf.
+set(CUDF_NVCOMP_LINKAGE
+    "AUTO"
+    CACHE STRING "Link nvCOMP automatically, statically, or dynamically"
+)
+set_property(CACHE CUDF_NVCOMP_LINKAGE PROPERTY STRINGS "AUTO" "STATIC" "SHARED")
+
 # cudart can be statically linked or dynamically linked. The python ecosystem wants dynamic linking
 option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
 # FORCE mode implies static CUDA runtime

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -136,10 +136,31 @@ if(CUDF_INSTALL_LIBRARY_DEPS)
 endif()
 find_and_configure_nvcomp(${_nvcomp_args})
 
-if(CUDF_DEPS_BUILD_SHARED OR NOT TARGET nvcomp::nvcomp_static)
-  set(CUDF_nvcomp_TARGET nvcomp::nvcomp)
-else()
+if(NOT DEFINED CUDF_NVCOMP_LINKAGE)
+  set(CUDF_NVCOMP_LINKAGE "AUTO")
+endif()
+
+if(CUDF_NVCOMP_LINKAGE STREQUAL "STATIC")
+  if(NOT TARGET nvcomp::nvcomp_static)
+    message(FATAL_ERROR "CUDF_NVCOMP_LINKAGE=STATIC but nvcomp::nvcomp_static is unavailable")
+  endif()
   set(CUDF_nvcomp_TARGET nvcomp::nvcomp_static)
+elseif(CUDF_NVCOMP_LINKAGE STREQUAL "SHARED")
+  if(NOT TARGET nvcomp::nvcomp)
+    message(FATAL_ERROR "CUDF_NVCOMP_LINKAGE=SHARED but nvcomp::nvcomp is unavailable")
+  endif()
+  set(CUDF_nvcomp_TARGET nvcomp::nvcomp)
+elseif(CUDF_NVCOMP_LINKAGE STREQUAL "AUTO")
+  if(CUDF_DEPS_BUILD_SHARED OR NOT TARGET nvcomp::nvcomp_static)
+    set(CUDF_nvcomp_TARGET nvcomp::nvcomp)
+  else()
+    set(CUDF_nvcomp_TARGET nvcomp::nvcomp_static)
+  endif()
+else()
+  message(
+    FATAL_ERROR
+      "CUDF_NVCOMP_LINKAGE must be AUTO, STATIC, or SHARED; got '${CUDF_NVCOMP_LINKAGE}'"
+  )
 endif()
 
 # Per-thread default stream

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -158,8 +158,7 @@ elseif(CUDF_NVCOMP_LINKAGE STREQUAL "AUTO")
   endif()
 else()
   message(
-    FATAL_ERROR
-      "CUDF_NVCOMP_LINKAGE must be AUTO, STATIC, or SHARED; got '${CUDF_NVCOMP_LINKAGE}'"
+    FATAL_ERROR "CUDF_NVCOMP_LINKAGE must be AUTO, STATIC, or SHARED; got '${CUDF_NVCOMP_LINKAGE}'"
   )
 endif()
 


### PR DESCRIPTION
## Summary
- add `CUDF_NVCOMP_LINKAGE=AUTO|STATIC|SHARED`
- preserve the existing target-selection behavior under the default `AUTO` mode
- fail during configuration when an explicitly requested nvCOMP target is unavailable

## Why
The cuDF Java distribution already packages the shared nvCOMP library. Downstream builds that otherwise force static dependencies currently embed a second copy of nvCOMP in `libcudf.so` while also shipping `libnvcomp.so`.

This option lets those distributions choose the packaged shared library without changing the default linkage policy for other cuDF consumers.

Related to NVIDIA/cudf-spark#15145.

## Validation
- configured and built Release `libcudf.so` with both `STATIC` and `SHARED` on CUDA 12.9.1 (`sm_75`)
- verified the shared variant has `DT_NEEDED: libnvcomp.so.5`
- verified Java load order `libnvcomp.so`, `libcudf.so`, `libcudfjni.so`

Measured on otherwise identical one-architecture builds:

| nvCOMP linkage | `libcudf.so` | ZIP level 6 |
| --- | ---: | ---: |
| static | 711,163,904 B | 359,193,871 B |
| shared | 691,845,960 B | 344,989,786 B |

This removes 18.42 MiB uncompressed and 13.55 MiB after DEFLATE.