### PR TITLE
Use libcudf-bundled CCCL for NRT UDF compilation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -650,8 +650,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
     with:
       build_type: pull-request
-      # Temporarily run the nightly wheel-test matrix to validate the CUDA 12.2 lane.
-      matrix_type: nightly
       script: ci/test_wheel_cudf.sh
   wheel-build-cudf-polars:
     needs: wheel-build-pylibcudf

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -650,6 +650,8 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels && fromJSON(needs.changed-files.outputs.changed_file_groups).neither_cudf_polars_nor_dask_cudf
     with:
       build_type: pull-request
+      # Temporarily run the nightly wheel-test matrix to validate the CUDA 12.2 lane.
+      matrix_type: nightly
       script: ci/test_wheel_cudf.sh
   wheel-build-cudf-polars:
     needs: wheel-build-pylibcudf

--- a/python/cudf/cudf/core/udf/nrt_utils.py
+++ b/python/cudf/cudf/core/udf/nrt_utils.py
@@ -47,7 +47,7 @@ def _get_libcudf_rapids_include_dir():
     return None
 
 
-def _append_nvrtc_search_path(search_paths, path):
+def _append_search_path(search_paths, path):
     paths = [p for p in search_paths.split(os.pathsep) if p]
     if path not in paths:
         paths.append(path)
@@ -71,8 +71,8 @@ def nrt_enabled():
     try:
         numba_config.CUDA_ENABLE_NRT = True
         if (include_dir := _get_libcudf_rapids_include_dir()) is not None:
-            numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS = (
-                _append_nvrtc_search_path(nvrtc_search_paths, include_dir)
+            numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS = _append_search_path(
+                nvrtc_search_paths, include_dir
             )
         yield
     finally:

--- a/python/cudf/cudf/core/udf/nrt_utils.py
+++ b/python/cudf/cudf/core/udf/nrt_utils.py
@@ -1,8 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextvars
+import os
 from contextlib import contextmanager
+from functools import cache
+from importlib.util import find_spec
 
 from numba.cuda import config as numba_config
 
@@ -30,6 +33,27 @@ class CaptureNRTUsage:
         _current_nrt_context.reset(self._token)
 
 
+@cache
+def _get_libcudf_rapids_include_dir():
+    spec = find_spec("libcudf")
+    if spec is None or spec.submodule_search_locations is None:
+        return None
+
+    for package_dir in spec.submodule_search_locations:
+        include_dir = os.path.join(package_dir, "include", "rapids")
+        if os.path.isfile(os.path.join(include_dir, "cuda", "atomic")):
+            return include_dir
+
+    return None
+
+
+def _append_nvrtc_search_path(search_paths, path):
+    paths = [p for p in search_paths.split(os.pathsep) if p]
+    if path not in paths:
+        paths.append(path)
+    return os.pathsep.join(paths)
+
+
 @contextmanager
 def nrt_enabled():
     """
@@ -38,9 +62,21 @@ def nrt_enabled():
     for a single kernel launch, so we use this context
     to enable it for those that we know need it.
     """
-    original_value = getattr(numba_config, "CUDA_ENABLE_NRT", False)
-    numba_config.CUDA_ENABLE_NRT = True
+    original_nrt_value = getattr(numba_config, "CUDA_ENABLE_NRT", False)
+    original_nvrtc_search_paths = getattr(
+        numba_config, "CUDA_NVRTC_EXTRA_SEARCH_PATHS", ""
+    )
+    nvrtc_search_paths = original_nvrtc_search_paths or ""
+
     try:
+        numba_config.CUDA_ENABLE_NRT = True
+        if (include_dir := _get_libcudf_rapids_include_dir()) is not None:
+            numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS = (
+                _append_nvrtc_search_path(nvrtc_search_paths, include_dir)
+            )
         yield
     finally:
-        numba_config.CUDA_ENABLE_NRT = original_value
+        numba_config.CUDA_ENABLE_NRT = original_nrt_value
+        numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS = (
+            original_nvrtc_search_paths
+        )

--- a/python/cudf/cudf/tests/private_objects/test_compile_udf.py
+++ b/python/cudf/cudf/tests/private_objects/test_compile_udf.py
@@ -1,9 +1,13 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+import os
 
 import pytest
 from numba import types
+from numba.cuda import config as numba_config
 
+from cudf.core.udf import nrt_utils
 from cudf.core.udf.utils import _udf_code_cache, compile_udf
 
 
@@ -68,3 +72,100 @@ def test_lambda_in_loop_code_cached():
         compile_udf(lambda x: x + 1, (types.float32,))
 
     assert_cache_size(1)
+
+
+class FakeModuleSpec:
+    def __init__(self, submodule_search_locations):
+        self.submodule_search_locations = submodule_search_locations
+
+
+def _set_libcudf_spec(monkeypatch, spec):
+    nrt_utils._get_libcudf_rapids_include_dir.cache_clear()
+    monkeypatch.setattr(nrt_utils, "find_spec", lambda name: spec)
+
+
+def test_get_libcudf_rapids_include_dir_missing(monkeypatch, tmp_path):
+    _set_libcudf_spec(monkeypatch, None)
+    assert nrt_utils._get_libcudf_rapids_include_dir() is None
+
+    _set_libcudf_spec(monkeypatch, FakeModuleSpec([str(tmp_path)]))
+    assert nrt_utils._get_libcudf_rapids_include_dir() is None
+
+
+def test_get_libcudf_rapids_include_dir_finds_cuda_atomic(
+    monkeypatch, tmp_path
+):
+    include_dir = tmp_path / "include" / "rapids"
+    (include_dir / "cuda").mkdir(parents=True)
+    (include_dir / "cuda" / "atomic").touch()
+    _set_libcudf_spec(monkeypatch, FakeModuleSpec([str(tmp_path)]))
+
+    assert nrt_utils._get_libcudf_rapids_include_dir() == str(include_dir)
+
+
+def test_nrt_enabled_adds_libcudf_rapids_include_dir(monkeypatch, tmp_path):
+    include_dir = tmp_path / "include" / "rapids"
+    (include_dir / "cuda").mkdir(parents=True)
+    (include_dir / "cuda" / "atomic").touch()
+    _set_libcudf_spec(monkeypatch, FakeModuleSpec([str(tmp_path)]))
+    monkeypatch.setattr(numba_config, "CUDA_ENABLE_NRT", False)
+    monkeypatch.setattr(
+        numba_config, "CUDA_NVRTC_EXTRA_SEARCH_PATHS", "/existing"
+    )
+
+    with nrt_utils.nrt_enabled():
+        assert numba_config.CUDA_ENABLE_NRT is True
+        assert numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS.split(
+            os.pathsep
+        ) == ["/existing", str(include_dir)]
+
+    assert numba_config.CUDA_ENABLE_NRT is False
+    assert numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS == "/existing"
+
+
+def test_nrt_enabled_does_not_duplicate_libcudf_rapids_include_dir(
+    monkeypatch, tmp_path
+):
+    include_dir = tmp_path / "include" / "rapids"
+    (include_dir / "cuda").mkdir(parents=True)
+    (include_dir / "cuda" / "atomic").touch()
+    _set_libcudf_spec(monkeypatch, FakeModuleSpec([str(tmp_path)]))
+    monkeypatch.setattr(numba_config, "CUDA_ENABLE_NRT", False)
+    monkeypatch.setattr(
+        numba_config,
+        "CUDA_NVRTC_EXTRA_SEARCH_PATHS",
+        os.pathsep.join(["/existing", str(include_dir)]),
+    )
+
+    with nrt_utils.nrt_enabled():
+        assert numba_config.CUDA_ENABLE_NRT is True
+        assert numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS.split(
+            os.pathsep
+        ) == ["/existing", str(include_dir)]
+
+    assert numba_config.CUDA_ENABLE_NRT is False
+    assert numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS == os.pathsep.join(
+        ["/existing", str(include_dir)]
+    )
+
+
+def test_nrt_enabled_restores_config_when_include_discovery_raises(
+    monkeypatch,
+):
+    def raise_error():
+        raise RuntimeError("include discovery failed")
+
+    monkeypatch.setattr(
+        nrt_utils, "_get_libcudf_rapids_include_dir", raise_error
+    )
+    monkeypatch.setattr(numba_config, "CUDA_ENABLE_NRT", False)
+    monkeypatch.setattr(
+        numba_config, "CUDA_NVRTC_EXTRA_SEARCH_PATHS", "/existing"
+    )
+
+    with pytest.raises(RuntimeError, match="include discovery failed"):
+        with nrt_utils.nrt_enabled():
+            pass
+
+    assert numba_config.CUDA_ENABLE_NRT is False
+    assert numba_config.CUDA_NVRTC_EXTRA_SEARCH_PATHS == "/existing"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
It looks like up until this point our usage of numba-cuda from CUDA wheels has been relying on the system CCCL rather than the one bundled with libcudf. We noticed this as a result of the change in ci-imgs to use the base rather than devel CUDA images as our base (https://github.com/rapidsai/ci-imgs/pull/408) because testing on older CTKs revealed that headers required by numba-cuda were missing (specifically `cuda/atomic`). To ensure that we have ABI-compatible usage of CCCL given that we have custom numba extension code for our string UDFs, we're best off ensuring that we use the CCCL bundled in libcudf rather than whatever is found on the system, so this PR adds that directory to our numba search path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
