### PR TITLE
refactor(parquet): introduce level_state_scan struct for preprocess_levels_kernel

### DIFF
--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -184,7 +184,7 @@ __device__ inline void decode_fixed_width_split_values(
   auto const data_out        = s->nesting_info[leaf_level_index].data_out;
 
   Type const dtype    = s->setup.col.physical_type;
-  auto const data_len = cuda::std::distance(s->data_start, s->data_end);
+  auto const data_len = cuda::std::distance(s->stream.data_start, s->stream.data_end);
 
   // Check malformed BYTE_STREAM_SPLIT pages
   if (s->dtype_len_in <= 0 or data_len <= 0) {
@@ -223,7 +223,7 @@ __device__ inline void decode_fixed_width_split_values(
     }();
 
     uint32_t const dtype_len = s->dtype_len;
-    uint8_t const* const src = s->data_start + src_pos;
+    uint8_t const* const src = s->stream.data_start + src_pos;
     uint8_t* const dst       = data_out + static_cast<size_t>(dst_pos) * dtype_len;
     auto const is_decimal    = s->setup.col.logical_type.has_value() and
                             s->setup.col.logical_type->type == LogicalType::DECIMAL;
@@ -806,7 +806,7 @@ inline __device__ void bool_plain_decode(page_state_s* s,
     int const byte_offset       = bit_pos >> 3;
     int const bit_in_byte_index = bit_pos & 7;
 
-    uint8_t const* const read_from = s->data_start + byte_offset;
+    uint8_t const* const read_from = s->stream.data_start + byte_offset;
     bool const read_bit            = (*read_from) & (1 << bit_in_byte_index);
 
     int const write_to_index     = rolling_index<state_buf::dict_buf_size>(bit_pos);
@@ -1057,20 +1057,24 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   rle_stream<uint32_t, decode_block_size_t, rolling_buf_size> dict_stream{dict_runs};
   if constexpr (has_dict_t) {
     dict_stream.init(block,
-                     s->dict_bits,
-                     s->data_start,
-                     s->data_end,
+                     s->stream.dict_bits,
+                     s->stream.data_start,
+                     s->stream.data_end,
                      sb->dict_idx,
                      s->setup.page.num_input_values);
   }
 
   // Use dictionary stream memory for bools
   rle_stream<uint32_t, decode_block_size_t, rolling_buf_size> bool_stream{bool_runs};
-  bool bools_are_rle_stream = (s->dict_run == 0);
+  bool bools_are_rle_stream = (s->stream.dict_run == 0);
   if constexpr (has_bools_t) {
     if (bools_are_rle_stream) {
-      bool_stream.init(
-        block, 1, s->data_start, s->data_end, sb->dict_idx, s->setup.page.num_input_values);
+      bool_stream.init(block,
+                       1,
+                       s->stream.data_start,
+                       s->stream.data_end,
+                       sb->dict_idx,
+                       s->setup.page.num_input_values);
     }
   }
   block.sync();

--- a/cpp/src/io/parquet/decode_preprocess.cu
+++ b/cpp/src/io/parquet/decode_preprocess.cu
@@ -6,6 +6,7 @@
 #include "delta_binary.cuh"
 #include "io/utilities/column_buffer.hpp"
 #include "page_decode.cuh"
+#include "page_state_composed.cuh"
 #include "reader_impl_chunking_utils.cuh"
 
 #include <cudf/detail/nvtx/ranges.hpp>
@@ -390,13 +391,13 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
                            size_t min_row,
                            size_t num_rows)
 {
-  __shared__ __align__(16) page_state_s state_g;
+  __shared__ __align__(16) level_scan_state state_g;
 
-  page_state_s* const s = &state_g;
-  auto const block      = cg::this_thread_block();
-  int const page_idx    = cg::this_grid().block_rank();
-  int const t           = block.thread_rank();
-  PageInfo* pp          = &pages[page_idx];
+  level_scan_state* const s = &state_g;
+  auto const block          = cg::this_thread_block();
+  int const page_idx        = cg::this_grid().block_rank();
+  int const t               = block.thread_rank();
+  PageInfo* pp              = &pages[page_idx];
 
   // Return early if this page is pruned
   if (not page_mask.empty() and not page_mask[page_idx]) { return; }
@@ -448,8 +449,8 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
     block.sync();
     decoders[level_type::REPETITION].init(block,
                                           s->setup.col.level_bits[level_type::REPETITION],
-                                          s->abs_lvl_start[level_type::REPETITION],
-                                          s->abs_lvl_end[level_type::REPETITION],
+                                          s->stream.abs_lvl_start[level_type::REPETITION],
+                                          s->stream.abs_lvl_end[level_type::REPETITION],
                                           rep,
                                           num_to_decode,
                                           stage,
@@ -471,8 +472,8 @@ CUDF_KERNEL void __launch_bounds__(level_decode_block_size)
     block.sync();
     decoders[level_type::DEFINITION].init(block,
                                           s->setup.col.level_bits[level_type::DEFINITION],
-                                          s->abs_lvl_start[level_type::DEFINITION],
-                                          s->abs_lvl_end[level_type::DEFINITION],
+                                          s->stream.abs_lvl_start[level_type::DEFINITION],
+                                          s->stream.abs_lvl_end[level_type::DEFINITION],
                                           def,
                                           num_to_decode,
                                           stage,

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -81,7 +81,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   bool const has_repetition = s->setup.col.max_level[level_type::REPETITION] > 0;
   bool const process_nulls  = should_process_nulls(s);
 
-  auto const data_len   = cuda::std::distance(s->data_start, s->data_end);
+  auto const data_len   = cuda::std::distance(s->stream.data_start, s->stream.data_end);
   auto const num_values = data_len / s->dtype_len_in;
 
   // Check malformed BYTE_STREAM_SPLIT pages
@@ -162,7 +162,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
         int leaf_level_index = s->setup.col.max_nesting_depth - 1;
 
         uint32_t dtype_len = s->dtype_len;
-        uint8_t const* src = s->data_start + val_src_pos;
+        uint8_t const* src = s->stream.data_start + val_src_pos;
         uint8_t* dst =
           nesting_info_base[leaf_level_index].data_out + static_cast<size_t>(dst_pos) * dtype_len;
         auto const is_decimal = s->setup.col.logical_type.has_value() and
@@ -296,8 +296,8 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   int const init_valid_map_offset =
     s->nesting_info[s->setup.col.max_nesting_depth - 1].valid_map_offset;
 
-  if (s->dict_base) {
-    out_warp_id = (s->dict_bits > 0) ? 2 : 1;
+  if (s->stream.dict_base) {
+    out_warp_id = (s->stream.dict_bits > 0) ? 2 : 1;
   } else {
     switch (s->setup.col.physical_type) {
       case Type::BOOLEAN: [[fallthrough]];
@@ -351,7 +351,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
       // This is likely a false positive in practice, but could be solved by wrapping the next
       // 9 lines in `if (s->dict_pos < src_target_pos) {}`. If that change is made here, it will
       // be needed in the other DecodeXXX kernels.
-      if (s->dict_base) {
+      if (s->stream.dict_base) {
         src_target_pos =
           decode_dictionary_indices<is_calc_sizes_only::NO>(s, sb, src_target_pos, warp).first;
       } else if (s->setup.col.physical_type == Type::BOOLEAN) {

--- a/cpp/src/io/parquet/page_data.cuh
+++ b/cpp/src/io/parquet/page_data.cuh
@@ -120,17 +120,18 @@ inline __device__ void read_int96_timestamp(page_state_s* s,
   using cuda::std::chrono::duration_cast;
 
   uint8_t const* src8;
-  uint32_t dict_pos, dict_size = s->dict_size, ofs;
+  uint32_t dict_pos, dict_size = s->stream.dict_size, ofs;
 
-  if (s->dict_base) {
+  if (s->stream.dict_base) {
     // Dictionary
-    dict_pos =
-      (s->dict_bits > 0) ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)] : 0;
-    src8 = s->dict_base;
+    dict_pos = (s->stream.dict_bits > 0)
+                 ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)]
+                 : 0;
+    src8     = s->stream.dict_base;
   } else {
     // Plain
     dict_pos = src_pos;
-    src8     = s->data_start;
+    src8     = s->stream.data_start;
   }
   dict_pos *= (uint32_t)s->dtype_len_in;
   ofs = 3 & reinterpret_cast<size_t>(src8);
@@ -193,18 +194,19 @@ inline __device__ void read_int64_timestamp(page_state_s* s,
                                             int64_t* dst)
 {
   uint8_t const* src8;
-  uint32_t dict_pos, dict_size = s->dict_size, ofs;
+  uint32_t dict_pos, dict_size = s->stream.dict_size, ofs;
   int64_t ts;
 
-  if (s->dict_base) {
+  if (s->stream.dict_base) {
     // Dictionary
-    dict_pos =
-      (s->dict_bits > 0) ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)] : 0;
-    src8 = s->dict_base;
+    dict_pos = (s->stream.dict_bits > 0)
+                 ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)]
+                 : 0;
+    src8     = s->stream.dict_base;
   } else {
     // Plain
     dict_pos = src_pos;
-    src8     = s->data_start;
+    src8     = s->stream.data_start;
   }
   dict_pos *= (uint32_t)s->dtype_len_in;
   ofs = 3 & reinterpret_cast<size_t>(src8);
@@ -268,13 +270,14 @@ __device__ void read_fixed_width_byte_array_as_int(page_state_s* s,
                                                    T* dst)
 {
   uint32_t const dtype_len_in = s->dtype_len_in;
-  uint8_t const* data         = s->dict_base ? s->dict_base : s->data_start;
+  uint8_t const* data         = s->stream.dict_base ? s->stream.dict_base : s->stream.data_start;
   uint32_t const pos =
-    (s->dict_base
-       ? ((s->dict_bits > 0) ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)] : 0)
+    (s->stream.dict_base
+       ? ((s->stream.dict_bits > 0) ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)]
+                                    : 0)
        : src_pos) *
     dtype_len_in;
-  uint32_t const dict_size = s->dict_size;
+  uint32_t const dict_size = s->stream.dict_size;
 
   T unscaled = 0;
   for (unsigned int i = 0; i < dtype_len_in; i++) {
@@ -305,17 +308,18 @@ inline __device__ void read_fixed_width_value_fast(page_state_s* s,
                                                    T* dst)
 {
   uint8_t const* dict;
-  uint32_t dict_pos, dict_size = s->dict_size;
+  uint32_t dict_pos, dict_size = s->stream.dict_size;
 
-  if (s->dict_base) {
+  if (s->stream.dict_base) {
     // Dictionary
-    dict_pos =
-      (s->dict_bits > 0) ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)] : 0;
-    dict = s->dict_base;
+    dict_pos = (s->stream.dict_bits > 0)
+                 ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)]
+                 : 0;
+    dict     = s->stream.dict_base;
   } else {
     // Plain
     dict_pos = src_pos;
-    dict     = s->data_start;
+    dict     = s->stream.data_start;
   }
   dict_pos *= (uint32_t)s->dtype_len_in;
   gpuStoreOutput(dst, dict, dict_pos, dict_size);
@@ -335,17 +339,18 @@ inline __device__ void read_nbyte_fixed_width_value(
   page_state_s* s, state_buf* sb, int src_pos, uint8_t* dst8, int len)
 {
   uint8_t const* dict;
-  uint32_t dict_pos, dict_size = s->dict_size;
+  uint32_t dict_pos, dict_size = s->stream.dict_size;
 
-  if (s->dict_base) {
+  if (s->stream.dict_base) {
     // Dictionary
-    dict_pos =
-      (s->dict_bits > 0) ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)] : 0;
-    dict = s->dict_base;
+    dict_pos = (s->stream.dict_bits > 0)
+                 ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)]
+                 : 0;
+    dict     = s->stream.dict_base;
   } else {
     // Plain
     dict_pos = src_pos;
-    dict     = s->data_start;
+    dict     = s->stream.data_start;
   }
   dict_pos *= (uint32_t)s->dtype_len_in;
   if (len & 3) {

--- a/cpp/src/io/parquet/page_decode.cuh
+++ b/cpp/src/io/parquet/page_decode.cuh
@@ -30,20 +30,29 @@ struct page_decode_setup_state {
   kernel_error::value_type error{};
 };
 
+// Data-source + dictionary + level byte-range state used while consuming a page's
+// encoded byte streams. Grouped so passes that only need to advance streams can
+// share exactly this subset (see page_state_composed.cuh).
+struct page_decode_stream_state {
+  uint8_t const* data_start{};
+  uint8_t const* data_end{};
+  uint8_t const* abs_lvl_start[NUM_LEVEL_TYPES]{};
+  uint8_t const* abs_lvl_end[NUM_LEVEL_TYPES]{};
+  uint32_t initial_rle_run[NUM_LEVEL_TYPES]{};
+  int32_t initial_rle_value[NUM_LEVEL_TYPES]{};
+  uint8_t const* dict_base{};
+  int32_t dict_size{};
+  int32_t dict_bits{};
+  uint32_t dict_run{};
+  int32_t dict_val{};
+};
+
 struct page_state_s {
   CUDF_HOST_DEVICE constexpr page_state_s() noexcept {}
   page_decode_setup_state setup{};
-  uint8_t const* data_start{};
-  uint8_t const* data_end{};
-  uint8_t const* dict_base{};  // ptr to dictionary page data
-  int32_t dict_size{};         // size of dictionary data
-  int32_t dtype_len{};         // Output data type length
-  int32_t dtype_len_in{};      // Can be larger than dtype_len if truncating 32-bit into 8-bit
-  int32_t dict_bits{};         // # of bits to store dictionary indices
-  uint32_t dict_run{};
-  int32_t dict_val{};
-  uint32_t initial_rle_run[NUM_LEVEL_TYPES]{};   // [def,rep]
-  int32_t initial_rle_value[NUM_LEVEL_TYPES]{};  // [def,rep]
+  page_decode_stream_state stream{};
+  int32_t dtype_len{};     // Output data type length
+  int32_t dtype_len_in{};  // Can be larger than dtype_len if truncating 32-bit into 8-bit
 
   // (leaf) value decoding
   int32_t nz_count{};  // number of valid entries in nz_idx (write position in circular buffer)
@@ -52,12 +61,10 @@ struct page_state_s {
   int32_t ts_scale{};  // timestamp scale: <0: divide by -ts_scale, >0: multiply by ts_scale
 
   // repetition/definition level decoding
-  int32_t input_value_count{};  // how many values of the input we've processed
-  int32_t input_row_count{};    // how many rows of the input we've processed
-  int32_t input_leaf_count{};   // how many leaf values of the input we've processed
-  uint8_t const* abs_lvl_start[NUM_LEVEL_TYPES]{};  // [def,rep]
-  uint8_t const* abs_lvl_end[NUM_LEVEL_TYPES]{};    // [def,rep]
-  int32_t row_index_lower_bound{};                  // lower bound of row indices we should process
+  int32_t input_value_count{};      // how many values of the input we've processed
+  int32_t input_row_count{};        // how many rows of the input we've processed
+  int32_t input_leaf_count{};       // how many leaf values of the input we've processed
+  int32_t row_index_lower_bound{};  // lower bound of row indices we should process
 
   // a shared-memory cache of frequently used data when decoding. The source of this data is
   // normally stored in global memory which can yield poor performance. So, when possible
@@ -118,7 +125,7 @@ struct null_count_back_copier {
  * @param s Page state
  * @return True if the page is nullable (max definition level > 0)
  */
-__device__ inline bool is_nullable(page_state_s* s)
+__device__ inline bool is_nullable(auto* s)
 {
   auto const lvl           = level_type::DEFINITION;
   auto const max_def_level = s->setup.col.max_level[lvl];
@@ -137,10 +144,10 @@ __device__ inline bool is_nullable(page_state_s* s)
  * @param s Page state
  * @return True if the page could contain null values
  */
-__device__ inline bool maybe_has_nulls(page_state_s* s)
+__device__ inline bool maybe_has_nulls(auto* s)
 {
   auto const lvl      = level_type::DEFINITION;
-  auto const init_run = s->initial_rle_run[lvl];
+  auto const init_run = s->stream.initial_rle_run[lvl];
   // literal runs, lets assume they could hold nulls
   if (is_literal_run(init_run)) { return true; }
 
@@ -149,7 +156,7 @@ __device__ inline bool maybe_has_nulls(page_state_s* s)
   if (s->setup.page.num_input_values != (init_run >> 1)) { return true; }
 
   auto const lvl_bits = s->setup.col.level_bits[lvl];
-  auto const run_val  = lvl_bits == 0 ? 0 : s->initial_rle_value[lvl];
+  auto const run_val  = lvl_bits == 0 ? 0 : s->stream.initial_rle_value[lvl];
 
   // the encoded repeated value isn't valid, we have (all) nulls
   return run_val != s->setup.col.max_level[lvl];
@@ -161,7 +168,7 @@ __device__ inline bool maybe_has_nulls(page_state_s* s)
  * @param s Page state
  * @return True if the page should process nulls
  */
-__device__ inline bool should_process_nulls(page_state_s* s)
+__device__ inline bool should_process_nulls(auto* s)
 {
   return is_nullable(s) && maybe_has_nulls(s);
 }
@@ -296,20 +303,20 @@ inline __device__ string_index_pair gpuGetStringData(page_state_s* s, state_buf*
   using len_type  = cuda::std::tuple_element<1, string_index_pair>::type;
   len_type len    = 0;
 
-  if (s->dict_base) {
+  if (s->stream.dict_base) {
     // String dictionary
     uint32_t dict_pos =
-      (s->dict_bits > 0)
+      (s->stream.dict_bits > 0)
         ? sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)] * sizeof(string_index_pair)
         : 0;
-    if (dict_pos < (uint32_t)s->dict_size) {
-      return *reinterpret_cast<string_index_pair const*>(s->dict_base + dict_pos);
+    if (dict_pos < (uint32_t)s->stream.dict_size) {
+      return *reinterpret_cast<string_index_pair const*>(s->stream.dict_base + dict_pos);
     }
   } else {
     // Plain encoding
     uint32_t dict_pos = sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)];
-    if (dict_pos <= (uint32_t)s->dict_size) {
-      ptr = reinterpret_cast<char const*>(s->data_start + dict_pos);
+    if (dict_pos <= (uint32_t)s->stream.dict_size) {
+      ptr = reinterpret_cast<char const*>(s->stream.data_start + dict_pos);
       len = sb->str_len[rolling_index<state_buf::str_buf_size>(src_pos)];
     }
   }
@@ -345,8 +352,8 @@ __device__ cuda::std::pair<int, int> decode_dictionary_indices(
   int target_pos,
   cg::thread_block_tile<cudf::detail::warp_size, cg::thread_block> const& warp)
 {
-  uint8_t const* end = s->data_end;
-  int dict_bits      = s->dict_bits;
+  uint8_t const* end = s->stream.data_end;
+  int dict_bits      = s->stream.dict_bits;
   int pos            = s->dict_pos;
   int str_len        = 0;
   int const t        = warp.thread_rank();
@@ -358,8 +365,8 @@ __device__ cuda::std::pair<int, int> decode_dictionary_indices(
   while (pos < target_pos) {
     int is_literal, batch_len;
     if (t == 0) {
-      uint32_t run       = s->dict_run;
-      uint8_t const* cur = s->data_start;
+      uint32_t run       = s->stream.dict_run;
+      uint8_t const* cur = s->stream.data_start;
       if (run <= 1) {
         run = (cur < end) ? get_vlq32(cur, end) : 0;
         if (!(run & 1)) {
@@ -374,7 +381,7 @@ __device__ cuda::std::pair<int, int> decode_dictionary_indices(
                 if (bytecnt > 3) { run_val |= cur[3] << 24; }
               }
             }
-            s->dict_val = run_val & ((1 << dict_bits) - 1);
+            s->stream.dict_val = run_val & ((1 << dict_bits) - 1);
           }
           cur += bytecnt;
         }
@@ -390,9 +397,9 @@ __device__ cuda::std::pair<int, int> decode_dictionary_indices(
         batch_len = max(min(32, (int)(run >> 1)), 1);
         run -= batch_len * 2;
       }
-      s->dict_run   = run;
-      s->data_start = cur;
-      is_literal    = run & 1;
+      s->stream.dict_run   = run;
+      s->stream.data_start = cur;
+      is_literal           = run & 1;
       __threadfence_block();
     }
     warp.sync();
@@ -402,10 +409,10 @@ __device__ cuda::std::pair<int, int> decode_dictionary_indices(
     // compute dictionary index.
     int dict_idx = 0;
     if (t < batch_len) {
-      dict_idx = s->dict_val;
+      dict_idx = s->stream.dict_val;
       if (is_literal) {
         int32_t ofs      = (t - ((batch_len + 7) & ~7)) * dict_bits;
-        uint8_t const* p = s->data_start + (ofs >> 3);
+        uint8_t const* p = s->stream.data_start + (ofs >> 3);
         ofs &= 7;
         if (p < end) {
           uint32_t c = 8 - ofs;
@@ -433,9 +440,11 @@ __device__ cuda::std::pair<int, int> decode_dictionary_indices(
     if constexpr (sizes_only == is_calc_sizes_only::YES) {
       int const len = [&]() {
         if (t >= batch_len || (pos + t >= target_pos)) { return 0; }
-        uint32_t const dict_pos = (s->dict_bits > 0) ? dict_idx * sizeof(string_index_pair) : 0;
-        if (dict_pos < (uint32_t)s->dict_size) {
-          auto const* src = reinterpret_cast<string_index_pair const*>(s->dict_base + dict_pos);
+        uint32_t const dict_pos =
+          (s->stream.dict_bits > 0) ? dict_idx * sizeof(string_index_pair) : 0;
+        if (dict_pos < (uint32_t)s->stream.dict_size) {
+          auto const* src =
+            reinterpret_cast<string_index_pair const*>(s->stream.dict_base + dict_pos);
           return src->second;
         }
         return 0;
@@ -470,7 +479,7 @@ inline __device__ int decode_rle_booleans(
   int target_pos,
   cg::thread_block_tile<cudf::detail::warp_size, cg::thread_block> const& warp)
 {
-  uint8_t const* end = s->data_end;
+  uint8_t const* end = s->stream.data_end;
   int64_t pos        = s->dict_pos;
   int const t        = warp.thread_rank();
 
@@ -481,13 +490,13 @@ inline __device__ int decode_rle_booleans(
   while (pos < target_pos) {
     int is_literal, batch_len;
     if (t == 0) {
-      uint32_t run       = s->dict_run;
-      uint8_t const* cur = s->data_start;
+      uint32_t run       = s->stream.dict_run;
+      uint8_t const* cur = s->stream.data_start;
       if (run <= 1) {
         run = (cur < end) ? get_vlq32(cur, end) : 0;
         if (!(run & 1)) {
           // Repeated value
-          s->dict_val = (cur < end) ? cur[0] & 1 : 0;
+          s->stream.dict_val = (cur < end) ? cur[0] & 1 : 0;
           cur++;
         }
       }
@@ -503,9 +512,9 @@ inline __device__ int decode_rle_booleans(
         batch_len = max(min(32, (int)(run >> 1)), 1);
         run -= batch_len * 2;
       }
-      s->dict_run   = run;
-      s->data_start = cur;
-      is_literal    = run & 1;
+      s->stream.dict_run   = run;
+      s->stream.data_start = cur;
+      is_literal           = run & 1;
       __threadfence_block();
     }
 
@@ -517,10 +526,10 @@ inline __device__ int decode_rle_booleans(
       int dict_idx;
       if (is_literal) {
         int32_t ofs      = t - ((batch_len + 7) & ~7);
-        uint8_t const* p = s->data_start + (ofs >> 3);
+        uint8_t const* p = s->stream.data_start + (ofs >> 3);
         dict_idx         = (p < end) ? (p[0] >> (ofs & 7u)) & 1 : 0;
       } else {
-        dict_idx = s->dict_val;
+        dict_idx = s->stream.dict_val;
       }
       sb->dict_idx[rolling_index<state_buf::dict_buf_size>(pos + t)] = dict_idx;
     }
@@ -550,15 +559,15 @@ __device__ size_type initialize_string_descriptors(page_state_s* s,
                                                    thread_group const& group)
 {
   int const t         = group.thread_rank();
-  int const dict_size = s->dict_size;
-  int k               = s->dict_val;
+  int const dict_size = s->stream.dict_size;
+  int k               = s->stream.dict_val;
   int pos             = s->dict_pos;
   int total_len       = 0;
 
   // All group threads can participate for fixed len byte arrays.
   if (s->setup.col.physical_type == Type::FIXED_LEN_BYTE_ARRAY) {
     int const dtype_len_in = s->dtype_len_in;
-    total_len              = min((target_pos - pos) * dtype_len_in, dict_size - s->dict_val);
+    total_len              = min((target_pos - pos) * dtype_len_in, dict_size - s->stream.dict_val);
     if constexpr (sizes_only == is_calc_sizes_only::NO) {
       for (pos += t, k += t * dtype_len_in; pos < target_pos; pos += group.size()) {
         sb->str_len[rolling_index<state_buf::str_buf_size>(pos)] =
@@ -569,13 +578,13 @@ __device__ size_type initialize_string_descriptors(page_state_s* s,
         if (k < dict_size) { k = min(k + (group.size() * dtype_len_in), dict_size); }
       }
     }
-    // Only thread_rank = 0 updates the s->dict_val
-    if (t == 0) { s->dict_val += total_len; }
+    // Only thread_rank = 0 updates the s->stream.dict_val
+    if (t == 0) { s->stream.dict_val += total_len; }
   }
   // This step is purely serial for byte arrays
   else {
     if (t == 0) {
-      uint8_t const* cur = s->data_start;
+      uint8_t const* cur = s->stream.data_start;
 
       for (int len = 0; pos < target_pos; pos++, len = 0) {
         if (k + 4 <= dict_size) {
@@ -590,7 +599,7 @@ __device__ size_type initialize_string_descriptors(page_state_s* s,
         k += len;
         total_len += len;
       }
-      s->dict_val = k;
+      s->stream.dict_val = k;
     }
   }
 
@@ -956,7 +965,7 @@ __device__ void gpuDecodeLevels(
  *
  * @return The length of the section
  */
-inline __device__ uint32_t InitLevelSection(page_state_s* s,
+inline __device__ uint32_t InitLevelSection(auto* s,
                                             uint8_t const* cur,
                                             uint8_t const* end,
                                             level_type lvl)
@@ -969,8 +978,8 @@ inline __device__ uint32_t InitLevelSection(page_state_s* s,
   auto start = cur;
 
   auto init_rle = [s, lvl, level_bits](uint8_t const* cur, uint8_t const* end) {
-    uint32_t const run      = get_vlq32(cur, end);
-    s->initial_rle_run[lvl] = run;
+    uint32_t const run             = get_vlq32(cur, end);
+    s->stream.initial_rle_run[lvl] = run;
     if (!(run & 1)) {
       if (cur < end) {
         int v = cur[0];
@@ -979,9 +988,9 @@ inline __device__ uint32_t InitLevelSection(page_state_s* s,
           v |= ((cur < end) ? cur[0] : 0) << 8;
           cur++;
         }
-        s->initial_rle_value[lvl] = v;
+        s->stream.initial_rle_value[lvl] = v;
       } else {
-        s->initial_rle_value[lvl] = 0;
+        s->stream.initial_rle_value[lvl] = 0;
       }
     }
 
@@ -993,18 +1002,18 @@ inline __device__ uint32_t InitLevelSection(page_state_s* s,
   // thus we will handle V2 headers separately.
   if ((s->setup.page.flags & PAGEINFO_FLAGS_V2) != 0 && (len = s->setup.page.lvl_bytes[lvl]) != 0) {
     // V2 only uses RLE encoding so no need to check encoding
-    s->abs_lvl_start[lvl] = cur;
+    s->stream.abs_lvl_start[lvl] = cur;
     init_rle(cur, cur + len);
   } else if (level_bits == 0) {
-    len                       = 0;
-    s->initial_rle_run[lvl]   = s->setup.page.num_input_values * 2;  // repeated value
-    s->initial_rle_value[lvl] = 0;
-    s->abs_lvl_start[lvl]     = cur;
+    len                              = 0;
+    s->stream.initial_rle_run[lvl]   = s->setup.page.num_input_values * 2;  // repeated value
+    s->stream.initial_rle_value[lvl] = 0;
+    s->stream.abs_lvl_start[lvl]     = cur;
   } else if (encoding == Encoding::RLE) {  // V1 header with RLE encoding
     if (cur + 4 < end) {
       len = (cur[0]) + (cur[1] << 8) + (cur[2] << 16) + (cur[3] << 24);
       cur += 4;
-      s->abs_lvl_start[lvl] = cur;
+      s->stream.abs_lvl_start[lvl] = cur;
       init_rle(cur, cur + len);
       // add back the 4 bytes for the length
       len += 4;
@@ -1013,16 +1022,17 @@ inline __device__ uint32_t InitLevelSection(page_state_s* s,
       s->set_error_code(decode_error::LEVEL_STREAM_OVERRUN);
     }
   } else if (encoding == Encoding::BIT_PACKED) {
-    len                       = (s->setup.page.num_input_values * level_bits + 7) >> 3;
-    s->initial_rle_run[lvl]   = ((s->setup.page.num_input_values + 7) >> 3) * 2 + 1;  // literal run
-    s->initial_rle_value[lvl] = 0;
-    s->abs_lvl_start[lvl]     = cur;
+    len = (s->setup.page.num_input_values * level_bits + 7) >> 3;
+    s->stream.initial_rle_run[lvl] =
+      ((s->setup.page.num_input_values + 7) >> 3) * 2 + 1;  // literal run
+    s->stream.initial_rle_value[lvl] = 0;
+    s->stream.abs_lvl_start[lvl]     = cur;
   } else {
     len = 0;
     s->set_error_code(decode_error::UNSUPPORTED_ENCODING);
   }
 
-  s->abs_lvl_end[lvl] = start + len;
+  s->stream.abs_lvl_end[lvl] = start + len;
 
   return static_cast<uint32_t>(len);
 }
@@ -1070,7 +1080,7 @@ enum class page_processing_stage {
  * @return True if this page should be processed further
  */
 template <typename Filter>
-inline __device__ bool setup_local_page_info(page_state_s* const s,
+inline __device__ bool setup_local_page_info(auto* const s,
                                              PageInfo const* p,
                                              device_span<ColumnChunkDesc const> chunks,
                                              size_t min_row,
@@ -1082,9 +1092,9 @@ inline __device__ bool setup_local_page_info(page_state_s* const s,
 
   // Fetch page info
   if (!t) {
-    s->setup.page   = *p;
-    s->nesting_info = nullptr;
-    s->setup.col    = chunks[s->setup.page.chunk_idx];
+    s->setup.page = *p;
+    if constexpr (requires { s->nesting_info; }) { s->nesting_info = nullptr; }
+    s->setup.col = chunks[s->setup.page.chunk_idx];
   }
   __syncthreads();
 
@@ -1101,27 +1111,32 @@ inline __device__ bool setup_local_page_info(page_state_s* const s,
   // if we can use the nesting decode cache, set it up now
   auto const can_use_decode_cache =
     s->setup.page.nesting_info_size <= max_cacheable_nesting_decode_info;
-  if (can_use_decode_cache) {
-    int depth = 0;
-    while (depth < s->setup.page.nesting_info_size) {
-      int const thread_depth = depth + t;
-      if (thread_depth < s->setup.page.nesting_info_size) {
-        // these values need to be copied over from global
-        s->nesting_decode_cache[thread_depth].max_def_level =
-          s->setup.page.nesting_decode[thread_depth].max_def_level;
-        s->nesting_decode_cache[thread_depth].page_start_value =
-          s->setup.page.nesting_decode[thread_depth].page_start_value;
-        s->nesting_decode_cache[thread_depth].start_depth =
-          s->setup.page.nesting_decode[thread_depth].start_depth;
-        s->nesting_decode_cache[thread_depth].end_depth =
-          s->setup.page.nesting_decode[thread_depth].end_depth;
+  if constexpr (requires { s->nesting_decode_cache; }) {
+    if (can_use_decode_cache) {
+      int depth = 0;
+      while (depth < s->setup.page.nesting_info_size) {
+        int const thread_depth = depth + t;
+        if (thread_depth < s->setup.page.nesting_info_size) {
+          // these values need to be copied over from global
+          s->nesting_decode_cache[thread_depth].max_def_level =
+            s->setup.page.nesting_decode[thread_depth].max_def_level;
+          s->nesting_decode_cache[thread_depth].page_start_value =
+            s->setup.page.nesting_decode[thread_depth].page_start_value;
+          s->nesting_decode_cache[thread_depth].start_depth =
+            s->setup.page.nesting_decode[thread_depth].start_depth;
+          s->nesting_decode_cache[thread_depth].end_depth =
+            s->setup.page.nesting_decode[thread_depth].end_depth;
+        }
+        depth += blockDim.x;
       }
-      depth += blockDim.x;
     }
   }
 
   if (!t) {
-    s->nesting_info = can_use_decode_cache ? s->nesting_decode_cache : s->setup.page.nesting_decode;
+    if constexpr (requires { s->nesting_info; }) {
+      s->nesting_info =
+        can_use_decode_cache ? s->nesting_decode_cache : s->setup.page.nesting_decode;
+    }
 
     // NOTE: s->setup.page.num_rows, s->setup.col.chunk_row, s->setup.first_row and
     // s->setup.num_rows will be invalid/bogus during first pass of the preprocess step for nested
@@ -1146,15 +1161,17 @@ inline __device__ bool setup_local_page_info(page_state_s* const s,
   __syncthreads();
 
   // zero counts
-  int depth = 0;
-  while (depth < s->setup.page.num_output_nesting_levels) {
-    int const thread_depth = depth + t;
-    if (thread_depth < s->setup.page.num_output_nesting_levels) {
-      s->nesting_info[thread_depth].valid_count = 0;
-      s->nesting_info[thread_depth].value_count = 0;
-      s->nesting_info[thread_depth].null_count  = 0;
+  if constexpr (requires { s->nesting_info; }) {
+    int depth = 0;
+    while (depth < s->setup.page.num_output_nesting_levels) {
+      int const thread_depth = depth + t;
+      if (thread_depth < s->setup.page.num_output_nesting_levels) {
+        s->nesting_info[thread_depth].valid_count = 0;
+        s->nesting_info[thread_depth].value_count = 0;
+        s->nesting_info[thread_depth].null_count  = 0;
+      }
+      depth += blockDim.x;
     }
-    depth += blockDim.x;
   }
   __syncthreads();
 
@@ -1187,32 +1204,55 @@ inline __device__ bool setup_local_page_info(page_state_s* const s,
     if (s->setup.page.num_input_values > 0) {
       uint8_t* cur = s->setup.page.page_data;
       uint8_t* end = cur + s->setup.page.uncompressed_page_size;
-      s->ts_scale  = 0;
-      // Validate data type
-      auto const data_type  = s->setup.col.physical_type;
-      auto const is_decimal = s->setup.col.logical_type.has_value() and
-                              s->setup.col.logical_type->type == LogicalType::DECIMAL;
-      switch (data_type) {
-        case Type::BOOLEAN:
-          s->dtype_len = 1;  // Boolean are stored as 1 byte on the output
-          break;
-        case Type::INT32: [[fallthrough]];
-        case Type::FLOAT: s->dtype_len = 4; break;
-        case Type::INT64:
-          if (s->setup.col.ts_clock_rate) {
-            s->ts_scale =
-              calc_timestamp_scale(s->setup.col.logical_type, s->setup.col.ts_clock_rate);
-          }
-          [[fallthrough]];
-        case Type::DOUBLE: s->dtype_len = 8; break;
-        case Type::INT96: s->dtype_len = 12; break;
-        case Type::BYTE_ARRAY:
+      if constexpr (requires { s->dtype_len; }) {
+        s->ts_scale = 0;
+        // Validate data type
+        auto const data_type  = s->setup.col.physical_type;
+        auto const is_decimal = s->setup.col.logical_type.has_value() and
+                                s->setup.col.logical_type->type == LogicalType::DECIMAL;
+        switch (data_type) {
+          case Type::BOOLEAN:
+            s->dtype_len = 1;  // Boolean are stored as 1 byte on the output
+            break;
+          case Type::INT32: [[fallthrough]];
+          case Type::FLOAT: s->dtype_len = 4; break;
+          case Type::INT64:
+            if (s->setup.col.ts_clock_rate) {
+              s->ts_scale =
+                calc_timestamp_scale(s->setup.col.logical_type, s->setup.col.ts_clock_rate);
+            }
+            [[fallthrough]];
+          case Type::DOUBLE: s->dtype_len = 8; break;
+          case Type::INT96: s->dtype_len = 12; break;
+          case Type::BYTE_ARRAY:
+            if (is_decimal) {
+              auto const decimal_precision = s->setup.col.logical_type->precision();
+              s->dtype_len                 = [decimal_precision]() {
+                if (decimal_precision <= MAX_DECIMAL32_PRECISION) {
+                  return sizeof(int32_t);
+                } else if (decimal_precision <= MAX_DECIMAL64_PRECISION) {
+                  return sizeof(int64_t);
+                } else {
+                  return sizeof(__int128_t);
+                }
+              }();
+            } else {
+              s->dtype_len = sizeof(string_index_pair);
+            }
+            break;
+          default:  // FIXED_LEN_BYTE_ARRAY:
+            s->dtype_len = s->setup.col.type_length;
+            if (s->dtype_len <= 0) { s->set_error_code(decode_error::INVALID_DATA_TYPE); }
+            break;
+        }
+        // Special check for downconversions
+        s->dtype_len_in = s->dtype_len;
+        if (data_type == Type::FIXED_LEN_BYTE_ARRAY) {
           if (is_decimal) {
-            auto const decimal_precision = s->setup.col.logical_type->precision();
-            s->dtype_len                 = [decimal_precision]() {
-              if (decimal_precision <= MAX_DECIMAL32_PRECISION) {
+            s->dtype_len = [dtype_len = s->dtype_len]() {
+              if (dtype_len <= sizeof(int32_t)) {
                 return sizeof(int32_t);
-              } else if (decimal_precision <= MAX_DECIMAL64_PRECISION) {
+              } else if (dtype_len <= sizeof(int64_t)) {
                 return sizeof(int64_t);
               } else {
                 return sizeof(__int128_t);
@@ -1221,95 +1261,74 @@ inline __device__ bool setup_local_page_info(page_state_s* const s,
           } else {
             s->dtype_len = sizeof(string_index_pair);
           }
-          break;
-        default:  // FIXED_LEN_BYTE_ARRAY:
-          s->dtype_len = s->setup.col.type_length;
-          if (s->dtype_len <= 0) { s->set_error_code(decode_error::INVALID_DATA_TYPE); }
-          break;
-      }
-      // Special check for downconversions
-      s->dtype_len_in = s->dtype_len;
-      if (data_type == Type::FIXED_LEN_BYTE_ARRAY) {
-        if (is_decimal) {
-          s->dtype_len = [dtype_len = s->dtype_len]() {
-            if (dtype_len <= sizeof(int32_t)) {
-              return sizeof(int32_t);
-            } else if (dtype_len <= sizeof(int64_t)) {
-              return sizeof(int64_t);
-            } else {
-              return sizeof(__int128_t);
+        } else if (data_type == Type::INT32) {
+          // check for smaller bitwidths
+          if (s->setup.col.logical_type.has_value()) {
+            auto const& lt = *s->setup.col.logical_type;
+            if (lt.type == LogicalType::INTEGER) {
+              s->dtype_len = lt.bit_width() / 8;
+            } else if (lt.is_time_millis()) {
+              // cudf outputs as INT64
+              s->dtype_len = 8;
             }
-          }();
-        } else {
-          s->dtype_len = sizeof(string_index_pair);
+          }
+        } else if (data_type == Type::BYTE_ARRAY && s->setup.col.is_strings_to_cat) {
+          s->dtype_len = 4;  // HASH32 output
+        } else if (data_type == Type::INT96) {
+          s->dtype_len = 8;  // Convert to 64-bit timestamp
         }
-      } else if (data_type == Type::INT32) {
-        // check for smaller bitwidths
-        if (s->setup.col.logical_type.has_value()) {
-          auto const& lt = *s->setup.col.logical_type;
-          if (lt.type == LogicalType::INTEGER) {
-            s->dtype_len = lt.bit_width() / 8;
-          } else if (lt.is_time_millis()) {
-            // cudf outputs as INT64
-            s->dtype_len = 8;
-          }
-        }
-      } else if (data_type == Type::BYTE_ARRAY && s->setup.col.is_strings_to_cat) {
-        s->dtype_len = 4;  // HASH32 output
-      } else if (data_type == Type::INT96) {
-        s->dtype_len = 8;  // Convert to 64-bit timestamp
-      }
 
-      // during the decoding step we need to offset the global output buffers
-      // for each level of nesting so that we write to the section this page
-      // is responsible for.
-      // - for flat schemas, we can do this directly by using row counts
-      // - for nested schemas, these offsets are computed during the preprocess step
-      //
-      // NOTE: in a chunked read situation, s->setup.col.column_data_base and
-      // s->setup.col.valid_map_base will be aliased to memory that has been freed when we get here
-      // in the non-decode step, so we cannot check against nullptr.  we'll just check a flag
-      // directly.
-      if (stage == page_processing_stage::DECODE) {
-        int max_depth = s->setup.col.max_nesting_depth;
-        for (int idx = 0; idx < max_depth; idx++) {
-          PageNestingDecodeInfo* nesting_info = &s->nesting_info[idx];
+        // during the decoding step we need to offset the global output buffers
+        // for each level of nesting so that we write to the section this page
+        // is responsible for.
+        // - for flat schemas, we can do this directly by using row counts
+        // - for nested schemas, these offsets are computed during the preprocess step
+        //
+        // NOTE: in a chunked read situation, s->setup.col.column_data_base and
+        // s->setup.col.valid_map_base will be aliased to memory that has been freed when we get
+        // here in the non-decode step, so we cannot check against nullptr.  we'll just check a flag
+        // directly.
+        if (stage == page_processing_stage::DECODE) {
+          int max_depth = s->setup.col.max_nesting_depth;
+          for (int idx = 0; idx < max_depth; idx++) {
+            PageNestingDecodeInfo* nesting_info = &s->nesting_info[idx];
 
-          size_t output_offset;
-          // schemas without lists
-          if (s->setup.col.max_level[level_type::REPETITION] == 0) {
-            output_offset = page_start_row >= min_row ? page_start_row - min_row : 0;
-          }
-          // for schemas with lists, we've already got the exact value precomputed
-          else {
-            output_offset = nesting_info->page_start_value;
-          }
-
-          if (s->setup.col.column_data_base != nullptr) {
-            nesting_info->data_out = static_cast<uint8_t*>(s->setup.col.column_data_base[idx]);
-            if (s->setup.col.column_string_base != nullptr) {
-              nesting_info->string_out =
-                static_cast<uint8_t*>(s->setup.col.column_string_base[idx]);
+            size_t output_offset;
+            // schemas without lists
+            if (s->setup.col.max_level[level_type::REPETITION] == 0) {
+              output_offset = page_start_row >= min_row ? page_start_row - min_row : 0;
+            }
+            // for schemas with lists, we've already got the exact value precomputed
+            else {
+              output_offset = nesting_info->page_start_value;
             }
 
-            nesting_info->data_out = static_cast<uint8_t*>(s->setup.col.column_data_base[idx]);
+            if (s->setup.col.column_data_base != nullptr) {
+              nesting_info->data_out = static_cast<uint8_t*>(s->setup.col.column_data_base[idx]);
+              if (s->setup.col.column_string_base != nullptr) {
+                nesting_info->string_out =
+                  static_cast<uint8_t*>(s->setup.col.column_string_base[idx]);
+              }
 
-            if (nesting_info->data_out != nullptr) {
-              // anything below max depth with a valid data pointer must be a list, so the
-              // element size is the size of the offset type.
-              uint32_t len = idx < max_depth - 1 ? sizeof(cudf::size_type) : s->dtype_len;
-              // if this is a string column, then dtype_len is a lie. data will be offsets rather
-              // than (ptr,len) tuples.
-              if (is_string_col(s->setup.col)) { len = sizeof(cudf::size_type); }
-              nesting_info->data_out += (output_offset * len);
-            }
-            if (nesting_info->string_out != nullptr) {
-              nesting_info->string_out += s->setup.page.str_offset;
-            }
-            nesting_info->valid_map = s->setup.col.valid_map_base[idx];
-            if (nesting_info->valid_map != nullptr) {
-              nesting_info->valid_map += output_offset >> 5;
-              nesting_info->valid_map_offset = (int32_t)(output_offset & 0x1f);
+              nesting_info->data_out = static_cast<uint8_t*>(s->setup.col.column_data_base[idx]);
+
+              if (nesting_info->data_out != nullptr) {
+                // anything below max depth with a valid data pointer must be a list, so the
+                // element size is the size of the offset type.
+                uint32_t len = idx < max_depth - 1 ? sizeof(cudf::size_type) : s->dtype_len;
+                // if this is a string column, then dtype_len is a lie. data will be offsets rather
+                // than (ptr,len) tuples.
+                if (is_string_col(s->setup.col)) { len = sizeof(cudf::size_type); }
+                nesting_info->data_out += (output_offset * len);
+              }
+              if (nesting_info->string_out != nullptr) {
+                nesting_info->string_out += s->setup.page.str_offset;
+              }
+              nesting_info->valid_map = s->setup.col.valid_map_base[idx];
+              if (nesting_info->valid_map != nullptr) {
+                nesting_info->valid_map += output_offset >> 5;
+                nesting_info->valid_map_offset = (int32_t)(output_offset & 0x1f);
+              }
             }
           }
         }
@@ -1320,10 +1339,10 @@ inline __device__ bool setup_local_page_info(page_state_s* const s,
       // Find the compressed size of definition levels
       cur += InitLevelSection(s, cur, end, level_type::DEFINITION);
 
-      s->dict_bits = 0;
-      s->dict_base = nullptr;
-      s->dict_size = 0;
-      s->dict_val  = 0;
+      s->stream.dict_bits = 0;
+      s->stream.dict_base = nullptr;
+      s->stream.dict_size = 0;
+      s->stream.dict_val  = 0;
       // NOTE:  if additional encodings are supported in the future, modifications must
       // be made to is_supported_encoding() in reader_impl_preprocess.cu
       switch (s->setup.page.encoding) {
@@ -1336,32 +1355,35 @@ inline __device__ bool setup_local_page_info(page_state_s* const s,
                s->setup.col.physical_type == Type::FIXED_LEN_BYTE_ARRAY) and
               not is_decimal and s->setup.col.str_dict_index != nullptr) {
             // String dictionary: use index
-            s->dict_base = reinterpret_cast<uint8_t const*>(s->setup.col.str_dict_index);
-            s->dict_size = s->setup.col.dict_page->num_input_values * sizeof(string_index_pair);
+            s->stream.dict_base = reinterpret_cast<uint8_t const*>(s->setup.col.str_dict_index);
+            s->stream.dict_size =
+              s->setup.col.dict_page->num_input_values * sizeof(string_index_pair);
           } else {
-            s->dict_base = s->setup.col.dict_page->page_data;
-            s->dict_size = s->setup.col.dict_page->uncompressed_page_size;
+            s->stream.dict_base = s->setup.col.dict_page->page_data;
+            s->stream.dict_size = s->setup.col.dict_page->uncompressed_page_size;
           }
-          s->dict_run  = 0;
-          s->dict_val  = 0;
-          s->dict_bits = (cur < end) ? *cur++ : 0;
-          if (s->dict_bits > 32 ||
-              (!s->dict_base && s->setup.col.dict_page->num_input_values > 0)) {
+          s->stream.dict_run  = 0;
+          s->stream.dict_val  = 0;
+          s->stream.dict_bits = (cur < end) ? *cur++ : 0;
+          if (s->stream.dict_bits > 32 ||
+              (!s->stream.dict_base && s->setup.col.dict_page->num_input_values > 0)) {
             s->set_error_code(decode_error::INVALID_DICT_WIDTH);
           }
         } break;
         case Encoding::PLAIN:
         case Encoding::BYTE_STREAM_SPLIT:
-          s->dict_size = static_cast<int32_t>(end - cur);
-          s->dict_val  = 0;
-          if (s->setup.col.physical_type == Type::BOOLEAN) { s->dict_run = s->dict_size * 2 + 1; }
+          s->stream.dict_size = static_cast<int32_t>(end - cur);
+          s->stream.dict_val  = 0;
+          if (s->setup.col.physical_type == Type::BOOLEAN) {
+            s->stream.dict_run = s->stream.dict_size * 2 + 1;
+          }
           break;
         case Encoding::RLE: {
           // first 4 bytes are length of RLE data
           int const len = (cur[0]) + (cur[1] << 8) + (cur[2] << 16) + (cur[3] << 24);
           cur += 4;
           if (cur + len > end) { s->set_error_code(decode_error::DATA_STREAM_OVERRUN); }
-          s->dict_run = 0;
+          s->stream.dict_run = 0;
         } break;
         case Encoding::DELTA_BINARY_PACKED:
         case Encoding::DELTA_LENGTH_BYTE_ARRAY:
@@ -1374,67 +1396,70 @@ inline __device__ bool setup_local_page_info(page_state_s* const s,
         }
       }
       if (cur > end) { s->set_error_code(decode_error::DATA_STREAM_OVERRUN); }
-      s->data_start = cur;
-      s->data_end   = end;
+      s->stream.data_start = cur;
+      s->stream.data_end   = end;
     } else {
       s->set_error_code(decode_error::EMPTY_PAGE);
     }
 
-    s->nz_count               = 0;
     s->setup.num_input_values = s->setup.page.num_input_values;
-    s->dict_pos               = 0;
-    s->src_pos                = 0;
+    if constexpr (requires { s->input_value_count; }) {
+      s->nz_count = 0;
+      s->dict_pos = 0;
+      s->src_pos  = 0;
 
-    // for flat hierarchies, we can't know how many leaf values to skip unless we do a full
-    // preprocess of the definition levels (since nulls will have no actual decodable value, there
-    // is no direct correlation between # of rows and # of decodable values).  so we will start
-    // processing at the beginning of the value stream and disregard any indices that start
-    // before the first row.
-    if (s->setup.col.max_level[level_type::REPETITION] == 0) {
-      s->setup.page.skipped_values      = 0;
-      s->setup.page.skipped_leaf_values = 0;
-      s->input_value_count              = 0;
-      s->input_row_count                = 0;
-      s->input_leaf_count               = 0;
-
-      // The fixed-width decode kernel ASSUMES this is always -1 for non-lists!
-      s->row_index_lower_bound = -1;
-    }
-    // for nested hierarchies, we have run a preprocess that lets us skip directly to the values
-    // we need to start decoding at
-    else {
-      // input_row_count translates to "how many rows we have processed so far", so since we are
-      // skipping directly to where we want to start decoding, set it to first_row
-      s->input_row_count = s->setup.first_row;
-
-      // return the lower bound to compare (page-relative) thread row index against. Explanation:
-      // In the case of nested schemas, rows can span page boundaries.  That is to say,
-      // we can encounter the first value for row X on page M, but the last value for page M
-      // might not be the last value for row X. page M+1 (or further) may contain the last value.
-      //
-      // This means that the first values we encounter for a given page (M+1) may not belong to the
-      // row indicated by chunk_row, but to the row before it that spanned page boundaries. If that
-      // previous row is within the overall row bounds, include the values by allowing relative row
-      // index -1
-      int const max_row = (min_row + num_rows) - 1;
-      if (min_row < page_start_row && max_row >= page_start_row - 1) {
-        s->row_index_lower_bound = -1;
-      } else {
-        s->row_index_lower_bound = s->setup.first_row;
-      }
-
-      // if we're in the decoding step, jump directly to the first
-      // value we care about
-      if (stage == page_processing_stage::DECODE) {
-        s->input_value_count = s->setup.page.skipped_values > -1 ? s->setup.page.skipped_values : 0;
-      } else if (stage == page_processing_stage::PREPROCESS) {
-        s->input_value_count = 0;
-        s->input_leaf_count  = 0;
-        // magic number to indicate it hasn't been set for use inside UpdatePageSizes
-        s->setup.page.skipped_values      = -1;
+      // for flat hierarchies, we can't know how many leaf values to skip unless we do a full
+      // preprocess of the definition levels (since nulls will have no actual decodable value, there
+      // is no direct correlation between # of rows and # of decodable values).  so we will start
+      // processing at the beginning of the value stream and disregard any indices that start
+      // before the first row.
+      if (s->setup.col.max_level[level_type::REPETITION] == 0) {
+        s->setup.page.skipped_values      = 0;
         s->setup.page.skipped_leaf_values = 0;
+        s->input_value_count              = 0;
+        s->input_row_count                = 0;
+        s->input_leaf_count               = 0;
+
+        // The fixed-width decode kernel ASSUMES this is always -1 for non-lists!
+        s->row_index_lower_bound = -1;
       }
-    }
+      // for nested hierarchies, we have run a preprocess that lets us skip directly to the values
+      // we need to start decoding at
+      else {
+        // input_row_count translates to "how many rows we have processed so far", so since we are
+        // skipping directly to where we want to start decoding, set it to first_row
+        s->input_row_count = s->setup.first_row;
+
+        // return the lower bound to compare (page-relative) thread row index against. Explanation:
+        // In the case of nested schemas, rows can span page boundaries.  That is to say,
+        // we can encounter the first value for row X on page M, but the last value for page M
+        // might not be the last value for row X. page M+1 (or further) may contain the last value.
+        //
+        // This means that the first values we encounter for a given page (M+1) may not belong to
+        // the row indicated by chunk_row, but to the row before it that spanned page boundaries. If
+        // that previous row is within the overall row bounds, include the values by allowing
+        // relative row index -1
+        int const max_row = (min_row + num_rows) - 1;
+        if (min_row < page_start_row && max_row >= page_start_row - 1) {
+          s->row_index_lower_bound = -1;
+        } else {
+          s->row_index_lower_bound = s->setup.first_row;
+        }
+
+        // if we're in the decoding step, jump directly to the first
+        // value we care about
+        if (stage == page_processing_stage::DECODE) {
+          s->input_value_count =
+            s->setup.page.skipped_values > -1 ? s->setup.page.skipped_values : 0;
+        } else if (stage == page_processing_stage::PREPROCESS) {
+          s->input_value_count = 0;
+          s->input_leaf_count  = 0;
+          // magic number to indicate it hasn't been set for use inside UpdatePageSizes
+          s->setup.page.skipped_values      = -1;
+          s->setup.page.skipped_leaf_values = 0;
+        }
+      }
+    }  // if constexpr (requires { s->input_value_count; })
 
     __threadfence_block();
   }

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -356,7 +356,7 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   uint32_t const skipped_leaf_values = s->setup.page.skipped_leaf_values;
 
   // initialize delta state
-  if (block.thread_rank() == 0) { db->init_binary_block(s->data_start, s->data_end); }
+  if (block.thread_rank() == 0) { db->init_binary_block(s->stream.data_start, s->stream.data_end); }
   block.sync();
 
   auto const batch_size = db->values_per_mb;
@@ -521,7 +521,10 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   if (block.thread_rank() == 0) {
     // initialize the prefixes and suffixes blocks
-    dba->init(s->data_start, s->data_end, s->setup.page.start_val, s->setup.page.temp_string_buf);
+    dba->init(s->stream.data_start,
+              s->stream.data_end,
+              s->setup.page.start_val,
+              s->setup.page.temp_string_buf);
   }
   block.sync();
 
@@ -728,7 +731,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   // initialize delta state
   if (block.thread_rank() == 0) {
     string_offset    = 0;
-    page_string_data = db->find_end_of_block(s->data_start, s->data_end);
+    page_string_data = db->find_end_of_block(s->stream.data_start, s->stream.data_end);
   }
   block.sync();
 
@@ -763,7 +766,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
         // if there is no repetition, then we need to work through the whole page, so reset the
         // delta decoder to the beginning of the page
-        if (not has_repetition) { db->init_binary_block(s->data_start, s->data_end); }
+        if (not has_repetition) { db->init_binary_block(s->stream.data_start, s->stream.data_end); }
       }
     }
     block.sync();

--- a/cpp/src/io/parquet/page_state_composed.cuh
+++ b/cpp/src/io/parquet/page_state_composed.cuh
@@ -9,6 +9,8 @@
 
 namespace cudf::io::parquet::detail {
 
+// Convenience macro to define error methods for page state structs that include a setup state.
+// Cheaper and easier than trying to introduce inheritance or templates for this purpose.
 #define CUDF_PARQUET_PAGE_STATE_ERROR_METHODS                                                  \
   inline __device__ void set_error_code(decode_error err)                                      \
   {                                                                                            \
@@ -21,11 +23,9 @@ namespace cudf::io::parquet::detail {
     ref.store(0, cuda::std::memory_order_release);                                             \
   }
 
-// Composition C: level-only preprocess (RLE level decoding only, no output).
-// Used by: preprocess_levels.
+// Shared memory state struct used by the preprocess_levels kernel.
 // Includes setup (page metadata + error) and stream (level byte ranges + RLE state)
-// because this pass only advances the level streams and never needs nesting,
-// progress, or conversion scratch.
+// which are necessary to advance level streams.
 struct level_scan_state {
   page_decode_setup_state setup;
   page_decode_stream_state stream;

--- a/cpp/src/io/parquet/page_state_composed.cuh
+++ b/cpp/src/io/parquet/page_state_composed.cuh
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "page_decode.cuh"
+
+namespace cudf::io::parquet::detail {
+
+#define CUDF_PARQUET_PAGE_STATE_ERROR_METHODS                                                  \
+  inline __device__ void set_error_code(decode_error err)                                      \
+  {                                                                                            \
+    cuda::atomic_ref<kernel_error::value_type, cuda::thread_scope_block> ref{setup.error};     \
+    ref.fetch_or(static_cast<kernel_error::value_type>(err), cuda::std::memory_order_relaxed); \
+  }                                                                                            \
+  inline __device__ void reset_error_code()                                                    \
+  {                                                                                            \
+    cuda::atomic_ref<kernel_error::value_type, cuda::thread_scope_block> ref{setup.error};     \
+    ref.store(0, cuda::std::memory_order_release);                                             \
+  }
+
+// Composition C: level-only preprocess (RLE level decoding only, no output).
+// Used by: preprocess_levels.
+// Includes setup (page metadata + error) and stream (level byte ranges + RLE state)
+// because this pass only advances the level streams and never needs nesting,
+// progress, or conversion scratch.
+struct level_scan_state {
+  page_decode_setup_state setup;
+  page_decode_stream_state stream;
+  CUDF_PARQUET_PAGE_STATE_ERROR_METHODS
+};
+
+#undef CUDF_PARQUET_PAGE_STATE_ERROR_METHODS
+
+}  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -636,7 +636,7 @@ CUDF_KERNEL void __launch_bounds__(delta_preproc_block_size)
       if (start_value > 0) {
         // just need to parse the header of the first delta binary block to get values_per_mb
         delta_binary_decoder db;
-        db.init_binary_block(s->data_start, s->data_end);
+        db.init_binary_block(s->stream.data_start, s->stream.data_end);
         // save enough for one mini-block plus some extra to save the last_string
         pp->temp_string_size = s->dtype_len_in * (db.values_per_mb + 1);
       }
@@ -656,8 +656,8 @@ CUDF_KERNEL void __launch_bounds__(delta_preproc_block_size)
 
     // now process string info in the range [start_value, end_value)
     // set up for decoding strings...can be either plain or dictionary
-    uint8_t const* data      = s->data_start;
-    uint8_t const* const end = s->data_end;
+    uint8_t const* data      = s->stream.data_start;
+    uint8_t const* const end = s->stream.data_end;
     auto const end_value     = pp->end_val;
 
     auto const [len, temp_bytes] = totalDeltaByteArraySize(data, end, start_value, end_value);
@@ -741,9 +741,10 @@ CUDF_KERNEL void __launch_bounds__(delta_length_block_size)
   // if this isn't a bounds page.
   if (not is_bounds_pg) {
     if (t == 0) {
-      auto const* string_start = string_lengths.find_end_of_block(s->data_start, s->data_end);
-      size_t len               = static_cast<size_t>(s->data_end - string_start);
-      pp->str_bytes            = len;
+      auto const* string_start =
+        string_lengths.find_end_of_block(s->stream.data_start, s->stream.data_end);
+      size_t len    = static_cast<size_t>(s->stream.data_end - string_start);
+      pp->str_bytes = len;
     }
   } else {
     // now process string info in the range [start_value, end_value)
@@ -751,7 +752,7 @@ CUDF_KERNEL void __launch_bounds__(delta_length_block_size)
     auto const start_value = pp->start_val;
     auto const end_value   = pp->end_val;
 
-    if (t == 0) { string_lengths.init_binary_block(s->data_start, s->data_end); }
+    if (t == 0) { string_lengths.init_binary_block(s->stream.data_start, s->stream.data_end); }
     __syncwarp();
 
     size_t total_bytes = 0;
@@ -858,8 +859,8 @@ CUDF_KERNEL void __launch_bounds__(preprocess_block_size)
   } else {
     // now process string info in the range [start_value, end_value)
     // set up for decoding strings...can be either plain or dictionary
-    uint8_t const* data      = s->data_start;
-    uint8_t const* const end = s->data_end;
+    uint8_t const* data      = s->stream.data_start;
+    uint8_t const* const end = s->stream.data_end;
     uint8_t const* dict_base = nullptr;
     int dict_size            = 0;
     auto const start_value   = pp->start_val;
@@ -879,12 +880,12 @@ CUDF_KERNEL void __launch_bounds__(preprocess_block_size)
         }
 
         // FIXME: need to return an error condition...this won't actually do anything
-        if (s->dict_bits > 32 || (!dict_base && col.dict_page->num_input_values > 0)) {
+        if (s->stream.dict_bits > 32 || (!dict_base && col.dict_page->num_input_values > 0)) {
           CUDF_UNREACHABLE("invalid dictionary bit size");
         }
 
         str_bytes = totalDictEntriesSize(
-          data, dict_base, s->dict_bits, dict_size, (end - data), start_value, end_value);
+          data, dict_base, s->stream.dict_bits, dict_size, (end - data), start_value, end_value);
         break;
       case Encoding::PLAIN:
         // Check if we have precomputed offsets available
@@ -1110,8 +1111,8 @@ inline __device__ void read_string_offsets_buffered(page_state_s* s,
 {
   auto const block     = cg::this_thread_block();
   int const t          = block.thread_rank();
-  uint8_t const* cur   = s->data_start;
-  auto const dict_size = s->dict_size;
+  uint8_t const* cur   = s->stream.data_start;
+  auto const dict_size = s->stream.dict_size;
 
   int32_t buffer_base        = 0;
   int32_t buffer_end         = 0;
@@ -1208,9 +1209,9 @@ inline __device__ void read_string_offsets_sequential(page_state_s* s,
   __shared__ uint32_t last_offset;  // offset into data_start
 
   cg::invoke_one(block, [&]() {
-    uint8_t const* cur     = s->data_start;
+    uint8_t const* cur     = s->stream.data_start;
     uint32_t length_offset = 0;
-    auto const dict_size   = s->dict_size;
+    auto const dict_size   = s->stream.dict_size;
 
     // Process the data
     // Parquet data is: 4-byte length, string, 4-byte length, string, ...
@@ -1333,7 +1334,7 @@ CUDF_KERNEL void preprocess_string_offsets_kernel(
   // However, if the average string length is large, we'll spend too much time copying raw string
   // data we don't need: have a single thread read the string lengths sequentially.
   constexpr int max_avg_string_length_for_buffer = prefetch_size / 16;  // for 1024 buffer, is 64
-  auto const avg_string_length = s->dict_size / pp->num_input_values - sizeof(int32_t);
+  auto const avg_string_length = s->stream.dict_size / pp->num_input_values - sizeof(int32_t);
 
   if (avg_string_length > max_avg_string_length_for_buffer) {
     // Use sequential processing for large average string lengths

--- a/cpp/src/io/parquet/page_string_utils.cuh
+++ b/cpp/src/io/parquet/page_string_utils.cuh
@@ -256,11 +256,11 @@ __device__ size_t decode_strings(page_state_s* s,
                             ? 0
                             : next_offset - input_thread_string_offset - sizeof(int32_t);
         }
-        if (input_thread_string_offset >= static_cast<uint32_t>(s->dict_size)) {
+        if (input_thread_string_offset >= static_cast<uint32_t>(s->stream.dict_size)) {
           return string_index_pair{nullptr, 0};
         }
         auto const thread_input_string =
-          reinterpret_cast<char const*>(s->data_start + input_thread_string_offset);
+          reinterpret_cast<char const*>(s->stream.data_start + input_thread_string_offset);
         return string_index_pair{thread_input_string, string_length};
       }
     }();
@@ -292,7 +292,7 @@ __device__ size_t decode_strings(page_state_s* s,
         auto const stream_length       = s->setup.page.str_bytes / split_string_length;
 
         for (int ii = 0; ii < split_string_length; ii++) {
-          thread_output_string[ii] = s->data_start[src_pos + ii * stream_length];
+          thread_output_string[ii] = s->stream.data_start[src_pos + ii * stream_length];
         }
       }
     } else {


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR builds on #23471 to create a minimal struct for the `preprocess_levels` kernel. The primary addition in this PR is `page_decode_stream_state` struct encapsulating the level stream decoding components of `page_state_s`, which now has one of those structs as a member. `preprocess_levels` now uses a minimal `level_scan_state` struct, which only contains the two sub-structs required by that kernel. The net result is a savings of 560 bytes of shared memory in the kernel. Interestingly, on a couple of architectures (sm75 and sm86) we also saw a drop register usage by 8 (80->72 on sm75, 54->46 on sm86). That is hopefully indicative of the ancillary benefits of reducing shared memory usage as we will be able to incrementally reduce the complexity of the kernels and make it easier for the compiler to produce better optimized code (in this case presumably with better register reuse by eliding intermediate shared memory accesses that made live range counting harder).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
