### PR TITLE
Reduce cudf-polars test output verbosity

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -75,7 +75,6 @@ python "${TIMEOUT_TOOL_PATH}" --enable-python 5400 \
        --dist=worksteal \
        --tb=native \
        --durations 10 --durations-min 10 \
-       -ra \
        $DESELECTED_TESTS_STR \
        "$@" \
        py-polars/tests \
@@ -97,7 +96,6 @@ python "${TIMEOUT_TOOL_PATH}" --enable-python 5400 \
        --dist=worksteal \
        --tb=native \
        --durations 10 --durations-min 10 \
-       -ra \
        $DESELECTED_TESTS_STR \
        "$@" \
        py-polars/tests \

--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -52,8 +52,7 @@ rapids-logger "pytest cudf-polars"
   --cov=cudf_polars \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-polars-coverage.xml" \
   --cov-report=term \
-  --durations=10 --durations-min=10 \
-  -ra
+  --durations=10 --durations-min=10
 
 rapids-logger "pytest cudf_streaming"
 timeout 30m ./ci/run_cudf_streaming_pytests.sh \


### PR DESCRIPTION
## Description

This removes the `-ra` flags from pytest, to just print the count of xfailed/skipped/etc. tests, rather than a reason for each. We added them earlier for debugging, but they're more just getting in the way now.
