### PR TITLE
Fix flaky cudf-polars Quent integration test

### DIFF
--- a/python/cudf_polars/tests/quent/test_quent_integration.py
+++ b/python/cudf_polars/tests/quent/test_quent_integration.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -26,6 +26,8 @@ pytest.importorskip("structlog")
 def engine_with_quent_context(
     request: pytest.FixtureRequest,
     quent_context: QuentContext,
+    ray_num_ranks: int,
+    ray_init_options: dict[str, Any],
 ) -> Iterator[StreamingEngine]:
     """
     A streaming engine configured with a quent context from the 'quent_context'
@@ -43,8 +45,14 @@ def engine_with_quent_context(
         pytest.importorskip("ray")
         import cudf_polars.engine.ray
 
+        # Always specify num_ranks: the default path sizes the engine from the
+        # GPUs Ray reports, which fails if this test shares an xdist worker
+        # with a test that already brought up the shared num_gpus=0 cluster.
         engine = cudf_polars.engine.ray.RayEngine(
-            executor_options={"quent_context": quent_context}
+            executor_options={"quent_context": quent_context},
+            engine_options={"allow_gpu_sharing": True},
+            ray_init_options=ray_init_options,
+            num_ranks=ray_num_ranks,
         )
     elif backend == "dask":
         pytest.importorskip("distributed")


### PR DESCRIPTION
## Description

On `main` and `release/26.08`, the following will error reliably:

```
pytest -p no:randomly -n0 \
	python/cudf_polars/tests/streaming/test_ray.py::test_yields_engine \
	python/cudf_polars/tests/quent/test_quent_integration.py
```

In CI, it will fail if a worker that previously happened to run one of the ray tests with 0 GPUs happened to worksteal the quent integration tests.

This fixes the issue by passing through `ray_init_options` and `ray_num_ranks` when creating the RayEngine for the quent tests, similar to the rest of the tests

Closes https://github.com/rapidsai/cudf/issues/23441

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
