### PR TITLE
Modify scalar factory APIs to honor the data_type scale

### DIFF
--- a/cpp/src/scalar/scalar_factories.cpp
+++ b/cpp/src/scalar/scalar_factories.cpp
@@ -15,6 +15,8 @@
 namespace cudf {
 namespace {
 struct scalar_construction_helper {
+  data_type type_;
+
   template <typename T,
             std::enable_if_t<is_fixed_width<T>() and not is_fixed_point<T>()>* = nullptr>
   std::unique_ptr<scalar> operator()(rmm::cuda_stream_view stream,
@@ -31,7 +33,8 @@ struct scalar_construction_helper {
   {
     using Type       = device_storage_type_t<T>;
     using ScalarType = scalar_type_t<T>;
-    return std::make_unique<ScalarType>(Type{}, numeric::scale_type{0}, false, stream, mr);
+    return std::make_unique<ScalarType>(
+      Type{}, numeric::scale_type{type_.scale()}, false, stream, mr);
   }
 
   template <typename T, typename... Args, std::enable_if_t<not is_fixed_width<T>()>* = nullptr>
@@ -49,7 +52,7 @@ std::unique_ptr<scalar> make_numeric_scalar(data_type type,
 {
   CUDF_EXPECTS(is_numeric(type), "Invalid, non-numeric type.");
 
-  return type_dispatcher(type, scalar_construction_helper{}, stream, mr);
+  return type_dispatcher(type, scalar_construction_helper{type}, stream, mr);
 }
 
 // Allocate storage for a single timestamp element
@@ -59,7 +62,7 @@ std::unique_ptr<scalar> make_timestamp_scalar(data_type type,
 {
   CUDF_EXPECTS(is_timestamp(type), "Invalid, non-timestamp type.");
 
-  return type_dispatcher(type, scalar_construction_helper{}, stream, mr);
+  return type_dispatcher(type, scalar_construction_helper{type}, stream, mr);
 }
 
 // Allocate storage for a single duration element
@@ -69,7 +72,7 @@ std::unique_ptr<scalar> make_duration_scalar(data_type type,
 {
   CUDF_EXPECTS(is_duration(type), "Invalid, non-duration type.");
 
-  return type_dispatcher(type, scalar_construction_helper{}, stream, mr);
+  return type_dispatcher(type, scalar_construction_helper{type}, stream, mr);
 }
 
 // Allocate storage for a single fixed width element
@@ -79,7 +82,7 @@ std::unique_ptr<scalar> make_fixed_width_scalar(data_type type,
 {
   CUDF_EXPECTS(is_fixed_width(type), "Invalid, non-fixed-width type.");
 
-  return type_dispatcher(type, scalar_construction_helper{}, stream, mr);
+  return type_dispatcher(type, scalar_construction_helper{type}, stream, mr);
 }
 
 std::unique_ptr<scalar> make_list_scalar(column_view elements,

--- a/cpp/tests/scalar/factories_test.cpp
+++ b/cpp/tests/scalar/factories_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,7 @@
 #include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/column/column_factories.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -136,6 +137,37 @@ TYPED_TEST(FixedPointScalarFactory, ValueProvided)
   EXPECT_EQ(fp_s->value(), rep_value);
   EXPECT_TRUE(fp_s->is_valid());
   EXPECT_TRUE(s->is_valid());
+}
+
+TYPED_TEST(FixedPointScalarFactory, MakeFixedWidthScalarPreservesScale)
+{
+  using decimalXX           = TypeParam;
+  auto const expected_dtype = cudf::data_type{cudf::type_to_id<decimalXX>(), -3};
+  auto const s              = cudf::make_fixed_width_scalar(expected_dtype);
+
+  EXPECT_EQ(s->type(), expected_dtype);
+  EXPECT_FALSE(s->is_valid());
+}
+
+TYPED_TEST(FixedPointScalarFactory, MakeDefaultConstructedScalarPreservesScale)
+{
+  using decimalXX           = TypeParam;
+  auto const expected_dtype = cudf::data_type{cudf::type_to_id<decimalXX>(), -3};
+  auto const s              = cudf::make_default_constructed_scalar(expected_dtype);
+
+  EXPECT_EQ(s->type(), expected_dtype);
+  EXPECT_FALSE(s->is_valid());
+}
+
+TYPED_TEST(FixedPointScalarFactory, MakeEmptyScalarLikePreservesScale)
+{
+  using decimalXX           = TypeParam;
+  auto const expected_dtype = cudf::data_type{cudf::type_to_id<decimalXX>(), -3};
+  auto const col            = cudf::make_empty_column(expected_dtype);
+  auto const s              = cudf::make_empty_scalar_like(col->view());
+
+  EXPECT_EQ(s->type(), expected_dtype);
+  EXPECT_FALSE(s->is_valid());
 }
 
 struct StructScalarFactory : public ScalarFactoryTest {};


### PR DESCRIPTION
## Description
Modifies the generic scalar factory functions `make_empty_scalar_like`, `make_default_constructed_scalar`, `make_numeric_scalar`, and `make_fixed_width_scalar` to preserve the `scale` of the input `data_type` when creating fixed-point scalars. The values are considered undefined by the `data_type` should include the correct scale.

No errors were found after modifying this behavior and a gtests were added to check the results.
Marked this as breaking since this is a behavior change in case callers were expecting a default 0 scale.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
