### PR TITLE
Fix fallback for unsupported fill strategy in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/select.py
+++ b/python/cudf_polars/cudf_polars/streaming/select.py
@@ -405,7 +405,7 @@ def _(
         [e.value for e in ir.exprs]
     ):
         return _lower_ir_fallback(
-            ir.reconstruct([child]),
+            ir,
             rec,
             msg=(
                 "fill_null with strategy other than 'zero' or 'one' is not supported "

--- a/python/cudf_polars/tests/streaming/test_select.py
+++ b/python/cudf_polars/tests/streaming/test_select.py
@@ -94,6 +94,22 @@ def test_select_fill_null_with_strategy(df, streaming_engine_factory):
         assert_gpu_result_equal(q, engine=engine)
 
 
+def test_select_scan_fill_null_with_strategy_fallback(tmp_path, spmd_engine_factory):
+    engine = spmd_engine_factory(
+        StreamingOptions(target_partition_size=1, fallback_mode="warn"),
+    )
+    path = tmp_path / "data.parquet"
+    pl.DataFrame({"a": [None, 1, None, 3]}).write_parquet(path)
+    q = pl.scan_parquet(path).select(pl.col("a").fill_null(strategy="forward"))
+
+    with warns_on_spmd(
+        engine,
+        UserWarning,
+        match="fill_null with strategy other than 'zero' or 'one' is not supported for multiple partitions",
+    ):
+        assert_gpu_result_equal(q, engine=engine)
+
+
 @pytest.mark.parametrize(
     "aggs",
     [


### PR DESCRIPTION
## Description

Fixes a streaming fallback bug where a `Scan`-backed `fill_null(strategy="forward")` expression may fail with:

```
AssertionError: Scan node must have a partition plan
```

Adds a regression test for the scan-backed fallback path.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
