### PR TITLE
Accept a device memory resource in the device-view factories

### DIFF
--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -11,10 +11,12 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/structs/struct_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/utility>
@@ -498,11 +500,14 @@ class alignas(16) column_device_view : public column_device_view_core {
    *
    * @param source_view The `column_view` to make usable in device code
    * @param stream CUDA stream used for device memory operations for children columns.
+   * @param mr Device memory resource used to allocate the returned child-view storage
    * @return A `unique_ptr` to a `column_device_view` that makes the data from
    *`source_view` available in device memory.
    */
   static std::unique_ptr<column_device_view, std::function<void(column_device_view*)>> create(
-    column_view source_view, rmm::cuda_stream_view stream = cudf::get_default_stream());
+    column_view source_view,
+    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
    * @brief Destroy the `column_device_view` object.
@@ -645,13 +650,15 @@ class alignas(16) mutable_column_device_view : public mutable_column_device_view
    *
    * @param source_view The `column_view` to make usable in device code
    * @param stream CUDA stream used for device memory operations for children columns.
+   * @param mr Device memory resource used to allocate the returned child-view storage
    * @return A `unique_ptr` to a `mutable_column_device_view` that makes the
    * data from `source_view` available in device memory.
    */
   static std::unique_ptr<mutable_column_device_view,
                          std::function<void(mutable_column_device_view*)>>
   create(mutable_column_view source_view,
-         rmm::cuda_stream_view stream = cudf::get_default_stream());
+         rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+         rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
    * @brief Returns reference to element at the specified index.

--- a/cpp/include/cudf/detail/row_operator/lexicographic.cuh
+++ b/cpp/include/cudf/detail/row_operator/lexicographic.cuh
@@ -677,8 +677,10 @@ struct less_equivalent_comparator
  *
  */
 struct preprocessed_table {
-  using table_device_view_owner =
-    std::invoke_result_t<decltype(table_device_view::create), table_view, rmm::cuda_stream_view>;
+  using table_device_view_owner = std::invoke_result_t<decltype(table_device_view::create),
+                                                       table_view,
+                                                       rmm::cuda_stream_view,
+                                                       rmm::device_async_resource_ref>;
 
   /**
    * @brief Preprocess table for use with lexicographical comparison

--- a/cpp/include/cudf/detail/row_operator/preprocessed_table.cuh
+++ b/cpp/include/cudf/detail/row_operator/preprocessed_table.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/include/cudf/detail/row_operator/preprocessed_table.cuh
+++ b/cpp/include/cudf/detail/row_operator/preprocessed_table.cuh
@@ -68,8 +68,10 @@ struct preprocessed_table {
   template <template <typename> class Hash>
   friend class ::cudf::detail::row::primitive::row_hasher;
 
-  using table_device_view_owner =
-    std::invoke_result_t<decltype(table_device_view::create), table_view, rmm::cuda_stream_view>;
+  using table_device_view_owner = std::invoke_result_t<decltype(table_device_view::create),
+                                                       table_view,
+                                                       rmm::cuda_stream_view,
+                                                       rmm::device_async_resource_ref>;
 
   preprocessed_table(table_device_view_owner&& table,
                      std::vector<rmm::device_buffer>&& null_buffers,

--- a/cpp/include/cudf/table/table_device_view.cuh
+++ b/cpp/include/cudf/table/table_device_view.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/cudf/table/table_device_view.cuh
+++ b/cpp/include/cudf/table/table_device_view.cuh
@@ -8,9 +8,11 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <cassert>
 #include <memory>
@@ -157,11 +159,14 @@ class table_device_view : public detail::table_device_view_base<column_device_vi
    *
    * @param source_view The table view whose contents will be copied to create a new table
    * @param stream CUDA stream used for device memory operations
+   * @param mr Device memory resource used to allocate the returned column-view storage
    * @return A `unique_ptr` to a `table_device_view` that makes the data from `source_view`
    * available in device memory
    */
   static std::unique_ptr<table_device_view, std::function<void(table_device_view*)>> create(
-    table_view source_view, rmm::cuda_stream_view stream = cudf::get_default_stream());
+    table_view source_view,
+    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
  private:
   table_device_view(table_view source_view, column_device_view* columns);
@@ -186,11 +191,14 @@ class mutable_table_device_view
    *
    * @param source_view The table view whose contents will be copied to create a new table
    * @param stream CUDA stream used for device memory operations
+   * @param mr Device memory resource used to allocate the returned column-view storage
    * @return A `unique_ptr` to a `mutable_table_device_view` that makes the data from `source_view`
    * available in device memory
    */
   static std::unique_ptr<mutable_table_device_view, std::function<void(mutable_table_device_view*)>>
-  create(mutable_table_view source_view, rmm::cuda_stream_view stream = cudf::get_default_stream());
+  create(mutable_table_view source_view,
+         rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+         rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
  private:
   mutable_table_device_view(mutable_table_view source_view, mutable_column_device_view* columns);
@@ -203,10 +211,13 @@ class mutable_table_device_view
  * @tparam HostTableView The type of the table_view to copy from
  * @param source_view The table_view to copy from
  * @param stream The stream to use for device memory allocation
+ * @param mr Device memory resource used to allocate the returned device buffer
  * @return tuple of device_buffer and @p ColumnDeviceView device pointer
  */
 template <typename ColumnDeviceView, typename HostTableView>
 std::pair<std::unique_ptr<rmm::device_buffer>, ColumnDeviceView*> create_column_device_views(
-  HostTableView source_view, rmm::cuda_stream_view stream);
+  HostTableView source_view,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/src/column/column_device_view.cu
+++ b/cpp/src/column/column_device_view.cu
@@ -53,7 +53,9 @@ namespace {
 // helper function for column_device_view::create and mutable_column_device::create methods
 template <typename ColumnView, typename ColumnDeviceView>
 std::unique_ptr<ColumnDeviceView, std::function<void(ColumnDeviceView*)>>
-create_device_view_from_view(ColumnView const& source, rmm::cuda_stream_view stream)
+create_device_view_from_view(ColumnView const& source,
+                             rmm::cuda_stream_view stream,
+                             rmm::device_async_resource_ref mr)
 {
   size_type num_children = source.num_children();
   // First calculate the size of memory needed to hold the child columns. This is done by calling
@@ -73,7 +75,8 @@ create_device_view_from_view(ColumnView const& source, rmm::cuda_stream_view str
   // Each ColumnDeviceView instance may have child objects that
   // require setting some internal device pointers before being copied
   // from CPU to device.
-  auto const descendant_storage = new rmm::device_uvector<char>(descendant_storage_bytes, stream);
+  auto const descendant_storage =
+    new rmm::device_uvector<char>(descendant_storage_bytes, stream, mr);
 
   auto deleter = [descendant_storage](ColumnDeviceView* v) {
     v->destroy();
@@ -108,7 +111,9 @@ column_device_view::column_device_view(column_view source, void* h_ptr, void* d_
 
 // Construct a unique_ptr that invokes `destroy()` as it's deleter
 std::unique_ptr<column_device_view, std::function<void(column_device_view*)>>
-column_device_view::create(column_view source, rmm::cuda_stream_view stream)
+column_device_view::create(column_view source,
+                           rmm::cuda_stream_view stream,
+                           rmm::device_async_resource_ref mr)
 {
   size_type num_children = source.num_children();
   if (num_children == 0) {
@@ -116,7 +121,7 @@ column_device_view::create(column_view source, rmm::cuda_stream_view stream)
     return std::unique_ptr<column_device_view>(new column_device_view(source));
   }
 
-  return create_device_view_from_view<column_view, column_device_view>(source, stream);
+  return create_device_view_from_view<column_view, column_device_view>(source, stream, mr);
 }
 
 std::size_t column_device_view::extent(column_view const& source)
@@ -160,12 +165,14 @@ void mutable_column_device_view::destroy() { delete this; }
 
 // Construct a unique_ptr that invokes `destroy()` as it's deleter
 std::unique_ptr<mutable_column_device_view, std::function<void(mutable_column_device_view*)>>
-mutable_column_device_view::create(mutable_column_view source, rmm::cuda_stream_view stream)
+mutable_column_device_view::create(mutable_column_view source,
+                                   rmm::cuda_stream_view stream,
+                                   rmm::device_async_resource_ref mr)
 {
   return source.num_children() == 0
            ? std::unique_ptr<mutable_column_device_view>(new mutable_column_device_view(source))
-           : create_device_view_from_view<mutable_column_view, mutable_column_device_view>(source,
-                                                                                           stream);
+           : create_device_view_from_view<mutable_column_view, mutable_column_device_view>(
+               source, stream, mr);
 }
 
 std::size_t mutable_column_device_view::extent(mutable_column_view source)

--- a/cpp/src/column/column_device_view.cu
+++ b/cpp/src/column/column_device_view.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf/column/column_device_view.cuh>

--- a/cpp/src/table/table_device_view.cu
+++ b/cpp/src/table/table_device_view.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/table/table_device_view.cu
+++ b/cpp/src/table/table_device_view.cu
@@ -42,7 +42,7 @@ template class table_device_view_base<mutable_column_device_view, mutable_table_
 
 template <typename ColumnDeviceView, typename HostTableView>
 std::pair<std::unique_ptr<rmm::device_buffer>, ColumnDeviceView*> create_column_device_views(
-  HostTableView source_view, rmm::cuda_stream_view stream)
+  HostTableView source_view, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
 {
   // First calculate the size of memory needed to hold the
   // table's ColumnDeviceViews. This is done by calling extent()
@@ -65,8 +65,9 @@ std::pair<std::unique_ptr<rmm::device_buffer>, ColumnDeviceView*> create_column_
   // ColumnDeviceViews so the column can set the pointer(s) for any
   // of its child objects.
   // align both h_ptr, d_ptr
-  auto descendant_storage = std::make_unique<rmm::device_buffer>(padded_views_size_bytes, stream);
-  void* h_ptr             = detail::align_ptr_for_type<ColumnDeviceView>(h_buffer.data());
+  auto descendant_storage =
+    std::make_unique<rmm::device_buffer>(padded_views_size_bytes, stream, mr);
+  void* h_ptr    = detail::align_ptr_for_type<ColumnDeviceView>(h_buffer.data());
   void* d_ptr    = detail::align_ptr_for_type<ColumnDeviceView>(descendant_storage->data());
   auto d_columns = detail::child_columns_to_device_array<ColumnDeviceView>(
     source_view.begin(), source_view.end(), h_ptr, d_ptr);
@@ -80,7 +81,9 @@ std::pair<std::unique_ptr<rmm::device_buffer>, ColumnDeviceView*> create_column_
 
 template std::pair<std::unique_ptr<rmm::device_buffer>, column_device_view*>
 create_column_device_views<column_device_view, host_span<column_view const>>(
-  host_span<column_view const> source_view, rmm::cuda_stream_view stream);
+  host_span<column_view const> source_view,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
 
 table_device_view::table_device_view(table_view source_view, column_device_view* columns)
   : detail::table_device_view_base<column_device_view, table_view>(source_view, columns)
@@ -88,10 +91,12 @@ table_device_view::table_device_view(table_view source_view, column_device_view*
 }
 
 std::unique_ptr<table_device_view, std::function<void(table_device_view*)>>
-table_device_view::create(table_view source_view, rmm::cuda_stream_view stream)
+table_device_view::create(table_view source_view,
+                          rmm::cuda_stream_view stream,
+                          rmm::device_async_resource_ref mr)
 {
   auto [descendant_storage, columns] =
-    create_column_device_views<column_device_view, table_view>(source_view, stream);
+    create_column_device_views<column_device_view, table_view>(source_view, stream, mr);
   auto deleter = [ds = descendant_storage.release()](table_device_view* tv) {
     tv->destroy();
     delete ds;
@@ -109,10 +114,13 @@ mutable_table_device_view::mutable_table_device_view(mutable_table_view source_v
 }
 
 std::unique_ptr<mutable_table_device_view, std::function<void(mutable_table_device_view*)>>
-mutable_table_device_view::create(mutable_table_view source_view, rmm::cuda_stream_view stream)
+mutable_table_device_view::create(mutable_table_view source_view,
+                                  rmm::cuda_stream_view stream,
+                                  rmm::device_async_resource_ref mr)
 {
   auto [descendant_storage, columns] =
-    create_column_device_views<mutable_column_device_view, mutable_table_view>(source_view, stream);
+    create_column_device_views<mutable_column_device_view, mutable_table_view>(
+      source_view, stream, mr);
   auto deleter = [ds = descendant_storage.release()](mutable_table_device_view* tv) {
     tv->destroy();
     delete ds;

--- a/cpp/src/text/bpe/byte_pair_encoding.cuh
+++ b/cpp/src/text/bpe/byte_pair_encoding.cuh
@@ -163,7 +163,8 @@ using mp_table_map_type = cuco::static_map<cudf::size_type,
 // std::unique_ptr<column_device_view> this helper simplifies the return type for us
 using col_device_view = std::invoke_result_t<decltype(&cudf::column_device_view::create),
                                              cudf::column_view,
-                                             rmm::cuda_stream_view>;
+                                             rmm::cuda_stream_view,
+                                             rmm::device_async_resource_ref>;
 
 struct bpe_merge_pairs::bpe_merge_pairs_impl {
   std::unique_ptr<cudf::column> const merge_pairs;

--- a/cpp/src/text/bpe/byte_pair_encoding.cuh
+++ b/cpp/src/text/bpe/byte_pair_encoding.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/text/vocabulary_tokenize.cu
+++ b/cpp/src/text/vocabulary_tokenize.cu
@@ -101,7 +101,8 @@ using vocabulary_map_type = cuco::static_map<cudf::size_type,
 // std::unique_ptr<column_device_view> this helper simplifies the return type in a maintainable way
 using col_device_view = std::invoke_result_t<decltype(&cudf::column_device_view::create),
                                              cudf::column_view,
-                                             rmm::cuda_stream_view>;
+                                             rmm::cuda_stream_view,
+                                             rmm::device_async_resource_ref>;
 
 struct tokenize_vocabulary::tokenize_vocabulary_impl {
   std::unique_ptr<cudf::column> const vocabulary;

--- a/cpp/src/text/wordpiece_tokenize.cu
+++ b/cpp/src/text/wordpiece_tokenize.cu
@@ -137,7 +137,8 @@ using sub_vocabulary_map_type = cuco::static_map<cudf::size_type,
 // std::unique_ptr<column_device_view> this helper simplifies the return type in a maintainable way
 using col_device_view = std::invoke_result_t<decltype(&cudf::column_device_view::create),
                                              cudf::column_view,
-                                             rmm::cuda_stream_view>;
+                                             rmm::cuda_stream_view,
+                                             rmm::device_async_resource_ref>;
 
 /**
  * @brief Internal class manages all the data held by the vocabulary object

--- a/cpp/tests/column/column_device_view_test.cu
+++ b/cpp/tests/column/column_device_view_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/column/column_device_view_test.cu
+++ b/cpp/tests/column/column_device_view_test.cu
@@ -7,6 +7,7 @@
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/memory_resource_utilities.hpp>
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_device_view.cuh>
@@ -55,4 +56,30 @@ TEST_F(ColumnDeviceViewTest, MismatchingType)
                             input_device_view->end<T>(),
                             output_device_view->begin<int64_t>()),
                cudf::logic_error);
+}
+
+TEST_F(ColumnDeviceViewTest, ExplicitMemoryResourceControl)
+{
+  auto harness = cudf::test::memory_resource_test_harness{this->mr()};
+  auto stream  = cudf::get_default_stream();
+  auto input   = cudf::test::strings_column_wrapper({"one", "two"}).release();
+
+  auto immutable_view = [&] {
+    auto current_scope = harness.fail_on_current_device_resource_use();
+    auto result = cudf::column_device_view::create(input->view(), stream, harness.output_mr());
+    harness.synchronize(stream);
+    return result;
+  }();
+  auto mutable_view = [&] {
+    auto current_scope = harness.fail_on_current_device_resource_use();
+    auto result =
+      cudf::mutable_column_device_view::create(input->mutable_view(), stream, harness.output_mr());
+    harness.synchronize(stream);
+    return result;
+  }();
+
+  harness.expect_output_allocations_live(stream);
+  immutable_view.reset();
+  mutable_view.reset();
+  harness.expect_no_live_allocations(stream);
 }

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/table/table_view_tests.cu
+++ b/cpp/tests/table/table_view_tests.cu
@@ -6,11 +6,13 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/memory_resource_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/row_operator/lexicographic.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/table/table.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -128,4 +130,32 @@ TEST_F(TableViewTest, SelectNoColumns)
 
   cudf::table_view selected = t.select({});
   EXPECT_EQ(selected.num_columns(), 0);
+}
+
+TEST_F(TableViewTest, ExplicitDeviceViewMemoryResourceControl)
+{
+  auto harness = cudf::test::memory_resource_test_harness{this->mr()};
+  auto stream  = cudf::get_default_stream();
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(cudf::test::strings_column_wrapper({"one", "two"}).release());
+  auto input = cudf::table{std::move(columns)};
+
+  auto immutable_view = [&] {
+    auto current_scope = harness.fail_on_current_device_resource_use();
+    auto result        = cudf::table_device_view::create(input.view(), stream, harness.output_mr());
+    harness.synchronize(stream);
+    return result;
+  }();
+  auto mutable_view = [&] {
+    auto current_scope = harness.fail_on_current_device_resource_use();
+    auto result =
+      cudf::mutable_table_device_view::create(input.mutable_view(), stream, harness.output_mr());
+    harness.synchronize(stream);
+    return result;
+  }();
+
+  harness.expect_output_allocations_live(stream);
+  immutable_view.reset();
+  mutable_view.reset();
+  harness.expect_no_live_allocations(stream);
 }


### PR DESCRIPTION
## Description

The `column_device_view`, `mutable_column_device_view`, `table_device_view`, and `mutable_table_device_view` factories allocate device storage for the descendant and column-view metadata of nested inputs, but offered no way for a caller to say where that storage should come from — it always came from whatever happened to be the current device resource. A caller that had otherwise routed its allocations to an explicit resource would still see these land somewhere else. Each factory now takes a defaulted `rmm::device_async_resource_ref`.

- Nested column descendant storage constructs its `device_uvector` from the supplied resource, and table column-view storage constructs its `device_buffer` from the supplied resource. Leaf columns still avoid allocation entirely, and the custom deleters retain the allocating objects so deallocation returns to the same resource.
- The parameter is defaulted, so existing one- and two-argument call sites are source compatible and keep their current behavior.
- The five `std::invoke_result_t` owner aliases in the row-operator and nvtext code are updated to model the new three-argument callable signature; the resulting owner types are unchanged.
- Adds immutable and mutable column and table tests that invoke each factory with an allocation-failing current resource, confirm the metadata is live on the explicit resource, and confirm every byte is released when the returned owners are reset.

Extracted from #23027 as a self-contained prerequisite for #20780. This change is independent of the `cudf::memory_resources` work and does not use that type.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
