### PR TITLE
[FEA] Remove Deprecated Transform APIs

### DIFF
--- a/cpp/benchmarks/binaryop/compiled_binaryop.cpp
+++ b/cpp/benchmarks/binaryop/compiled_binaryop.cpp
@@ -163,14 +163,14 @@ __device__ void transform(float* out, float a, float b) {
                                               outputs,
                                               {},
                                               std::nullopt)
-                        : cudf::multi_transform(cuda,
-                                                cudf::udf_source_type::CUDA,
-                                                cudf::null_aware::NO,
-                                                std::nullopt,
-                                                inputs,
-                                                outputs,
-                                                {},
-                                                std::nullopt);
+                        : cudf::transform(cuda,
+                                          cudf::udf_source_type::CUDA,
+                                          cudf::null_aware::NO,
+                                          std::nullopt,
+                                          inputs,
+                                          outputs,
+                                          {},
+                                          std::nullopt);
 
   // use number of bytes read and written to global memory
   state.add_global_memory_reads<TypeLhs>(num_rows);
@@ -186,14 +186,14 @@ __device__ void transform(float* out, float a, float b) {
                                                                  outputs,
                                                                  {},
                                                                  std::nullopt)
-                                           : cudf::multi_transform(cuda,
-                                                                   cudf::udf_source_type::CUDA,
-                                                                   cudf::null_aware::NO,
-                                                                   std::nullopt,
-                                                                   inputs,
-                                                                   outputs,
-                                                                   {},
-                                                                   std::nullopt);
+                                           : cudf::transform(cuda,
+                                                             cudf::udf_source_type::CUDA,
+                                                             cudf::null_aware::NO,
+                                                             std::nullopt,
+                                                             inputs,
+                                                             outputs,
+                                                             {},
+                                                             std::nullopt);
   });
 }
 

--- a/cpp/benchmarks/ndsh/q09.cpp
+++ b/cpp/benchmarks/ndsh/q09.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/benchmarks/ndsh/q09.cpp
+++ b/cpp/benchmarks/ndsh/q09.cpp
@@ -20,6 +20,9 @@
 
 #include <nvbench/nvbench.cuh>
 
+#include <array>
+#include <utility>
+
 enum class engine_type : int32_t { BINARYOP = 0, AST = 1, TRANSFORM = 2 };
 
 engine_type engine_from_string(std::string const& str)
@@ -150,16 +153,20 @@ struct q9_data {
 
   cudf::transform_input transform_inputs[] = {discount, extendedprice, supplycost, quantity};
 
-  return cudf::transform(transform_inputs,
-                         udf,
-                         cudf::data_type{cudf::type_id::FLOAT64},
-                         cudf::udf_source_type::CUDA,
-                         std::nullopt,
-                         cudf::null_aware::NO,
-                         std::nullopt,
-                         cudf::output_nullability::PRESERVE,
-                         stream,
-                         mr);
+  return std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    transform_inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT64},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt,
+                    stream,
+                    mr)
+      ->release()
+      .front());
 }
 
 [[nodiscard]] std::unique_ptr<cudf::column> compute_amount_ast(

--- a/cpp/benchmarks/ndsh/q09.cpp
+++ b/cpp/benchmarks/ndsh/q09.cpp
@@ -150,16 +150,16 @@ struct q9_data {
 
   cudf::transform_input transform_inputs[] = {discount, extendedprice, supplycost, quantity};
 
-  return cudf::transform_extended(transform_inputs,
-                                  udf,
-                                  cudf::data_type{cudf::type_id::FLOAT64},
-                                  cudf::udf_source_type::CUDA,
-                                  std::nullopt,
-                                  cudf::null_aware::NO,
-                                  std::nullopt,
-                                  cudf::output_nullability::PRESERVE,
-                                  stream,
-                                  mr);
+  return cudf::transform(transform_inputs,
+                         udf,
+                         cudf::data_type{cudf::type_id::FLOAT64},
+                         cudf::udf_source_type::CUDA,
+                         std::nullopt,
+                         cudf::null_aware::NO,
+                         std::nullopt,
+                         cudf::output_nullability::PRESERVE,
+                         stream,
+                         mr);
 }
 
 [[nodiscard]] std::unique_ptr<cudf::column> compute_amount_ast(

--- a/cpp/benchmarks/transform/polynomials.cpp
+++ b/cpp/benchmarks/transform/polynomials.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/benchmarks/transform/polynomials.cpp
+++ b/cpp/benchmarks/transform/polynomials.cpp
@@ -17,6 +17,7 @@
 #include <nvbench/nvbench.cuh>
 
 #include <algorithm>
+#include <array>
 #include <random>
 
 template <typename key_type>
@@ -82,14 +83,15 @@ static void BM_transform_polynomials(nvbench::state& state)
 
     // clang-format on
 
-    cudf::transform(inputs,
-                    udf,
-                    cudf::data_type{cudf::type_to_id<key_type>()},
+    cudf::transform(udf,
                     cudf::udf_source_type::CUDA,
-                    std::nullopt,
                     cudf::null_aware::NO,
                     std::nullopt,
-                    cudf::output_nullability::PRESERVE,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_to_id<key_type>()},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt,
                     launch.get_stream().get_stream());
   });
 

--- a/cpp/benchmarks/transform/polynomials.cpp
+++ b/cpp/benchmarks/transform/polynomials.cpp
@@ -82,15 +82,15 @@ static void BM_transform_polynomials(nvbench::state& state)
 
     // clang-format on
 
-    cudf::transform_extended(inputs,
-                             udf,
-                             cudf::data_type{cudf::type_to_id<key_type>()},
-                             cudf::udf_source_type::CUDA,
-                             std::nullopt,
-                             cudf::null_aware::NO,
-                             std::nullopt,
-                             cudf::output_nullability::PRESERVE,
-                             launch.get_stream().get_stream());
+    cudf::transform(inputs,
+                    udf,
+                    cudf::data_type{cudf::type_to_id<key_type>()},
+                    cudf::udf_source_type::CUDA,
+                    std::nullopt,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    cudf::output_nullability::PRESERVE,
+                    launch.get_stream().get_stream());
   });
 
   state.add_buffer_size(

--- a/cpp/benchmarks/transform/polynomials_concurrent.cpp
+++ b/cpp/benchmarks/transform/polynomials_concurrent.cpp
@@ -85,15 +85,15 @@ static void BM_transform_polynomials_concurrent(nvbench::state& state)
                         ";"
                         "}";
 
-      cudf::transform_extended(inputs,
-                               udf,
-                               cudf::data_type{cudf::type_to_id<key_type>()},
-                               cudf::udf_source_type::CUDA,
-                               std::nullopt,
-                               cudf::null_aware::NO,
-                               std::nullopt,
-                               cudf::output_nullability::PRESERVE,
-                               stream);
+      cudf::transform(inputs,
+                      udf,
+                      cudf::data_type{cudf::type_to_id<key_type>()},
+                      cudf::udf_source_type::CUDA,
+                      std::nullopt,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      cudf::output_nullability::PRESERVE,
+                      stream);
       nvtxRangePop();
     };
 

--- a/cpp/benchmarks/transform/polynomials_concurrent.cpp
+++ b/cpp/benchmarks/transform/polynomials_concurrent.cpp
@@ -18,6 +18,7 @@
 #include <nvbench/nvbench.cuh>
 
 #include <algorithm>
+#include <array>
 #include <random>
 
 template <typename key_type>
@@ -85,15 +86,17 @@ static void BM_transform_polynomials_concurrent(nvbench::state& state)
                         ";"
                         "}";
 
-      cudf::transform(inputs,
-                      udf,
-                      cudf::data_type{cudf::type_to_id<key_type>()},
-                      cudf::udf_source_type::CUDA,
-                      std::nullopt,
-                      cudf::null_aware::NO,
-                      std::nullopt,
-                      cudf::output_nullability::PRESERVE,
-                      stream);
+      cudf::transform(
+        udf,
+        cudf::udf_source_type::CUDA,
+        cudf::null_aware::NO,
+        std::nullopt,
+        inputs,
+        std::array{cudf::transform_output{cudf::data_type{cudf::type_to_id<key_type>()},
+                                          cudf::output_nullability::PRESERVE}},
+        {},
+        std::nullopt,
+        stream);
       nvtxRangePop();
     };
 

--- a/cpp/benchmarks/transform/transform.cpp
+++ b/cpp/benchmarks/transform/transform.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/benchmarks/transform/transform.cpp
+++ b/cpp/benchmarks/transform/transform.cpp
@@ -24,6 +24,7 @@
 #include <nvbench/types.cuh>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -92,14 +93,15 @@ static void BM_transform(nvbench::state& state)
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    cudf::transform(inputs,
-                    code,
-                    cudf::data_type{cudf::type_to_id<key_type>()},
+    cudf::transform(code,
                     cudf::udf_source_type::CUDA,
-                    std::nullopt,
                     cudf::null_aware::NO,
                     std::nullopt,
-                    cudf::output_nullability::PRESERVE,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_to_id<key_type>()},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt,
                     launch.get_stream().get_stream());
   });
 

--- a/cpp/benchmarks/transform/transform.cpp
+++ b/cpp/benchmarks/transform/transform.cpp
@@ -92,15 +92,15 @@ static void BM_transform(nvbench::state& state)
   auto const mem_stats_logger = cudf::memory_stats_logger();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    cudf::transform_extended(inputs,
-                             code,
-                             cudf::data_type{cudf::type_to_id<key_type>()},
-                             cudf::udf_source_type::CUDA,
-                             std::nullopt,
-                             cudf::null_aware::NO,
-                             std::nullopt,
-                             cudf::output_nullability::PRESERVE,
-                             launch.get_stream().get_stream());
+    cudf::transform(inputs,
+                    code,
+                    cudf::data_type{cudf::type_to_id<key_type>()},
+                    cudf::udf_source_type::CUDA,
+                    std::nullopt,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    cudf::output_nullability::PRESERVE,
+                    launch.get_stream().get_stream());
   });
 
   state.add_buffer_size(

--- a/cpp/examples/string_transforms/compute_checksum_jit.cpp
+++ b/cpp/examples/string_transforms/compute_checksum_jit.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/examples/string_transforms/compute_checksum_jit.cpp
+++ b/cpp/examples/string_transforms/compute_checksum_jit.cpp
@@ -10,6 +10,9 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <array>
+#include <utility>
+
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
@@ -39,16 +42,20 @@ std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   auto email                     = table.column(1);
   cudf::transform_input inputs[] = {name, email};
 
-  auto result = cudf::transform(inputs,
-                                udf,
-                                cudf::data_type{cudf::type_id::UINT16},
-                                cudf::udf_source_type::CUDA,
-                                std::nullopt,
-                                cudf::null_aware::NO,
-                                std::nullopt,
-                                cudf::output_nullability::PRESERVE,
-                                stream,
-                                mr);
+  auto result = std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_id::UINT16},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt,
+                    stream,
+                    mr)
+      ->release()
+      .front());
 
   return std::make_tuple(std::move(result), transformed);
 }

--- a/cpp/examples/string_transforms/compute_checksum_jit.cpp
+++ b/cpp/examples/string_transforms/compute_checksum_jit.cpp
@@ -39,16 +39,16 @@ std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   auto email                     = table.column(1);
   cudf::transform_input inputs[] = {name, email};
 
-  auto result = cudf::transform_extended(inputs,
-                                         udf,
-                                         cudf::data_type{cudf::type_id::UINT16},
-                                         cudf::udf_source_type::CUDA,
-                                         std::nullopt,
-                                         cudf::null_aware::NO,
-                                         std::nullopt,
-                                         cudf::output_nullability::PRESERVE,
-                                         stream,
-                                         mr);
+  auto result = cudf::transform(inputs,
+                                udf,
+                                cudf::data_type{cudf::type_id::UINT16},
+                                cudf::udf_source_type::CUDA,
+                                std::nullopt,
+                                cudf::null_aware::NO,
+                                std::nullopt,
+                                cudf::output_nullability::PRESERVE,
+                                stream,
+                                mr);
 
   return std::make_tuple(std::move(result), transformed);
 }

--- a/cpp/examples/string_transforms/extract_email_jit.cpp
+++ b/cpp/examples/string_transforms/extract_email_jit.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/examples/string_transforms/extract_email_jit.cpp
+++ b/cpp/examples/string_transforms/extract_email_jit.cpp
@@ -10,6 +10,9 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <array>
+#include <utility>
+
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
@@ -53,16 +56,20 @@ __device__ void email_provider(cudf::string_view* out,
   auto emails                    = table.column(1);
   cudf::transform_input inputs[] = {emails, cudf::scalar_column_view(*alt)};
 
-  auto providers = cudf::transform(inputs,
-                                   udf,
-                                   cudf::data_type{cudf::type_id::STRING},
-                                   cudf::udf_source_type::CUDA,
-                                   std::nullopt,
-                                   cudf::null_aware::NO,
-                                   std::nullopt,
-                                   cudf::output_nullability::PRESERVE,
-                                   stream,
-                                   mr);
+  auto providers = std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_id::STRING},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt,
+                    stream,
+                    mr)
+      ->release()
+      .front());
 
   return {std::move(providers), std::move(transformed)};
 }

--- a/cpp/examples/string_transforms/extract_email_jit.cpp
+++ b/cpp/examples/string_transforms/extract_email_jit.cpp
@@ -53,16 +53,16 @@ __device__ void email_provider(cudf::string_view* out,
   auto emails                    = table.column(1);
   cudf::transform_input inputs[] = {emails, cudf::scalar_column_view(*alt)};
 
-  auto providers = cudf::transform_extended(inputs,
-                                            udf,
-                                            cudf::data_type{cudf::type_id::STRING},
-                                            cudf::udf_source_type::CUDA,
-                                            std::nullopt,
-                                            cudf::null_aware::NO,
-                                            std::nullopt,
-                                            cudf::output_nullability::PRESERVE,
-                                            stream,
-                                            mr);
+  auto providers = cudf::transform(inputs,
+                                   udf,
+                                   cudf::data_type{cudf::type_id::STRING},
+                                   cudf::udf_source_type::CUDA,
+                                   std::nullopt,
+                                   cudf::null_aware::NO,
+                                   std::nullopt,
+                                   cudf::output_nullability::PRESERVE,
+                                   stream,
+                                   mr);
 
   return {std::move(providers), std::move(transformed)};
 }

--- a/cpp/examples/string_transforms/format_phone_jit.cpp
+++ b/cpp/examples/string_transforms/format_phone_jit.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/examples/string_transforms/format_phone_jit.cpp
+++ b/cpp/examples/string_transforms/format_phone_jit.cpp
@@ -11,6 +11,9 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <array>
+#include <utility>
+
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
@@ -120,16 +123,20 @@ __device__ void e164_format(void* scratch,
                                     cudf::scalar_column_view(*min_visible_age),
                                     cudf::scalar_column_view(*size)};
 
-  auto formatted = cudf::transform(inputs,
-                                   udf,
-                                   cudf::data_type{cudf::type_id::STRING},
-                                   cudf::udf_source_type::CUDA,
-                                   scratch.data(),
-                                   cudf::null_aware::NO,
-                                   std::nullopt,
-                                   cudf::output_nullability::PRESERVE,
-                                   stream,
-                                   mr);
+  auto formatted = std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    scratch.data(),
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_id::STRING},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt,
+                    stream,
+                    mr)
+      ->release()
+      .front());
 
   return std::make_tuple(std::move(formatted), transformed);
 }

--- a/cpp/examples/string_transforms/format_phone_jit.cpp
+++ b/cpp/examples/string_transforms/format_phone_jit.cpp
@@ -120,16 +120,16 @@ __device__ void e164_format(void* scratch,
                                     cudf::scalar_column_view(*min_visible_age),
                                     cudf::scalar_column_view(*size)};
 
-  auto formatted = cudf::transform_extended(inputs,
-                                            udf,
-                                            cudf::data_type{cudf::type_id::STRING},
-                                            cudf::udf_source_type::CUDA,
-                                            scratch.data(),
-                                            cudf::null_aware::NO,
-                                            std::nullopt,
-                                            cudf::output_nullability::PRESERVE,
-                                            stream,
-                                            mr);
+  auto formatted = cudf::transform(inputs,
+                                   udf,
+                                   cudf::data_type{cudf::type_id::STRING},
+                                   cudf::udf_source_type::CUDA,
+                                   scratch.data(),
+                                   cudf::null_aware::NO,
+                                   std::nullopt,
+                                   cudf::output_nullability::PRESERVE,
+                                   stream,
+                                   mr);
 
   return std::make_tuple(std::move(formatted), transformed);
 }

--- a/cpp/examples/string_transforms/localize_phone_jit.cpp
+++ b/cpp/examples/string_transforms/localize_phone_jit.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/examples/string_transforms/localize_phone_jit.cpp
+++ b/cpp/examples/string_transforms/localize_phone_jit.cpp
@@ -12,6 +12,9 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <array>
+#include <utility>
+
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table)
 {
@@ -141,16 +144,20 @@ __device__ void format_phone(void* scratch,
   cudf::transform_input inputs[] = {
     country_code, area_code, phone_number, cudf::scalar_column_view(*size)};
 
-  auto result = cudf::transform(inputs,
-                                udf,
-                                cudf::data_type{cudf::type_id::STRING},
-                                cudf::udf_source_type::CUDA,
-                                scratch.data(),
-                                cudf::null_aware::NO,
-                                std::nullopt,
-                                cudf::output_nullability::PRESERVE,
-                                stream,
-                                mr);
+  auto result = std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    scratch.data(),
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_id::STRING},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt,
+                    stream,
+                    mr)
+      ->release()
+      .front());
 
   return {std::move(result), std::move(transformed)};
 }

--- a/cpp/examples/string_transforms/localize_phone_jit.cpp
+++ b/cpp/examples/string_transforms/localize_phone_jit.cpp
@@ -141,16 +141,16 @@ __device__ void format_phone(void* scratch,
   cudf::transform_input inputs[] = {
     country_code, area_code, phone_number, cudf::scalar_column_view(*size)};
 
-  auto result = cudf::transform_extended(inputs,
-                                         udf,
-                                         cudf::data_type{cudf::type_id::STRING},
-                                         cudf::udf_source_type::CUDA,
-                                         scratch.data(),
-                                         cudf::null_aware::NO,
-                                         std::nullopt,
-                                         cudf::output_nullability::PRESERVE,
-                                         stream,
-                                         mr);
+  auto result = cudf::transform(inputs,
+                                udf,
+                                cudf::data_type{cudf::type_id::STRING},
+                                cudf::udf_source_type::CUDA,
+                                scratch.data(),
+                                cudf::null_aware::NO,
+                                std::nullopt,
+                                cudf::output_nullability::PRESERVE,
+                                stream,
+                                mr);
 
   return {std::move(result), std::move(transformed)};
 }

--- a/cpp/include/cudf/transform.hpp
+++ b/cpp/include/cudf/transform.hpp
@@ -29,48 +29,6 @@ namespace CUDF_EXPORT cudf {
  */
 
 /**
- * @brief Creates a new column by applying a transform function against every
- * element of the input columns.
- *
- * Computes:
- * `out[i] = F(inputs[i]...)`.
- *
- * Note that for every scalar in `inputs` (columns of size 1), `input[i] == input[0]`
- *
- *
- * @throws std::invalid_argument if any of the input columns have different sizes (except scalars of
- * size 1)
- * @throws std::invalid_argument if `output_type` or any of the inputs are not fixed-width or string
- * types
- * @throws std::invalid_argument if any of the input columns have nulls
- * @throws std::logic_error if JIT is not supported by the runtime
- *
- * The size of the resulting column is the size of the largest column.
- *
- * @param inputs        Immutable views of the input columns to transform
- * @param transform_udf The PTX/CUDA string of the transform function to apply
- * @param output_type   The output type that is compatible with the output type in the UDF
- * @param is_ptx        true: the UDF is treated as PTX code; false: the UDF is treated as CUDA code
- * @param user_data     User-defined device data to pass to the UDF.
- * @param is_null_aware Signifies the UDF will receive row inputs as optional values
- * @param null_policy   Signifies if a null mask should be created for the output column
- * @param stream        CUDA stream used for device memory operations and kernel launches
- * @param mr            Device memory resource used to allocate the returned column's device memory
- * @return              The column resulting from applying the transform function to
- *                      every element of the input
- */
-[[deprecated("Use transform_extended instead")]] std::unique_ptr<column> transform(
-  std::vector<column_view> const& inputs,
-  std::string const& transform_udf,
-  data_type output_type,
-  bool is_ptx,
-  std::optional<void*> user_data    = std::nullopt,
-  null_aware is_null_aware          = null_aware::NO,
-  output_nullability null_policy    = output_nullability::PRESERVE,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
-
-/**
  * @brief Typedef for inputs to the transform function. Each input can be either a column or a
  * scalar column.
  */
@@ -124,7 +82,37 @@ struct transform_output {
  * @return              The column resulting from applying the transform function to
  *                      every element of the input
  */
-std::unique_ptr<column> transform_extended(
+std::unique_ptr<column> transform(
+  std::span<transform_input const> inputs,
+  std::string const& udf,
+  data_type output_type,
+  udf_source_type source_type,
+  std::optional<void*> user_data    = std::nullopt,
+  null_aware is_null_aware          = null_aware::NO,
+  std::optional<size_type> row_size = std::nullopt,
+  output_nullability null_policy    = output_nullability::PRESERVE,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Creates a new column by applying a transform function against every element of the input
+ * columns.
+ *
+ * @deprecated in release 26.10. Use `transform` instead.
+ *
+ * @param inputs Immutable views of the inputs to transform
+ * @param udf The PTX/CUDA string of the transform function to apply
+ * @param output_type The output type that is compatible with the output type in the UDF
+ * @param source_type The source type of the UDF (CUDA or PTX)
+ * @param user_data User-defined device data to pass to the UDF
+ * @param is_null_aware Signifies the UDF will receive row inputs as optional values
+ * @param row_size The row size of the transform operation
+ * @param null_policy Signifies if a null mask should be created for the output column
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return The column resulting from applying the transform function
+ */
+[[deprecated("Use transform instead")]] std::unique_ptr<column> transform_extended(
   std::span<transform_input const> inputs,
   std::string const& udf,
   data_type output_type,
@@ -142,7 +130,6 @@ std::unique_ptr<column> transform_extended(
  *
  * Computes:
  * `(outputs[i]...) =  UDF(inputs[i]...)`.
- *
  *
  * @throws std::invalid_argument if any of the input columns have different sizes (except scalars)
  * @throws std::invalid_argument if `output_type` or any of the inputs are not fixed-width or string
@@ -178,7 +165,37 @@ std::unique_ptr<column> transform_extended(
  * function to every element of the input according to the output specifications
  *
  */
-std::unique_ptr<table> multi_transform(
+std::unique_ptr<table> transform(
+  std::string const& udf,
+  udf_source_type source_type,
+  null_aware is_null_aware,
+  std::optional<void*> user_data,
+  std::span<transform_input const> inputs,
+  std::span<transform_output const> outputs,
+  std::vector<std::unique_ptr<column>>&& string_offsets,
+  std::optional<size_type> row_size,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Creates a new table by applying a transform function against every element of the input
+ * columns.
+ *
+ * @deprecated in release 26.10. Use `transform` instead.
+ *
+ * @param udf The PTX/CUDA string of the transform function to apply
+ * @param source_type The source type of the UDF (CUDA or PTX)
+ * @param is_null_aware Signifies the UDF will receive row inputs as optional values
+ * @param user_data User-defined device data to pass to the UDF
+ * @param inputs Immutable views of the inputs to transform (columns and scalar columns)
+ * @param outputs Specification of the output columns to be created
+ * @param string_offsets Pre-allocated offsets for string output columns
+ * @param row_size The row size of the transform operation
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return A table containing the transformed output columns
+ */
+[[deprecated("Use transform instead")]] std::unique_ptr<table> multi_transform(
   std::string const& udf,
   udf_source_type source_type,
   null_aware is_null_aware,

--- a/cpp/include/cudf/transform.hpp
+++ b/cpp/include/cudf/transform.hpp
@@ -48,53 +48,6 @@ struct transform_output {
 };
 
 /**
- * @brief Creates a new column by applying a transform function against every
- * element of the input columns.
- *
- * Computes:
- * `out[i] = F(inputs[i]...)`.
- *
- *
- * @throws std::invalid_argument if any of the input columns have different sizes (except scalars)
- * @throws std::invalid_argument if any of the output or input types are not supported.
- * CUDA-supported input types are fixed-width, string, and their dictionary types. PTX-supported
- * input types are integrals, floats, and their dictionary types. CUDA-supported output types are
- * fixed-width, string, and their dictionary types. PTX-supported output types are integrals,
- * floats, and their dictionary types.
- * @throws std::invalid_argument if the inputs only have a scalar with no column inputs and
- * `row_size` is not provided. This is because the row size cannot be inferred from the inputs in
- * this case.
- *
- * The size of the resulting column is the `row_size` if provided, otherwise it is inferred from
- * the input columns.
- *
- * @param inputs        Immutable views of the inputs to transform (columns and scalar columns)
- * @param udf The PTX/CUDA string of the transform function to apply
- * @param output_type   The output type that is compatible with the output type in the UDF
- * @param source_type   The source type of the UDF (CUDA or PTX)
- * @param user_data     User-defined device data to pass to the UDF.
- * @param is_null_aware Signifies the UDF will receive row inputs as optional values
- * @param null_policy   Signifies if a null mask should be created for the output column
- * @param row_size The row size of the transform operation. If not provided, it is inferred from the
- * input columns.
- * @param stream        CUDA stream used for device memory operations and kernel launches
- * @param mr            Device memory resource used to allocate the returned column's device memory
- * @return              The column resulting from applying the transform function to
- *                      every element of the input
- */
-std::unique_ptr<column> transform(
-  std::span<transform_input const> inputs,
-  std::string const& udf,
-  data_type output_type,
-  udf_source_type source_type,
-  std::optional<void*> user_data    = std::nullopt,
-  null_aware is_null_aware          = null_aware::NO,
-  std::optional<size_type> row_size = std::nullopt,
-  output_nullability null_policy    = output_nullability::PRESERVE,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
-
-/**
  * @brief Creates a new column by applying a transform function against every element of the input
  * columns.
  *

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q01.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q01.cpp
@@ -36,10 +36,12 @@
 #include <rapidsmpf/streaming/core/context.hpp>
 #include <rapidsmpf/utils/misc.hpp>
 
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <optional>
+#include <utility>
 
 namespace {
 
@@ -189,27 +191,35 @@ static __device__ void calculate_charge(double *charge, double discprice, double
            )***";
 
     // disc_price
-    result.push_back(cudf::transform(std::vector<cudf::transform_input>{extendedprice, discount},
-                                     udf_disc_price,
-                                     cudf::data_type(cudf::type_id::FLOAT64),
-                                     cudf::udf_source_type::CUDA,
-                                     std::nullopt,
-                                     cudf::null_aware::NO,
-                                     std::nullopt,
-                                     cudf::output_nullability::PRESERVE,
-                                     chunk_stream,
-                                     ctx->br()->device_mr()));
+    result.push_back(std::move(
+      cudf::transform(udf_disc_price,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      std::vector<cudf::transform_input>{extendedprice, discount},
+                      std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT64),
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt,
+                      chunk_stream,
+                      ctx->br()->device_mr())
+        ->release()
+        .front()));
     // charge
-    result.push_back(cudf::transform(std::vector<cudf::transform_input>{result.back()->view(), tax},
-                                     udf_charge,
-                                     cudf::data_type(cudf::type_id::FLOAT64),
-                                     cudf::udf_source_type::CUDA,
-                                     std::nullopt,
-                                     cudf::null_aware::NO,
-                                     std::nullopt,
-                                     cudf::output_nullability::PRESERVE,
-                                     chunk_stream,
-                                     ctx->br()->device_mr()));
+    result.push_back(std::move(
+      cudf::transform(udf_charge,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      std::vector<cudf::transform_input>{result.back()->view(), tax},
+                      std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT64),
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt,
+                      chunk_stream,
+                      ctx->br()->device_mr())
+        ->release()
+        .front()));
     // l_discount
     result.push_back(
       std::make_unique<cudf::column>(discount, chunk_stream, ctx->br()->device_mr()));

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q01.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q01.cpp
@@ -189,29 +189,27 @@ static __device__ void calculate_charge(double *charge, double discprice, double
            )***";
 
     // disc_price
-    result.push_back(
-      cudf::transform_extended(std::vector<cudf::transform_input>{extendedprice, discount},
-                               udf_disc_price,
-                               cudf::data_type(cudf::type_id::FLOAT64),
-                               cudf::udf_source_type::CUDA,
-                               std::nullopt,
-                               cudf::null_aware::NO,
-                               std::nullopt,
-                               cudf::output_nullability::PRESERVE,
-                               chunk_stream,
-                               ctx->br()->device_mr()));
+    result.push_back(cudf::transform(std::vector<cudf::transform_input>{extendedprice, discount},
+                                     udf_disc_price,
+                                     cudf::data_type(cudf::type_id::FLOAT64),
+                                     cudf::udf_source_type::CUDA,
+                                     std::nullopt,
+                                     cudf::null_aware::NO,
+                                     std::nullopt,
+                                     cudf::output_nullability::PRESERVE,
+                                     chunk_stream,
+                                     ctx->br()->device_mr()));
     // charge
-    result.push_back(
-      cudf::transform_extended(std::vector<cudf::transform_input>{result.back()->view(), tax},
-                               udf_charge,
-                               cudf::data_type(cudf::type_id::FLOAT64),
-                               cudf::udf_source_type::CUDA,
-                               std::nullopt,
-                               cudf::null_aware::NO,
-                               std::nullopt,
-                               cudf::output_nullability::PRESERVE,
-                               chunk_stream,
-                               ctx->br()->device_mr()));
+    result.push_back(cudf::transform(std::vector<cudf::transform_input>{result.back()->view(), tax},
+                                     udf_charge,
+                                     cudf::data_type(cudf::type_id::FLOAT64),
+                                     cudf::udf_source_type::CUDA,
+                                     std::nullopt,
+                                     cudf::null_aware::NO,
+                                     std::nullopt,
+                                     cudf::output_nullability::PRESERVE,
+                                     chunk_stream,
+                                     ctx->br()->device_mr()));
     // l_discount
     result.push_back(
       std::make_unique<cudf::column>(discount, chunk_stream, ctx->br()->device_mr()));

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q03.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q03.cpp
@@ -47,10 +47,12 @@
 #include <rapidsmpf/utils/misc.hpp>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <optional>
+#include <utility>
 
 namespace {
 
@@ -196,16 +198,20 @@ static __device__ void calculate_revenue(double *revenue, double extprice, doubl
            )***";
 
     // revenue
-    result.push_back(cudf::transform(std::vector<cudf::transform_input>{extendedprice, discount},
-                                     udf,
-                                     cudf::data_type(cudf::type_id::FLOAT64),
-                                     cudf::udf_source_type::CUDA,
-                                     std::nullopt,
-                                     cudf::null_aware::NO,
-                                     std::nullopt,
-                                     cudf::output_nullability::PRESERVE,
-                                     chunk_stream,
-                                     ctx->br()->device_mr()));
+    result.push_back(std::move(
+      cudf::transform(udf,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      std::vector<cudf::transform_input>{extendedprice, discount},
+                      std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT64),
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt,
+                      chunk_stream,
+                      ctx->br()->device_mr())
+        ->release()
+        .front()));
     co_await ch_out->send(cudf_streaming::to_message(
       sequence_number,
       std::make_unique<cudf_streaming::table_chunk>(

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q03.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q03.cpp
@@ -196,17 +196,16 @@ static __device__ void calculate_revenue(double *revenue, double extprice, doubl
            )***";
 
     // revenue
-    result.push_back(
-      cudf::transform_extended(std::vector<cudf::transform_input>{extendedprice, discount},
-                               udf,
-                               cudf::data_type(cudf::type_id::FLOAT64),
-                               cudf::udf_source_type::CUDA,
-                               std::nullopt,
-                               cudf::null_aware::NO,
-                               std::nullopt,
-                               cudf::output_nullability::PRESERVE,
-                               chunk_stream,
-                               ctx->br()->device_mr()));
+    result.push_back(cudf::transform(std::vector<cudf::transform_input>{extendedprice, discount},
+                                     udf,
+                                     cudf::data_type(cudf::type_id::FLOAT64),
+                                     cudf::udf_source_type::CUDA,
+                                     std::nullopt,
+                                     cudf::null_aware::NO,
+                                     std::nullopt,
+                                     cudf::output_nullability::PRESERVE,
+                                     chunk_stream,
+                                     ctx->br()->device_mr()));
     co_await ch_out->send(cudf_streaming::to_message(
       sequence_number,
       std::make_unique<cudf_streaming::table_chunk>(

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q09.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q09.cpp
@@ -39,10 +39,12 @@
 #include <rapidsmpf/streaming/core/channel.hpp>
 #include <rapidsmpf/streaming/core/context.hpp>
 
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <optional>
+#include <utility>
 
 using rapidsmpf::safe_cast;
 
@@ -210,17 +212,21 @@ static __device__ void calculate_amount(double *amount, double discount, double 
     *amount = extprice * (1 - discount) - supplycost * quantity;
 }
            )***";
-    result.push_back(cudf::transform(
-      std::vector<cudf::transform_input>{discount, extendedprice, supplycost, quantity},
-      udf,
-      cudf::data_type(cudf::type_id::FLOAT64),
-      cudf::udf_source_type::CUDA,
-      std::nullopt,
-      cudf::null_aware::NO,
-      std::nullopt,
-      cudf::output_nullability::PRESERVE,
-      chunk_stream,
-      ctx->br()->device_mr()));
+    result.push_back(
+      std::move(cudf::transform(
+                  udf,
+                  cudf::udf_source_type::CUDA,
+                  cudf::null_aware::NO,
+                  std::nullopt,
+                  std::vector<cudf::transform_input>{discount, extendedprice, supplycost, quantity},
+                  std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT64),
+                                                    cudf::output_nullability::PRESERVE}},
+                  {},
+                  std::nullopt,
+                  chunk_stream,
+                  ctx->br()->device_mr())
+                  ->release()
+                  .front()));
     co_await ch_out->send(cudf_streaming::to_message(
       sequence_number,
       std::make_unique<cudf_streaming::table_chunk>(

--- a/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q09.cpp
+++ b/cpp/libcudf_streaming/benchmarks/streaming/ndsh/q09.cpp
@@ -210,7 +210,7 @@ static __device__ void calculate_amount(double *amount, double discount, double 
     *amount = extprice * (1 - discount) - supplycost * quantity;
 }
            )***";
-    result.push_back(cudf::transform_extended(
+    result.push_back(cudf::transform(
       std::vector<cudf::transform_input>{discount, extendedprice, supplycost, quantity},
       udf,
       cudf::data_type(cudf::type_id::FLOAT64),

--- a/cpp/src/stream_compaction/filter/filter.cu
+++ b/cpp/src/stream_compaction/filter/filter.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/stream_compaction/filter/filter.cu
+++ b/cpp/src/stream_compaction/filter/filter.cu
@@ -54,16 +54,16 @@ std::unique_ptr<table> filter(std::string const& predicate_udf,
 
   transform_output outputs[] = {transform_output{data_type{type_id::BOOL8}, predicate_nullability}};
 
-  auto result = cudf::multi_transform(predicate_udf,
-                                      source_type,
-                                      is_null_aware,
-                                      user_data,
-                                      predicate_inputs,
-                                      outputs,
-                                      {},
-                                      filter_table.num_rows(),
-                                      stream,
-                                      mr);
+  auto result = cudf::transform(predicate_udf,
+                                source_type,
+                                is_null_aware,
+                                user_data,
+                                predicate_inputs,
+                                outputs,
+                                {},
+                                filter_table.num_rows(),
+                                stream,
+                                mr);
 
   return apply_mask(filter_table, result->get_column(0), mask_type::RETENTION, stream, mr);
 }

--- a/cpp/src/transform/transform.cu
+++ b/cpp/src/transform/transform.cu
@@ -1092,16 +1092,16 @@ std::unique_ptr<table> execute_transform(std::string const& udf,
 
 }  // namespace
 
-std::unique_ptr<table> multi_transform(std::string const& udf,
-                                       udf_source_type source_type,
-                                       null_aware is_null_aware,
-                                       std::optional<void*> user_data,
-                                       std::span<transform_input const> inputs,
-                                       std::span<transform_output const> outputs,
-                                       std::vector<std::unique_ptr<column>>&& string_offsets,
-                                       std::optional<size_type> row_size,
-                                       rmm::cuda_stream_view stream,
-                                       rmm::device_async_resource_ref mr)
+std::unique_ptr<table> transform(std::string const& udf,
+                                 udf_source_type source_type,
+                                 null_aware is_null_aware,
+                                 std::optional<void*> user_data,
+                                 std::span<transform_input const> inputs,
+                                 std::span<transform_output const> outputs,
+                                 std::vector<std::unique_ptr<column>>&& string_offsets,
+                                 std::optional<size_type> row_size,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
   perform_checks(source_type, is_null_aware, row_size, inputs, outputs, string_offsets);
@@ -1117,6 +1117,49 @@ std::unique_ptr<table> multi_transform(std::string const& udf,
                            mr);
 }
 
+std::unique_ptr<table> multi_transform(std::string const& udf,
+                                       udf_source_type source_type,
+                                       null_aware is_null_aware,
+                                       std::optional<void*> user_data,
+                                       std::span<transform_input const> inputs,
+                                       std::span<transform_output const> outputs,
+                                       std::vector<std::unique_ptr<column>>&& string_offsets,
+                                       std::optional<size_type> row_size,
+                                       rmm::cuda_stream_view stream,
+                                       rmm::device_async_resource_ref mr)
+{
+  return transform(udf,
+                   source_type,
+                   is_null_aware,
+                   user_data,
+                   inputs,
+                   outputs,
+                   std::move(string_offsets),
+                   row_size,
+                   stream,
+                   mr);
+}
+
+std::unique_ptr<column> transform(std::span<transform_input const> inputs,
+                                  std::string const& udf,
+                                  data_type output_type,
+                                  udf_source_type source_type,
+                                  std::optional<void*> user_data,
+                                  null_aware is_null_aware,
+                                  std::optional<size_type> row_size,
+                                  output_nullability null_policy,
+                                  rmm::cuda_stream_view stream,
+                                  rmm::device_async_resource_ref mr)
+{
+  transform_output outputs[] = {{.type = output_type, .nullability = null_policy}};
+
+  auto table = transform(
+    udf, source_type, is_null_aware, user_data, inputs, outputs, {}, row_size, stream, mr);
+
+  auto cols = table->release();
+  return std::move(cols[0]);
+}
+
 std::unique_ptr<column> transform_extended(std::span<transform_input const> inputs,
                                            std::string const& udf,
                                            data_type output_type,
@@ -1128,50 +1171,16 @@ std::unique_ptr<column> transform_extended(std::span<transform_input const> inpu
                                            rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr)
 {
-  transform_output outputs[] = {{.type = output_type, .nullability = null_policy}};
-
-  auto table = multi_transform(
-    udf, source_type, is_null_aware, user_data, inputs, outputs, {}, row_size, stream, mr);
-
-  auto cols = table->release();
-  return std::move(cols[0]);
-}
-
-std::unique_ptr<column> transform(std::vector<column_view> const& columns,
-                                  std::string const& transform_udf,
-                                  data_type output_type,
-                                  bool is_ptx,
-                                  std::optional<void*> user_data,
-                                  null_aware is_null_aware,
-                                  output_nullability null_policy,
-                                  rmm::cuda_stream_view stream,
-                                  rmm::device_async_resource_ref mr)
-{
-  // legacy behavior was to detect which column were scalars based on their sizes
-  std::vector<transform_input> inputs;
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  auto base_column = jit::get_transform_base_column(columns);
-  for (auto const& col : columns) {
-    if (jit::is_scalar(base_column->size(), col.size())) {
-#pragma GCC diagnostic pop
-      inputs.emplace_back(scalar_column_view{col});
-    } else {
-      inputs.emplace_back(col);
-    }
-  }
-
-  return transform_extended(inputs,
-                            transform_udf,
-                            output_type,
-                            is_ptx ? udf_source_type::PTX : udf_source_type::CUDA,
-                            user_data,
-                            is_null_aware,
-                            base_column->size(),
-                            null_policy,
-                            stream,
-                            mr);
+  return transform(inputs,
+                   udf,
+                   output_type,
+                   source_type,
+                   user_data,
+                   is_null_aware,
+                   row_size,
+                   null_policy,
+                   stream,
+                   mr);
 }
 
 std::unique_ptr<column> compute_column_jit(table_view const& table,
@@ -1181,16 +1190,16 @@ std::unique_ptr<column> compute_column_jit(table_view const& table,
 {
   auto args = detail::row_ir::ast_converter::compute_column(
     detail::row_ir::target::CUDA, expr, table, {}, "compute_operation", stream, mr);
-  auto result = multi_transform(args.udf,
-                                args.source_type,
-                                args.is_null_aware,
-                                args.user_data,
-                                args.inputs,
-                                args.outputs,
-                                std::move(args.string_offsets),
-                                args.row_size,
-                                stream,
-                                mr);
+  auto result = transform(args.udf,
+                          args.source_type,
+                          args.is_null_aware,
+                          args.user_data,
+                          args.inputs,
+                          args.outputs,
+                          std::move(args.string_offsets),
+                          args.row_size,
+                          stream,
+                          mr);
   auto cols   = result->release();
   return std::move(cols[0]);
 }

--- a/cpp/src/transform/transform.cu
+++ b/cpp/src/transform/transform.cu
@@ -1140,26 +1140,6 @@ std::unique_ptr<table> multi_transform(std::string const& udf,
                    mr);
 }
 
-std::unique_ptr<column> transform(std::span<transform_input const> inputs,
-                                  std::string const& udf,
-                                  data_type output_type,
-                                  udf_source_type source_type,
-                                  std::optional<void*> user_data,
-                                  null_aware is_null_aware,
-                                  std::optional<size_type> row_size,
-                                  output_nullability null_policy,
-                                  rmm::cuda_stream_view stream,
-                                  rmm::device_async_resource_ref mr)
-{
-  transform_output outputs[] = {{.type = output_type, .nullability = null_policy}};
-
-  auto table = transform(
-    udf, source_type, is_null_aware, user_data, inputs, outputs, {}, row_size, stream, mr);
-
-  auto cols = table->release();
-  return std::move(cols[0]);
-}
-
 std::unique_ptr<column> transform_extended(std::span<transform_input const> inputs,
                                            std::string const& udf,
                                            data_type output_type,
@@ -1171,16 +1151,12 @@ std::unique_ptr<column> transform_extended(std::span<transform_input const> inpu
                                            rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr)
 {
-  return transform(inputs,
-                   udf,
-                   output_type,
-                   source_type,
-                   user_data,
-                   is_null_aware,
-                   row_size,
-                   null_policy,
-                   stream,
-                   mr);
+  transform_output outputs[] = {{.type = output_type, .nullability = null_policy}};
+
+  auto result = transform(
+    udf, source_type, is_null_aware, user_data, inputs, outputs, {}, row_size, stream, mr);
+  auto columns = result->release();
+  return std::move(columns.front());
 }
 
 std::unique_ptr<column> compute_column_jit(table_view const& table,

--- a/cpp/tests/jit/row_ir.cpp
+++ b/cpp/tests/jit/row_ir.cpp
@@ -394,14 +394,14 @@ return cudf::errc::SUCCESS;
 
   EXPECT_EQ(transform_args.udf, expected_udf);
 
-  auto result = cudf::multi_transform(transform_args.udf,
-                                      transform_args.source_type,
-                                      transform_args.is_null_aware,
-                                      transform_args.user_data,
-                                      transform_args.inputs,
-                                      transform_args.outputs,
-                                      std::move(transform_args.string_offsets),
-                                      transform_args.row_size);
+  auto result = cudf::transform(transform_args.udf,
+                                transform_args.source_type,
+                                transform_args.is_null_aware,
+                                transform_args.user_data,
+                                transform_args.inputs,
+                                transform_args.outputs,
+                                std::move(transform_args.string_offsets),
+                                transform_args.row_size);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->get_column(0).view());
 }

--- a/cpp/tests/streams/transform_test.cpp
+++ b/cpp/tests/streams/transform_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/streams/transform_test.cpp
+++ b/cpp/tests/streams/transform_test.cpp
@@ -29,15 +29,15 @@ void test_udf(char const* udf,
 
   cudf::transform_input inputs[] = {in};
 
-  cudf::transform_extended(inputs,
-                           udf,
-                           cudf::data_type(cudf::type_to_id<dtype>()),
-                           source_type,
-                           std::nullopt,
-                           cudf::null_aware::NO,
-                           std::nullopt,
-                           cudf::output_nullability::PRESERVE,
-                           cudf::test::get_default_stream());
+  cudf::transform(inputs,
+                  udf,
+                  cudf::data_type(cudf::type_to_id<dtype>()),
+                  source_type,
+                  std::nullopt,
+                  cudf::null_aware::NO,
+                  std::nullopt,
+                  cudf::output_nullability::PRESERVE,
+                  cudf::test::get_default_stream());
 }
 
 TEST_F(TransformTest, Transform)

--- a/cpp/tests/streams/transform_test.cpp
+++ b/cpp/tests/streams/transform_test.cpp
@@ -14,6 +14,8 @@
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
 
+#include <array>
+
 class TransformTest : public cudf::test::BaseFixture {};
 
 template <class dtype, class Data>
@@ -29,14 +31,15 @@ void test_udf(char const* udf,
 
   cudf::transform_input inputs[] = {in};
 
-  cudf::transform(inputs,
-                  udf,
-                  cudf::data_type(cudf::type_to_id<dtype>()),
+  cudf::transform(udf,
                   source_type,
-                  std::nullopt,
                   cudf::null_aware::NO,
                   std::nullopt,
-                  cudf::output_nullability::PRESERVE,
+                  inputs,
+                  std::array{cudf::transform_output{cudf::data_type(cudf::type_to_id<dtype>()),
+                                                    cudf::output_nullability::PRESERVE}},
+                  {},
+                  std::nullopt,
                   cudf::test::get_default_stream());
 }
 

--- a/cpp/tests/transform/integration/unary_transform_test.cpp
+++ b/cpp/tests/transform/integration/unary_transform_test.cpp
@@ -65,29 +65,29 @@ TEST_F(AssertsTest, TypeSupport)
 {
   cudf::transform_input inputs[] = {a, b, cudf::scalar_column_view(t)};
 
-  EXPECT_NO_THROW(cudf::transform_extended(inputs,
-                                           udf,
-                                           cudf::data_type{cudf::type_id::FLOAT32},
-                                           cudf::udf_source_type::CUDA,
-                                           std::nullopt,
-                                           cudf::null_aware::NO));
+  EXPECT_NO_THROW(cudf::transform(inputs,
+                                  udf,
+                                  cudf::data_type{cudf::type_id::FLOAT32},
+                                  cudf::udf_source_type::CUDA,
+                                  std::nullopt,
+                                  cudf::null_aware::NO));
 
-  EXPECT_THROW(cudf::transform_extended(inputs,
-                                        udf,
-                                        cudf::data_type{cudf::type_id::STRUCT},
-                                        cudf::udf_source_type::CUDA,
-                                        std::nullopt,
-                                        cudf::null_aware::NO),
+  EXPECT_THROW(cudf::transform(inputs,
+                               udf,
+                               cudf::data_type{cudf::type_id::STRUCT},
+                               cudf::udf_source_type::CUDA,
+                               std::nullopt,
+                               cudf::null_aware::NO),
                std::invalid_argument);
 
   cudf::transform_input struct_inputs[] = {struct_col, cudf::scalar_column_view(t)};
 
-  EXPECT_THROW(cudf::transform_extended(struct_inputs,
-                                        udf,
-                                        cudf::data_type{cudf::type_id::FLOAT32},
-                                        cudf::udf_source_type::CUDA,
-                                        std::nullopt,
-                                        cudf::null_aware::NO),
+  EXPECT_THROW(cudf::transform(struct_inputs,
+                               udf,
+                               cudf::data_type{cudf::type_id::FLOAT32},
+                               cudf::udf_source_type::CUDA,
+                               std::nullopt,
+                               cudf::null_aware::NO),
                std::invalid_argument);
 }
 
@@ -95,24 +95,24 @@ TEST_F(AssertsTest, UnequalRowCount)
 {
   cudf::transform_input inputs[] = {a, b, bad_col};
 
-  EXPECT_THROW(cudf::transform_extended(inputs,
-                                        udf,
-                                        cudf::data_type{cudf::type_id::FLOAT32},
-                                        cudf::udf_source_type::CUDA,
-                                        std::nullopt,
-                                        cudf::null_aware::NO),
+  EXPECT_THROW(cudf::transform(inputs,
+                               udf,
+                               cudf::data_type{cudf::type_id::FLOAT32},
+                               cudf::udf_source_type::CUDA,
+                               std::nullopt,
+                               cudf::null_aware::NO),
                std::invalid_argument);
 }
 
 TEST_F(AssertsTest, NullSupport)
 {
   cudf::transform_input inputs[] = {a, b_nulls, cudf::scalar_column_view(t)};
-  EXPECT_NO_THROW(cudf::transform_extended(inputs,
-                                           udf,
-                                           cudf::data_type{cudf::type_id::FLOAT32},
-                                           cudf::udf_source_type::CUDA,
-                                           std::nullopt,
-                                           cudf::null_aware::NO));
+  EXPECT_NO_THROW(cudf::transform(inputs,
+                                  udf,
+                                  cudf::data_type{cudf::type_id::FLOAT32},
+                                  cudf::udf_source_type::CUDA,
+                                  std::nullopt,
+                                  cudf::null_aware::NO));
 }
 
 struct UnaryOperationIntegrationTest : public cudf::test::BaseFixture {};
@@ -132,7 +132,7 @@ void test_udf(std::string const& udf,
 
   cudf::transform_input inputs[] = {in};
   std::unique_ptr<cudf::column> out =
-    cudf::transform_extended(inputs, udf, cudf::data_type(cudf::type_to_id<dtype>()), source_type);
+    cudf::transform(inputs, udf, cudf::data_type(cudf::type_to_id<dtype>()), source_type);
 
   ASSERT_UNARY<dtype, dtype>(out->view(), in, op);
 }
@@ -433,7 +433,7 @@ __device__ inline void decode(cudf::string_view * output, cudf::string_view inpu
 
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform_extended(
+    auto out = cudf::transform(
       inputs, cuda, cudf::data_type{cudf::type_id::STRING}, cudf::udf_source_type::CUDA);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), a->view());
@@ -451,7 +451,7 @@ __device__ inline void decode(cudf::string_view * output, cudf::string_view inpu
 
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform_extended(
+    auto out = cudf::transform(
       inputs, cuda, cudf::data_type{cudf::type_id::STRING}, cudf::udf_source_type::CUDA);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), a->view());
@@ -537,12 +537,12 @@ __device__ inline void decode(float * output, float input){
     auto a_encoded                 = cudf::dictionary::encode(a->view());
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform_extended(
+    auto out = cudf::transform(
       inputs, cuda, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::CUDA);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), a->view());
 
-    auto out_ptx = cudf::transform_extended(
+    auto out_ptx = cudf::transform(
       inputs, ptx, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::PTX);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out_ptx->view(), a->view());
@@ -558,12 +558,12 @@ __device__ inline void decode(float * output, float input){
     auto a_encoded                 = cudf::dictionary::encode(a->view());
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform_extended(
+    auto out = cudf::transform(
       inputs, cuda, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::CUDA);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), a->view());
 
-    auto out_ptx = cudf::transform_extended(
+    auto out_ptx = cudf::transform(
       inputs, ptx, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::PTX);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out_ptx->view(), a->view());
@@ -575,7 +575,7 @@ __device__ inline void decode(float * output, float input){
     auto a_encoded                 = cudf::dictionary::encode(a_empty->view());
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform_extended(
+    auto out = cudf::transform(
       inputs, cuda, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::CUDA);
 
     EXPECT_EQ(out->size(), 0);
@@ -593,11 +593,11 @@ __device__ inline void decode(float * output, float input){
 
     cudf::transform_input inputs[] = {sliced_input};
 
-    auto out = cudf::transform_extended(
+    auto out = cudf::transform(
       inputs, cuda, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::CUDA);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), sliced_expect);
 
-    auto out_ptx = cudf::transform_extended(
+    auto out_ptx = cudf::transform(
       inputs, ptx, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::PTX);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out_ptx->view(), sliced_expect);
@@ -709,13 +709,13 @@ __device__ inline void transform(
   cudf::test::fixed_width_column_wrapper<T> expected(expected_host.begin(), expected_host.end());
 
   cudf::transform_input cuda_inputs[]       = {a, b, cudf::scalar_column_view(c)};
-  std::unique_ptr<cudf::column> cuda_result = cudf::transform_extended(
+  std::unique_ptr<cudf::column> cuda_result = cudf::transform(
     cuda_inputs, cuda, cudf::data_type(cudf::type_to_id<T>()), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, expected);
 
   cudf::transform_input ptx_inputs[]       = {a, b, cudf::scalar_column_view(c)};
-  std::unique_ptr<cudf::column> ptx_result = cudf::transform_extended(
+  std::unique_ptr<cudf::column> ptx_result = cudf::transform(
     ptx_inputs, ptx, cudf::data_type(cudf::type_to_id<T>()), cudf::udf_source_type::PTX);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*ptx_result, expected);
@@ -763,7 +763,7 @@ TYPED_TEST(TernaryDecimalOperationTest, TransformDecimalsAndScalar)
     expected_host.begin(), expected_host.end(), RES.scale());
 
   cudf::transform_input inputs[]            = {a, b, cudf::scalar_column_view(c)};
-  std::unique_ptr<cudf::column> cuda_result = cudf::transform_extended(
+  std::unique_ptr<cudf::column> cuda_result = cudf::transform(
     inputs, cuda, cudf::data_type(cudf::type_to_id<T>(), RES.scale()), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, expected);
@@ -785,7 +785,7 @@ TEST_F(StringOperationTest, StringComparison)
 
   auto expected = cudf::test::fixed_width_column_wrapper<bool>{true, true, false, false, true};
   cudf::transform_input inputs[] = {a, b, c};
-  auto result                    = cudf::transform_extended(
+  auto result                    = cudf::transform(
     inputs, cuda, cudf::data_type(cudf::type_id::BOOL8), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
@@ -805,7 +805,7 @@ TEST_F(StringOperationTest, StringContains)
   auto expected =
     cudf::test::fixed_width_column_wrapper<bool>{false, true, false, false, true, false};
   cudf::transform_input inputs[] = {a, b};
-  auto result                    = cudf::transform_extended(
+  auto result                    = cudf::transform(
     inputs, cuda, cudf::data_type(cudf::type_id::BOOL8), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
@@ -824,7 +824,7 @@ TEST_F(StringOperationTest, StringFind)
 
   auto expected = cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 1, 2, 1};
   cudf::transform_input inputs[] = {a, b};
-  auto result                    = cudf::transform_extended(
+  auto result                    = cudf::transform(
     inputs, cuda, cudf::data_type(cudf::type_id::INT32), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
@@ -846,7 +846,7 @@ TEST_F(StringOperationTest, MixedTypes)
   auto expected =
     cudf::test::fixed_width_column_wrapper<bool>{true, true, false, false, false, false};
   cudf::transform_input inputs[] = {a, b, c, d};
-  auto result                    = cudf::transform_extended(
+  auto result                    = cudf::transform(
     inputs, cuda, cudf::data_type(cudf::type_id::BOOL8), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
@@ -869,14 +869,14 @@ TEST_F(StringOperationTest, Output)
   auto expected =
     cudf::test::strings_column_wrapper{"this", "is", "the", "largest", "lexicographical", "test"};
   cudf::transform_input inputs[] = {a, b, c, d};
-  auto result                    = cudf::transform_extended(
+  auto result                    = cudf::transform(
     inputs, cuda, cudf::data_type(cudf::type_id::STRING), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 
   auto expected_empty                  = cudf::test::strings_column_wrapper{};
   cudf::transform_input empty_inputs[] = {empty, empty, empty, empty};
-  auto result_empty                    = cudf::transform_extended(
+  auto result_empty                    = cudf::transform(
     empty_inputs, cuda, cudf::data_type(cudf::type_id::STRING), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_empty, result_empty->view());
@@ -906,14 +906,14 @@ TEST_F(StringOperationTest, OutputOffsetted)
     "xaa1", "xxbb2", "xxxcc3", "xxxxdd4", "xxxxxee5", "xxxxxxff6"};
   cudf::transform_input inputs[]   = {a, b, c};
   cudf::transform_output outputs[] = {cudf::data_type(cudf::type_id::STRING)};
-  auto result                      = cudf::multi_transform(cuda,
-                                      cudf::udf_source_type::CUDA,
-                                      cudf::null_aware::NO,
-                                      std::nullopt,
-                                      inputs,
-                                      outputs,
-                                      std::move(strings_offsets),
-                                      std::nullopt);
+  auto result                      = cudf::transform(cuda,
+                                cudf::udf_source_type::CUDA,
+                                cudf::null_aware::NO,
+                                std::nullopt,
+                                inputs,
+                                outputs,
+                                std::move(strings_offsets),
+                                std::nullopt);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->get_column(0));
 }
@@ -957,14 +957,14 @@ TEST_F(StringOperationTest, OutputOffsettedMixed)
   cudf::transform_output outputs[] = {{cudf::data_type(cudf::type_id::INT32)},
                                       {cudf::data_type(cudf::type_id::STRING)},
                                       {cudf::data_type(cudf::type_id::BOOL8)}};
-  auto result                      = cudf::multi_transform(cuda,
-                                      cudf::udf_source_type::CUDA,
-                                      cudf::null_aware::NO,
-                                      std::nullopt,
-                                      inputs,
-                                      outputs,
-                                      std::move(strings_offsets),
-                                      std::nullopt);
+  auto result                      = cudf::transform(cuda,
+                                cudf::udf_source_type::CUDA,
+                                cudf::null_aware::NO,
+                                std::nullopt,
+                                inputs,
+                                outputs,
+                                std::move(strings_offsets),
+                                std::nullopt);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result->view());
 }
@@ -1013,12 +1013,12 @@ __device__ void transform(void* user_data, cudf::size_type row,
                                                      "Søren Zoë",
                                                      "张 伟"};
   cudf::transform_input inputs[] = {first_name, last_name, cudf::scalar_column_view(scratch_sizes)};
-  auto result                    = cudf::transform_extended(inputs,
-                                         cuda,
-                                         cudf::data_type(cudf::type_id::STRING),
-                                         cudf::udf_source_type::CUDA,
-                                         scratch.data(),
-                                         cudf::null_aware::NO);
+  auto result                    = cudf::transform(inputs,
+                                cuda,
+                                cudf::data_type(cudf::type_id::STRING),
+                                cudf::udf_source_type::CUDA,
+                                scratch.data(),
+                                cudf::null_aware::NO);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
@@ -1033,7 +1033,7 @@ TEST_F(StringOperationTest, EmptyInput)
 
   auto empty                          = cudf::test::strings_column_wrapper();
   cudf::transform_input bool_inputs[] = {empty, empty};
-  auto result                         = cudf::transform_extended(
+  auto result                         = cudf::transform(
     bool_inputs, rtn_bool, cudf::data_type(cudf::type_id::BOOL8), cudf::udf_source_type::CUDA);
   EXPECT_EQ(0, result->size());
 
@@ -1043,7 +1043,7 @@ TEST_F(StringOperationTest, EmptyInput)
   }
   )***";
   cudf::transform_input str_inputs[] = {empty, empty};
-  result                             = cudf::transform_extended(
+  result                             = cudf::transform(
     str_inputs, rtn_str, cudf::data_type(cudf::type_id::STRING), cudf::udf_source_type::CUDA);
   EXPECT_EQ(0, result->size());
 }
@@ -1099,14 +1099,14 @@ __device__ void capture_group(cudf::string_view* area_code,
   cudf::transform_output outputs[] = {{.type = cudf::data_type(cudf::type_id::STRING)},
                                       {.type = cudf::data_type(cudf::type_id::STRING)},
                                       {.type = cudf::data_type(cudf::type_id::STRING)}};
-  auto result                      = cudf::multi_transform(cuda,
-                                      cudf::udf_source_type::CUDA,
-                                      cudf::null_aware::NO,
-                                      std::nullopt,
-                                      inputs,
-                                      outputs,
-                                                           {},
-                                      std::nullopt);
+  auto result                      = cudf::transform(cuda,
+                                cudf::udf_source_type::CUDA,
+                                cudf::null_aware::NO,
+                                std::nullopt,
+                                inputs,
+                                outputs,
+                                                     {},
+                                std::nullopt);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result->view());
 }
@@ -1222,13 +1222,13 @@ TEST_F(NullTest, ColumnNulls)
   expected->set_null_mask(std::move(expected_mask), expect_null_count);
 
   cudf::transform_input cuda_inputs[] = {*low, *high, *t};
-  auto cuda_result                    = cudf::transform_extended(
+  auto cuda_result                    = cudf::transform(
     cuda_inputs, cuda, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, *expected);
 
   cudf::transform_input ptx_inputs[] = {*low, *high, *t};
-  auto ptx_result                    = cudf::transform_extended(
+  auto ptx_result                    = cudf::transform(
     ptx_inputs, ptx, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::PTX);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*ptx_result, *expected);
@@ -1254,13 +1254,13 @@ TEST_F(NullTest, ColumnNulls_And_Scalar)
   expected->set_null_mask(std::move(expected_mask), expect_null_count);
 
   cudf::transform_input cuda_inputs[] = {*low, *high, cudf::scalar_column_view(*t_scalar)};
-  auto cuda_result                    = cudf::transform_extended(
+  auto cuda_result                    = cudf::transform(
     cuda_inputs, cuda, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, *expected);
 
   cudf::transform_input ptx_inputs[] = {*low, *high, cudf::scalar_column_view(*t_scalar)};
-  auto ptx_result                    = cudf::transform_extended(
+  auto ptx_result                    = cudf::transform(
     ptx_inputs, ptx, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::PTX);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*ptx_result, *expected);
@@ -1285,13 +1285,13 @@ TEST_F(NullTest, ColumnNulls_And_ScalarNull)
                           low->size());
 
   cudf::transform_input cuda_inputs[] = {*low, *high, cudf::scalar_column_view(*t_scalar)};
-  auto cuda_result                    = cudf::transform_extended(
+  auto cuda_result                    = cudf::transform(
     cuda_inputs, cuda, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::CUDA);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, *expected);
 
   cudf::transform_input ptx_inputs[] = {*low, *high, cudf::scalar_column_view(*t_scalar)};
-  auto ptx_result                    = cudf::transform_extended(
+  auto ptx_result                    = cudf::transform(
     ptx_inputs, ptx, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::PTX);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*ptx_result, *expected);
@@ -1313,14 +1313,14 @@ TEST_F(NullTest, IsNull)
   auto expected = cudf::test::fixed_width_column_wrapper<bool>({true, true, false, true, false});
 
   cudf::transform_input inputs[] = {*value};
-  auto result                    = cudf::transform_extended(inputs,
-                                         udf,
-                                         cudf::data_type(cudf::type_id::BOOL8),
-                                         cudf::udf_source_type::CUDA,
-                                         std::nullopt,
-                                         cudf::null_aware::YES,
-                                         std::nullopt,
-                                         cudf::output_nullability::ALL_VALID);
+  auto result                    = cudf::transform(inputs,
+                                udf,
+                                cudf::data_type(cudf::type_id::BOOL8),
+                                cudf::udf_source_type::CUDA,
+                                std::nullopt,
+                                cudf::null_aware::YES,
+                                std::nullopt,
+                                cudf::output_nullability::ALL_VALID);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, expected);
 }
@@ -1360,14 +1360,14 @@ return l - t * l + t * h;
       .release();
 
   cudf::transform_input inputs[] = {*low, *high, *t};
-  auto cuda_result               = cudf::transform_extended(inputs,
-                                              udf,
-                                              cudf::data_type(cudf::type_id::FLOAT32),
-                                              cudf::udf_source_type::CUDA,
-                                              std::nullopt,
-                                              cudf::null_aware::YES,
-                                              std::nullopt,
-                                              cudf::output_nullability::ALL_VALID);
+  auto cuda_result               = cudf::transform(inputs,
+                                     udf,
+                                     cudf::data_type(cudf::type_id::FLOAT32),
+                                     cudf::udf_source_type::CUDA,
+                                     std::nullopt,
+                                     cudf::null_aware::YES,
+                                     std::nullopt,
+                                     cudf::output_nullability::ALL_VALID);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, *expected);
 }
@@ -1401,14 +1401,14 @@ __device__ cudf::errc expression (
     cudf::transform_output outputs[] = {
       {cudf::data_type(cudf::type_id::INT32), cudf::output_nullability::ALL_VALID}};
     std::unique_ptr<cudf::table> result;
-    EXPECT_NO_THROW(result = cudf::multi_transform(cuda,
-                                                   cudf::udf_source_type::CUDA,
-                                                   cudf::null_aware::NO,
-                                                   std::nullopt,
-                                                   inputs,
-                                                   outputs,
-                                                   {},
-                                                   std::nullopt));
+    EXPECT_NO_THROW(result = cudf::transform(cuda,
+                                             cudf::udf_source_type::CUDA,
+                                             cudf::null_aware::NO,
+                                             std::nullopt,
+                                             inputs,
+                                             outputs,
+                                             {},
+                                             std::nullopt));
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->get_column(0), expected);
   }
@@ -1418,14 +1418,14 @@ __device__ cudf::errc expression (
     cudf::transform_output outputs[] = {
       {cudf::data_type(cudf::type_id::INT32), cudf::output_nullability::ALL_VALID}};
     std::unique_ptr<cudf::table> result;
-    EXPECT_THROW(result = cudf::multi_transform(cuda,
-                                                cudf::udf_source_type::CUDA,
-                                                cudf::null_aware::NO,
-                                                std::nullopt,
-                                                inputs,
-                                                outputs,
-                                                {},
-                                                std::nullopt),
+    EXPECT_THROW(result = cudf::transform(cuda,
+                                          cudf::udf_source_type::CUDA,
+                                          cudf::null_aware::NO,
+                                          std::nullopt,
+                                          inputs,
+                                          outputs,
+                                          {},
+                                          std::nullopt),
                  cudf::evaluation_error);
   }
 }

--- a/cpp/tests/transform/integration/unary_transform_test.cpp
+++ b/cpp/tests/transform/integration/unary_transform_test.cpp
@@ -34,6 +34,9 @@
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/transform.hpp>
 
+#include <array>
+#include <utility>
+
 namespace transformation {
 
 struct RuntimeSupportTest : public cudf::test::BaseFixture {
@@ -65,29 +68,47 @@ TEST_F(AssertsTest, TypeSupport)
 {
   cudf::transform_input inputs[] = {a, b, cudf::scalar_column_view(t)};
 
-  EXPECT_NO_THROW(cudf::transform(inputs,
-                                  udf,
-                                  cudf::data_type{cudf::type_id::FLOAT32},
-                                  cudf::udf_source_type::CUDA,
-                                  std::nullopt,
-                                  cudf::null_aware::NO));
+  EXPECT_NO_THROW((void)std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt)
+      ->release()
+      .front()));
 
-  EXPECT_THROW(cudf::transform(inputs,
-                               udf,
-                               cudf::data_type{cudf::type_id::STRUCT},
-                               cudf::udf_source_type::CUDA,
-                               std::nullopt,
-                               cudf::null_aware::NO),
+  EXPECT_THROW((void)std::move(cudf::transform(udf,
+                                               cudf::udf_source_type::CUDA,
+                                               cudf::null_aware::NO,
+                                               std::nullopt,
+                                               inputs,
+                                               std::array{cudf::transform_output{
+                                                 cudf::data_type{cudf::type_id::STRUCT},
+                                                 cudf::output_nullability::PRESERVE}},
+                                               {},
+                                               std::nullopt)
+                                 ->release()
+                                 .front()),
                std::invalid_argument);
 
   cudf::transform_input struct_inputs[] = {struct_col, cudf::scalar_column_view(t)};
 
-  EXPECT_THROW(cudf::transform(struct_inputs,
-                               udf,
-                               cudf::data_type{cudf::type_id::FLOAT32},
-                               cudf::udf_source_type::CUDA,
-                               std::nullopt,
-                               cudf::null_aware::NO),
+  EXPECT_THROW((void)std::move(cudf::transform(udf,
+                                               cudf::udf_source_type::CUDA,
+                                               cudf::null_aware::NO,
+                                               std::nullopt,
+                                               struct_inputs,
+                                               std::array{cudf::transform_output{
+                                                 cudf::data_type{cudf::type_id::FLOAT32},
+                                                 cudf::output_nullability::PRESERVE}},
+                                               {},
+                                               std::nullopt)
+                                 ->release()
+                                 .front()),
                std::invalid_argument);
 }
 
@@ -95,24 +116,36 @@ TEST_F(AssertsTest, UnequalRowCount)
 {
   cudf::transform_input inputs[] = {a, b, bad_col};
 
-  EXPECT_THROW(cudf::transform(inputs,
-                               udf,
-                               cudf::data_type{cudf::type_id::FLOAT32},
-                               cudf::udf_source_type::CUDA,
-                               std::nullopt,
-                               cudf::null_aware::NO),
+  EXPECT_THROW((void)std::move(cudf::transform(udf,
+                                               cudf::udf_source_type::CUDA,
+                                               cudf::null_aware::NO,
+                                               std::nullopt,
+                                               inputs,
+                                               std::array{cudf::transform_output{
+                                                 cudf::data_type{cudf::type_id::FLOAT32},
+                                                 cudf::output_nullability::PRESERVE}},
+                                               {},
+                                               std::nullopt)
+                                 ->release()
+                                 .front()),
                std::invalid_argument);
 }
 
 TEST_F(AssertsTest, NullSupport)
 {
   cudf::transform_input inputs[] = {a, b_nulls, cudf::scalar_column_view(t)};
-  EXPECT_NO_THROW(cudf::transform(inputs,
-                                  udf,
-                                  cudf::data_type{cudf::type_id::FLOAT32},
-                                  cudf::udf_source_type::CUDA,
-                                  std::nullopt,
-                                  cudf::null_aware::NO));
+  EXPECT_NO_THROW((void)std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt)
+      ->release()
+      .front()));
 }
 
 struct UnaryOperationIntegrationTest : public cudf::test::BaseFixture {};
@@ -130,9 +163,19 @@ void test_udf(std::string const& udf,
   cudf::test::fixed_width_column_wrapper<dtype, typename decltype(data_iter)::value_type> in(
     data_iter, data_iter + size, all_valid);
 
-  cudf::transform_input inputs[] = {in};
-  std::unique_ptr<cudf::column> out =
-    cudf::transform(inputs, udf, cudf::data_type(cudf::type_to_id<dtype>()), source_type);
+  cudf::transform_input inputs[]    = {in};
+  std::unique_ptr<cudf::column> out = std::move(
+    cudf::transform(udf,
+                    source_type,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_to_id<dtype>()),
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   ASSERT_UNARY<dtype, dtype>(out->view(), in, op);
 }
@@ -433,8 +476,18 @@ __device__ inline void decode(cudf::string_view * output, cudf::string_view inpu
 
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform(
-      inputs, cuda, cudf::data_type{cudf::type_id::STRING}, cudf::udf_source_type::CUDA);
+    auto out = std::move(
+      cudf::transform(cuda,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::STRING},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), a->view());
   }
@@ -451,8 +504,18 @@ __device__ inline void decode(cudf::string_view * output, cudf::string_view inpu
 
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform(
-      inputs, cuda, cudf::data_type{cudf::type_id::STRING}, cudf::udf_source_type::CUDA);
+    auto out = std::move(
+      cudf::transform(cuda,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::STRING},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), a->view());
   }
@@ -537,13 +600,33 @@ __device__ inline void decode(float * output, float input){
     auto a_encoded                 = cudf::dictionary::encode(a->view());
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform(
-      inputs, cuda, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::CUDA);
+    auto out = std::move(
+      cudf::transform(cuda,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), a->view());
 
-    auto out_ptx = cudf::transform(
-      inputs, ptx, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::PTX);
+    auto out_ptx = std::move(
+      cudf::transform(ptx,
+                      cudf::udf_source_type::PTX,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out_ptx->view(), a->view());
   }
@@ -558,13 +641,33 @@ __device__ inline void decode(float * output, float input){
     auto a_encoded                 = cudf::dictionary::encode(a->view());
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform(
-      inputs, cuda, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::CUDA);
+    auto out = std::move(
+      cudf::transform(cuda,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), a->view());
 
-    auto out_ptx = cudf::transform(
-      inputs, ptx, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::PTX);
+    auto out_ptx = std::move(
+      cudf::transform(ptx,
+                      cudf::udf_source_type::PTX,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out_ptx->view(), a->view());
   }
@@ -575,8 +678,18 @@ __device__ inline void decode(float * output, float input){
     auto a_encoded                 = cudf::dictionary::encode(a_empty->view());
     cudf::transform_input inputs[] = {*a_encoded};
 
-    auto out = cudf::transform(
-      inputs, cuda, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::CUDA);
+    auto out = std::move(
+      cudf::transform(cuda,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
 
     EXPECT_EQ(out->size(), 0);
   }
@@ -593,12 +706,32 @@ __device__ inline void decode(float * output, float input){
 
     cudf::transform_input inputs[] = {sliced_input};
 
-    auto out = cudf::transform(
-      inputs, cuda, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::CUDA);
+    auto out = std::move(
+      cudf::transform(cuda,
+                      cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out->view(), sliced_expect);
 
-    auto out_ptx = cudf::transform(
-      inputs, ptx, cudf::data_type{cudf::type_id::FLOAT32}, cudf::udf_source_type::PTX);
+    auto out_ptx = std::move(
+      cudf::transform(ptx,
+                      cudf::udf_source_type::PTX,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type{cudf::type_id::FLOAT32},
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front());
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(out_ptx->view(), sliced_expect);
   }
@@ -709,14 +842,34 @@ __device__ inline void transform(
   cudf::test::fixed_width_column_wrapper<T> expected(expected_host.begin(), expected_host.end());
 
   cudf::transform_input cuda_inputs[]       = {a, b, cudf::scalar_column_view(c)};
-  std::unique_ptr<cudf::column> cuda_result = cudf::transform(
-    cuda_inputs, cuda, cudf::data_type(cudf::type_to_id<T>()), cudf::udf_source_type::CUDA);
+  std::unique_ptr<cudf::column> cuda_result = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    cuda_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_to_id<T>()),
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, expected);
 
   cudf::transform_input ptx_inputs[]       = {a, b, cudf::scalar_column_view(c)};
-  std::unique_ptr<cudf::column> ptx_result = cudf::transform(
-    ptx_inputs, ptx, cudf::data_type(cudf::type_to_id<T>()), cudf::udf_source_type::PTX);
+  std::unique_ptr<cudf::column> ptx_result = std::move(
+    cudf::transform(ptx,
+                    cudf::udf_source_type::PTX,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    ptx_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_to_id<T>()),
+                                                      cudf::output_nullability::PRESERVE}},
+                    {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*ptx_result, expected);
 }
@@ -763,8 +916,19 @@ TYPED_TEST(TernaryDecimalOperationTest, TransformDecimalsAndScalar)
     expected_host.begin(), expected_host.end(), RES.scale());
 
   cudf::transform_input inputs[]            = {a, b, cudf::scalar_column_view(c)};
-  std::unique_ptr<cudf::column> cuda_result = cudf::transform(
-    inputs, cuda, cudf::data_type(cudf::type_to_id<T>(), RES.scale()), cudf::udf_source_type::CUDA);
+  std::unique_ptr<cudf::column> cuda_result = std::move(
+    cudf::transform(
+      cuda,
+      cudf::udf_source_type::CUDA,
+      cudf::null_aware::NO,
+      std::nullopt,
+      inputs,
+      std::array{cudf::transform_output{cudf::data_type(cudf::type_to_id<T>(), RES.scale()),
+                                        cudf::output_nullability::PRESERVE}},
+      {},
+      std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, expected);
 }
@@ -785,8 +949,18 @@ TEST_F(StringOperationTest, StringComparison)
 
   auto expected = cudf::test::fixed_width_column_wrapper<bool>{true, true, false, false, true};
   cudf::transform_input inputs[] = {a, b, c};
-  auto result                    = cudf::transform(
-    inputs, cuda, cudf::data_type(cudf::type_id::BOOL8), cudf::udf_source_type::CUDA);
+  auto result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::BOOL8),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
@@ -805,8 +979,18 @@ TEST_F(StringOperationTest, StringContains)
   auto expected =
     cudf::test::fixed_width_column_wrapper<bool>{false, true, false, false, true, false};
   cudf::transform_input inputs[] = {a, b};
-  auto result                    = cudf::transform(
-    inputs, cuda, cudf::data_type(cudf::type_id::BOOL8), cudf::udf_source_type::CUDA);
+  auto result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::BOOL8),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
@@ -824,8 +1008,18 @@ TEST_F(StringOperationTest, StringFind)
 
   auto expected = cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 1, 2, 1};
   cudf::transform_input inputs[] = {a, b};
-  auto result                    = cudf::transform(
-    inputs, cuda, cudf::data_type(cudf::type_id::INT32), cudf::udf_source_type::CUDA);
+  auto result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::INT32),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
@@ -846,8 +1040,18 @@ TEST_F(StringOperationTest, MixedTypes)
   auto expected =
     cudf::test::fixed_width_column_wrapper<bool>{true, true, false, false, false, false};
   cudf::transform_input inputs[] = {a, b, c, d};
-  auto result                    = cudf::transform(
-    inputs, cuda, cudf::data_type(cudf::type_id::BOOL8), cudf::udf_source_type::CUDA);
+  auto result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::BOOL8),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
@@ -869,15 +1073,35 @@ TEST_F(StringOperationTest, Output)
   auto expected =
     cudf::test::strings_column_wrapper{"this", "is", "the", "largest", "lexicographical", "test"};
   cudf::transform_input inputs[] = {a, b, c, d};
-  auto result                    = cudf::transform(
-    inputs, cuda, cudf::data_type(cudf::type_id::STRING), cudf::udf_source_type::CUDA);
+  auto result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::STRING),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 
   auto expected_empty                  = cudf::test::strings_column_wrapper{};
   cudf::transform_input empty_inputs[] = {empty, empty, empty, empty};
-  auto result_empty                    = cudf::transform(
-    empty_inputs, cuda, cudf::data_type(cudf::type_id::STRING), cudf::udf_source_type::CUDA);
+  auto result_empty                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    empty_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::STRING),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_empty, result_empty->view());
 }
@@ -1013,12 +1237,18 @@ __device__ void transform(void* user_data, cudf::size_type row,
                                                      "Søren Zoë",
                                                      "张 伟"};
   cudf::transform_input inputs[] = {first_name, last_name, cudf::scalar_column_view(scratch_sizes)};
-  auto result                    = cudf::transform(inputs,
-                                cuda,
-                                cudf::data_type(cudf::type_id::STRING),
-                                cudf::udf_source_type::CUDA,
-                                scratch.data(),
-                                cudf::null_aware::NO);
+  auto result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    scratch.data(),
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::STRING),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
@@ -1033,8 +1263,18 @@ TEST_F(StringOperationTest, EmptyInput)
 
   auto empty                          = cudf::test::strings_column_wrapper();
   cudf::transform_input bool_inputs[] = {empty, empty};
-  auto result                         = cudf::transform(
-    bool_inputs, rtn_bool, cudf::data_type(cudf::type_id::BOOL8), cudf::udf_source_type::CUDA);
+  auto result                         = std::move(
+    cudf::transform(rtn_bool,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    bool_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::BOOL8),
+                                                      cudf::output_nullability::PRESERVE}},
+                                            {},
+                    std::nullopt)
+      ->release()
+      .front());
   EXPECT_EQ(0, result->size());
 
   std::string rtn_str                = R"***(
@@ -1043,8 +1283,18 @@ TEST_F(StringOperationTest, EmptyInput)
   }
   )***";
   cudf::transform_input str_inputs[] = {empty, empty};
-  result                             = cudf::transform(
-    str_inputs, rtn_str, cudf::data_type(cudf::type_id::STRING), cudf::udf_source_type::CUDA);
+  result                             = std::move(
+    cudf::transform(rtn_str,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    str_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::STRING),
+                                                      cudf::output_nullability::PRESERVE}},
+                                                {},
+                    std::nullopt)
+      ->release()
+      .front());
   EXPECT_EQ(0, result->size());
 }
 
@@ -1222,14 +1472,34 @@ TEST_F(NullTest, ColumnNulls)
   expected->set_null_mask(std::move(expected_mask), expect_null_count);
 
   cudf::transform_input cuda_inputs[] = {*low, *high, *t};
-  auto cuda_result                    = cudf::transform(
-    cuda_inputs, cuda, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::CUDA);
+  auto cuda_result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    cuda_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT32),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, *expected);
 
   cudf::transform_input ptx_inputs[] = {*low, *high, *t};
-  auto ptx_result                    = cudf::transform(
-    ptx_inputs, ptx, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::PTX);
+  auto ptx_result                    = std::move(
+    cudf::transform(ptx,
+                    cudf::udf_source_type::PTX,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    ptx_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT32),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*ptx_result, *expected);
 }
@@ -1254,14 +1524,34 @@ TEST_F(NullTest, ColumnNulls_And_Scalar)
   expected->set_null_mask(std::move(expected_mask), expect_null_count);
 
   cudf::transform_input cuda_inputs[] = {*low, *high, cudf::scalar_column_view(*t_scalar)};
-  auto cuda_result                    = cudf::transform(
-    cuda_inputs, cuda, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::CUDA);
+  auto cuda_result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    cuda_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT32),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, *expected);
 
   cudf::transform_input ptx_inputs[] = {*low, *high, cudf::scalar_column_view(*t_scalar)};
-  auto ptx_result                    = cudf::transform(
-    ptx_inputs, ptx, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::PTX);
+  auto ptx_result                    = std::move(
+    cudf::transform(ptx,
+                    cudf::udf_source_type::PTX,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    ptx_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT32),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*ptx_result, *expected);
 }
@@ -1285,14 +1575,34 @@ TEST_F(NullTest, ColumnNulls_And_ScalarNull)
                           low->size());
 
   cudf::transform_input cuda_inputs[] = {*low, *high, cudf::scalar_column_view(*t_scalar)};
-  auto cuda_result                    = cudf::transform(
-    cuda_inputs, cuda, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::CUDA);
+  auto cuda_result                    = std::move(
+    cudf::transform(cuda,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    cuda_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT32),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, *expected);
 
   cudf::transform_input ptx_inputs[] = {*low, *high, cudf::scalar_column_view(*t_scalar)};
-  auto ptx_result                    = cudf::transform(
-    ptx_inputs, ptx, cudf::data_type(cudf::type_id::FLOAT32), cudf::udf_source_type::PTX);
+  auto ptx_result                    = std::move(
+    cudf::transform(ptx,
+                    cudf::udf_source_type::PTX,
+                    cudf::null_aware::NO,
+                    std::nullopt,
+                    ptx_inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT32),
+                                                      cudf::output_nullability::PRESERVE}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*ptx_result, *expected);
 }
@@ -1313,14 +1623,18 @@ TEST_F(NullTest, IsNull)
   auto expected = cudf::test::fixed_width_column_wrapper<bool>({true, true, false, true, false});
 
   cudf::transform_input inputs[] = {*value};
-  auto result                    = cudf::transform(inputs,
-                                udf,
-                                cudf::data_type(cudf::type_id::BOOL8),
-                                cudf::udf_source_type::CUDA,
-                                std::nullopt,
-                                cudf::null_aware::YES,
-                                std::nullopt,
-                                cudf::output_nullability::ALL_VALID);
+  auto result                    = std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::YES,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::BOOL8),
+                                                      cudf::output_nullability::ALL_VALID}},
+                                       {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, expected);
 }
@@ -1360,14 +1674,18 @@ return l - t * l + t * h;
       .release();
 
   cudf::transform_input inputs[] = {*low, *high, *t};
-  auto cuda_result               = cudf::transform(inputs,
-                                     udf,
-                                     cudf::data_type(cudf::type_id::FLOAT32),
-                                     cudf::udf_source_type::CUDA,
-                                     std::nullopt,
-                                     cudf::null_aware::YES,
-                                     std::nullopt,
-                                     cudf::output_nullability::ALL_VALID);
+  auto cuda_result               = std::move(
+    cudf::transform(udf,
+                    cudf::udf_source_type::CUDA,
+                    cudf::null_aware::YES,
+                    std::nullopt,
+                    inputs,
+                    std::array{cudf::transform_output{cudf::data_type(cudf::type_id::FLOAT32),
+                                                      cudf::output_nullability::ALL_VALID}},
+                                  {},
+                    std::nullopt)
+      ->release()
+      .front());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*cuda_result, *expected);
 }

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -72,7 +72,9 @@
 
 #include <jni.h>
 
+#include <array>
 #include <numeric>
+#include <utility>
 
 using cudf::jni::ptr_as_jlong;
 using cudf::jni::release_as_jlong;
@@ -1556,11 +1558,18 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_transform(
     cudf::jni::native_jstring n_j_udf(env, j_udf);
     std::string n_udf              = n_j_udf;
     cudf::transform_input inputs[] = {*column};
-    return release_as_jlong(
-      cudf::transform(inputs,
-                      n_udf,
-                      cudf::data_type(cudf::type_id::INT32),
-                      j_is_ptx ? cudf::udf_source_type::PTX : cudf::udf_source_type::CUDA));
+    return release_as_jlong(std::move(
+      cudf::transform(n_udf,
+                      j_is_ptx ? cudf::udf_source_type::PTX : cudf::udf_source_type::CUDA,
+                      cudf::null_aware::NO,
+                      std::nullopt,
+                      inputs,
+                      std::array{cudf::transform_output{cudf::data_type(cudf::type_id::INT32),
+                                                        cudf::output_nullability::PRESERVE}},
+                      {},
+                      std::nullopt)
+        ->release()
+        .front()));
   }
   JNI_CATCH(env, 0);
 }

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1556,11 +1556,11 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_transform(
     cudf::jni::native_jstring n_j_udf(env, j_udf);
     std::string n_udf              = n_j_udf;
     cudf::transform_input inputs[] = {*column};
-    return release_as_jlong(cudf::transform_extended(
-      inputs,
-      n_udf,
-      cudf::data_type(cudf::type_id::INT32),
-      j_is_ptx ? cudf::udf_source_type::PTX : cudf::udf_source_type::CUDA));
+    return release_as_jlong(
+      cudf::transform(inputs,
+                      n_udf,
+                      cudf::data_type(cudf::type_id::INT32),
+                      j_is_ptx ? cudf::udf_source_type::PTX : cudf::udf_source_type::CUDA));
   }
   JNI_CATCH(env, 0);
 }

--- a/python/pylibcudf/pylibcudf/libcudf/transform.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/transform.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr

--- a/python/pylibcudf/pylibcudf/libcudf/transform.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/transform.pxd
@@ -29,13 +29,25 @@ from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 cdef extern from "cudf/transform.hpp" namespace "cudf" nogil:
     cdef cppclass scalar_column_view:
-        scalar_column_view(const column_view& input)
+        scalar_column_view(
+            const column_view& input
+        ) except +libcudf_exception_handler
 
     cdef cppclass transform_input:
-        transform_input(const column_view& input)
-        transform_input(const scalar_column_view& input)
+        transform_input(
+            const column_view& input
+        ) except +libcudf_exception_handler
+        transform_input(
+            const scalar_column_view& input
+        ) except +libcudf_exception_handler
 
     ctypedef const transform_input const_transform_input
+
+    cdef cppclass transform_output:
+        data_type type
+        output_nullability nullability
+
+    ctypedef const transform_output const_transform_output
 
     cdef pair[unique_ptr[device_buffer], size_type] bools_to_mask (
         const column_view& input,
@@ -63,15 +75,15 @@ cdef extern from "cudf/transform.hpp" namespace "cudf" nogil:
         device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
-    cdef unique_ptr[column] transform(
-        span[const_transform_input] inputs,
-        const string & udf,
-        data_type output_type,
+    cdef unique_ptr[table] transform(
+        const string& udf,
         udf_source_type source_type,
-        optional[void *] user_data,
         null_aware is_null_aware,
+        optional[void*] user_data,
+        span[const_transform_input] inputs,
+        span[const_transform_output] outputs,
+        vector[unique_ptr[column]]&& string_offsets,
         optional[size_type] row_size,
-        output_nullability null_policy,
         cudaStream_t stream,
         device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/transform.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/transform.pxd
@@ -4,6 +4,7 @@ from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 from libcpp.optional cimport optional
 from libcpp.pair cimport pair
+from libcpp.span cimport span
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -12,8 +13,14 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.expressions cimport expression
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
-from pylibcudf.libcudf.types cimport bitmask_type, data_type, size_type
-from pylibcudf.libcudf.types cimport null_aware, output_nullability
+from pylibcudf.libcudf.types cimport (
+    bitmask_type,
+    data_type,
+    null_aware,
+    output_nullability,
+    size_type,
+    udf_source_type,
+)
 
 from rmm.librmm.device_buffer cimport device_buffer
 from cuda.bindings.cyruntime cimport cudaStream_t
@@ -21,6 +28,15 @@ from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/transform.hpp" namespace "cudf" nogil:
+    cdef cppclass scalar_column_view:
+        scalar_column_view(const column_view& input)
+
+    cdef cppclass transform_input:
+        transform_input(const column_view& input)
+        transform_input(const scalar_column_view& input)
+
+    ctypedef const transform_input const_transform_input
+
     cdef pair[unique_ptr[device_buffer], size_type] bools_to_mask (
         const column_view& input,
         cudaStream_t stream,
@@ -48,12 +64,13 @@ cdef extern from "cudf/transform.hpp" namespace "cudf" nogil:
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] transform(
-        const vector[column_view] & inputs,
-        const string & transform_udf,
+        span[const_transform_input] inputs,
+        const string & udf,
         data_type output_type,
-        bool is_ptx,
+        udf_source_type source_type,
         optional[void *] user_data,
         null_aware is_null_aware,
+        optional[size_type] row_size,
         output_nullability null_policy,
         cudaStream_t stream,
         device_async_resource_ref mr

--- a/python/pylibcudf/pylibcudf/transform.pyx
+++ b/python/pylibcudf/pylibcudf/transform.pyx
@@ -34,6 +34,7 @@ from .utils cimport _get_stream, _get_memory_resource
 from cuda.bindings.cyruntime cimport cudaStream_t
 
 ctypedef const cpp_transform.transform_input const_transform_input
+ctypedef const cpp_transform.transform_output const_transform_output
 
 __all__ = [
     "bools_to_mask",
@@ -333,6 +334,12 @@ cpdef Column transform(
     """
     cdef vector[cpp_transform.transform_input] c_inputs
     cdef unique_ptr[column] c_result
+    cdef unique_ptr[table] c_table_result
+    cdef vector[unique_ptr[column]] c_columns
+    cdef vector[unique_ptr[column]] string_offsets
+    cdef vector[cpp_transform.transform_output] c_outputs
+    cdef cpp_transform.transform_output c_output
+    cdef unique_ptr[cpp_transform.scalar_column_view] c_scalar_input
     cdef string c_transform_udf = transform_udf.encode()
     cdef udf_source_type source_type = (
         udf_source_type.PTX if is_ptx else udf_source_type.CUDA
@@ -366,27 +373,34 @@ cpdef Column transform(
     for input in inputs:
         input_view = (<Column?>input).view()
         if input_view.size() == 1 and input_view.size() != base_size:
+            c_scalar_input.reset(
+                new cpp_transform.scalar_column_view(input_view)
+            )
             c_inputs.push_back(
-                cpp_transform.transform_input(
-                    cpp_transform.scalar_column_view(input_view)
-                )
+                cpp_transform.transform_input(dereference(c_scalar_input))
             )
         else:
             c_inputs.push_back(cpp_transform.transform_input(input_view))
 
+    c_output.type = output_type.c_obj
+    c_output.nullability = c_null_policy
+    c_outputs.push_back(c_output)
+
     with nogil:
-        c_result = cpp_transform.transform(
-            span[const_transform_input](c_inputs.data(), c_inputs.size()),
+        c_table_result = cpp_transform.transform(
             c_transform_udf,
-            output_type.c_obj,
             source_type,
-            user_data,
             c_is_null_aware,
+            user_data,
+            span[const_transform_input](c_inputs.data(), c_inputs.size()),
+            span[const_transform_output](c_outputs.data(), c_outputs.size()),
+            move(string_offsets),
             row_size,
-            c_null_policy,
             _cs,
             mr.get_mr()
         )
+        c_columns = dereference(c_table_result).release()
+        c_result = move(c_columns[0])
 
     return Column.from_libcudf(move(c_result), _stream, mr)
 

--- a/python/pylibcudf/pylibcudf/transform.pyx
+++ b/python/pylibcudf/pylibcudf/transform.pyx
@@ -5,6 +5,7 @@ from cython.operator cimport dereference
 
 from libcpp.memory cimport unique_ptr
 from libcpp.optional cimport optional
+from libcpp.span cimport span
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.utility cimport move, pair
@@ -14,7 +15,11 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
-from pylibcudf.libcudf.types cimport bitmask_type, size_type
+from pylibcudf.libcudf.types cimport (
+    bitmask_type,
+    size_type,
+    udf_source_type,
+)
 
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.pylibrmm.device_buffer cimport DeviceBuffer
@@ -27,6 +32,8 @@ from .gpumemoryview cimport gpumemoryview
 from .types cimport DataType, null_aware, output_nullability
 from .utils cimport _get_stream, _get_memory_resource
 from cuda.bindings.cyruntime cimport cudaStream_t
+
+ctypedef const cpp_transform.transform_input const_transform_input
 
 __all__ = [
     "bools_to_mask",
@@ -324,29 +331,58 @@ cpdef Column transform(
     Column
         The transformed column having the UDF applied to each element.
     """
-    cdef vector[column_view] c_inputs
+    cdef vector[cpp_transform.transform_input] c_inputs
     cdef unique_ptr[column] c_result
     cdef string c_transform_udf = transform_udf.encode()
-    cdef bool c_is_ptx = is_ptx
+    cdef udf_source_type source_type = (
+        udf_source_type.PTX if is_ptx else udf_source_type.CUDA
+    )
     cdef null_aware c_is_null_aware = is_null_aware
     cdef output_nullability c_null_policy = null_policy
     cdef optional[void *] user_data
+    cdef optional[size_type] row_size
+    cdef column_view input_view
+    cdef size_type smallest_size
+    cdef size_type largest_size
+    cdef size_type base_size
 
     cdef Stream _stream = _get_stream(stream)
     cdef cudaStream_t _cs = _stream.view().value()
     mr = _get_memory_resource(mr)
 
+    if inputs:
+        input_view = (<Column?>inputs[0]).view()
+        smallest_size = input_view.size()
+        largest_size = smallest_size
+
+        for input in inputs[1:]:
+            input_view = (<Column?>input).view()
+            smallest_size = min(smallest_size, input_view.size())
+            largest_size = max(largest_size, input_view.size())
+
+        base_size = 0 if largest_size == 1 and smallest_size == 0 else largest_size
+        row_size = base_size
+
     for input in inputs:
-        c_inputs.push_back((<Column?>input).view())
+        input_view = (<Column?>input).view()
+        if input_view.size() == 1 and input_view.size() != base_size:
+            c_inputs.push_back(
+                cpp_transform.transform_input(
+                    cpp_transform.scalar_column_view(input_view)
+                )
+            )
+        else:
+            c_inputs.push_back(cpp_transform.transform_input(input_view))
 
     with nogil:
         c_result = cpp_transform.transform(
-            c_inputs,
+            span[const_transform_input](c_inputs.data(), c_inputs.size()),
             c_transform_udf,
             output_type.c_obj,
-            c_is_ptx,
+            source_type,
             user_data,
             c_is_null_aware,
+            row_size,
             c_null_policy,
             _cs,
             mr.get_mr()

--- a/python/pylibcudf/pylibcudf/transform.pyx
+++ b/python/pylibcudf/pylibcudf/transform.pyx
@@ -351,14 +351,9 @@ cpdef Column transform(
     mr = _get_memory_resource(mr)
 
     if inputs:
-        input_view = (<Column?>inputs[0]).view()
-        smallest_size = input_view.size()
-        largest_size = smallest_size
-
-        for input in inputs[1:]:
-            input_view = (<Column?>input).view()
-            smallest_size = min(smallest_size, input_view.size())
-            largest_size = max(largest_size, input_view.size())
+        sizes = [(<Column?>input).view().size() for input in inputs]
+        smallest_size = min(sizes)
+        largest_size = max(sizes)
 
         base_size = 0 if largest_size == 1 and smallest_size == 0 else largest_size
         row_size = base_size


### PR DESCRIPTION
## Description

This pull request removes the deprecated `transform` API signature. It detected scalars by the size of the column views.
`transform_extended` was added to solve this problem without a silent breaking change (ambiguous ODR resolution).
`multi_transform` was also added to support multi-output transforms, this also has a different signature.
This pull request collapses them into a single `transform` function. 
The old `transform` function signature has been replaced with a new one, `transform_extended` and `multi_transform` are now deprecated.

Python and Java bindings have also been updated.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
