### PR TITLE
Reject unsupported masked array-interface inputs

### DIFF
--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -268,6 +268,9 @@ def _prepare_array_metadata(
         If the interface is invalid, big-endian, non-contiguous,
         or exceed the size_type limit.
     """
+    if iface.get("mask") is not None:
+        raise NotImplementedError("Masked array-interface inputs are not supported")
+
     if iface["typestr"][0] == ">":
         raise ValueError("Big-endian data is not supported")
 

--- a/python/pylibcudf/tests/test_column_from_array.py
+++ b/python/pylibcudf/tests/test_column_from_array.py
@@ -178,6 +178,22 @@ def test_array_interface_with_data_none():
         plc.Column.from_array(ArrayInterfaceWithNone())
 
 
+def test_array_interface_with_mask_raises():
+    class ArrayInterfaceWithMask:
+        def __init__(self):
+            self.values = np.array([1, 2, 3], dtype=np.int32)
+
+        @property
+        def __array_interface__(self):
+            return {**self.values.__array_interface__, "mask": object()}
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Masked array-interface inputs are not supported",
+    ):
+        plc.Column.from_array_interface(ArrayInterfaceWithMask())
+
+
 def test_from_zero_dimensional_array():
     arr = np.array(0)
     with pytest.raises(

--- a/python/pylibcudf/tests/test_column_from_device.py
+++ b/python/pylibcudf/tests/test_column_from_device.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyarrow as pa
@@ -80,6 +80,25 @@ def test_from_cuda_array_interface(
     res = plc.Column.from_cuda_array_interface(iface_obj)
 
     assert_column_eq(input_column, res)
+
+
+def test_cuda_array_interface_with_mask_raises():
+    class CudaArrayInterfaceWithMask:
+        @property
+        def __cuda_array_interface__(self):
+            return {
+                "data": (0, False),
+                "shape": (1,),
+                "typestr": "<i4",
+                "version": 3,
+                "mask": object(),
+            }
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Masked array-interface inputs are not supported",
+    ):
+        plc.Column.from_cuda_array_interface(CudaArrayInterfaceWithMask())
 
 
 def test_from_rmm_buffer():


### PR DESCRIPTION
## Description

Reject array-interface inputs with a non-null mask.

Both array-interface constructors document masks as unsupported, but the shared metadata parser previously ignored them and constructed a column with no null mask. This rejects the input before either host or CUDA data is wrapped.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New tests cover the change.
- [ ] Documentation is not affected.