### PR TITLE
Record cudf-polars device only after a successful switch

### DIFF
--- a/python/cudf_polars/cudf_polars/callback.py
+++ b/python/cudf_polars/cudf_polars/callback.py
@@ -235,15 +235,14 @@ def set_device(device: int | None) -> Generator[int, None, None]:
                 f"A previous query used device-{SEEN_DEVICE}, "
                 f"the current query is using device-{to_use}."
             )
+        if to_use != current:
+            gpu.setDevice(to_use)
         SEEN_DEVICE = to_use
-    if to_use != current:
-        gpu.setDevice(to_use)
-        try:
-            yield to_use
-        finally:
-            gpu.setDevice(current)
-    else:
+    try:
         yield to_use
+    finally:
+        if to_use != current:
+            gpu.setDevice(current)
 
 
 @overload

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -91,9 +91,11 @@ def test_invalid_device_raises(device, monkeypatch):
 
 def test_failed_device_switch_does_not_set_seen_device(monkeypatch):
     monkeypatch.setattr(cudf_polars.callback, "SEEN_DEVICE", None)
-    monkeypatch.setattr(gpu, "getDevice", lambda: 0)
+    monkeypatch.setattr(gpu, "getDevice", lambda: 1)
+    calls = []
 
     def fail_for_invalid_device(device):
+        calls.append(device)
         if device == -1:
             raise RuntimeError("invalid device")
 
@@ -111,6 +113,7 @@ def test_failed_device_switch_does_not_set_seen_device(monkeypatch):
         pass
 
     assert cudf_polars.callback.SEEN_DEVICE == 0
+    assert calls == [-1, 0, 1]
 
 
 def test_multiple_devices_in_same_process_raise(monkeypatch):

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -89,6 +89,30 @@ def test_invalid_device_raises(device, monkeypatch):
             q.collect(engine=pl.GPUEngine(device=device))
 
 
+def test_failed_device_switch_does_not_set_seen_device(monkeypatch):
+    monkeypatch.setattr(cudf_polars.callback, "SEEN_DEVICE", None)
+    monkeypatch.setattr(gpu, "getDevice", lambda: 0)
+
+    def fail_for_invalid_device(device):
+        if device == -1:
+            raise RuntimeError("invalid device")
+
+    monkeypatch.setattr(gpu, "setDevice", fail_for_invalid_device)
+
+    with (
+        pytest.raises(RuntimeError, match="invalid device"),
+        cudf_polars.callback.set_device(-1),
+    ):
+        pass
+
+    assert cudf_polars.callback.SEEN_DEVICE is None
+
+    with cudf_polars.callback.set_device(0):
+        pass
+
+    assert cudf_polars.callback.SEEN_DEVICE == 0
+
+
 def test_multiple_devices_in_same_process_raise(monkeypatch):
     # A device we haven't already seen
     monkeypatch.setattr(cudf_polars.callback, "SEEN_DEVICE", 4)


### PR DESCRIPTION
## Description

Record the process-wide device only after `gpu.setDevice()` succeeds.

Previously, a failed device switch left `SEEN_DEVICE` set to the failed device, so later valid queries were rejected as a multi-device conflict.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New tests cover the change.
- [ ] Documentation is not affected.