### PR TITLE
Fix usage of dask-cuda in pip constraints

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1701,14 +1701,25 @@ dependencies:
           - xlsxwriter
   depends_on_dask_cuda:
     common:
-      - output_types: [conda, pyproject]
+      - output_types: [conda, requirements]
         packages:
           - &dask_cuda_unsuffixed dask-cuda==26.10.*,>=0.0.0a0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/
-          - *dask_cuda_unsuffixed
+    specific:
+      - output_types: pyproject
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - dask-cuda[cu12]==26.10.*,>=0.0.0a0
+          - matrix:
+              cuda: "13.*"
+              cuda_suffixed: "true"
+            packages:
+              - dask-cuda[cu13]==26.10.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *dask_cuda_unsuffixed
   depends_on_dask_cudf:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1701,29 +1701,14 @@ dependencies:
           - xlsxwriter
   depends_on_dask_cuda:
     common:
-      - output_types: conda
+      - output_types: [conda, pyproject]
         packages:
           - &dask_cuda_unsuffixed dask-cuda==26.10.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - dask-cuda[cu12]==26.10.*,>=0.0.0a0
-          - matrix:
-              cuda: "13.*"
-              cuda_suffixed: "true"
-            packages:
-              - dask-cuda[cu13]==26.10.*,>=0.0.0a0
-          - matrix:
-            packages:
-              - *dask_cuda_unsuffixed
+          - *dask_cuda_unsuffixed
   depends_on_dask_cudf:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1701,9 +1701,14 @@ dependencies:
           - xlsxwriter
   depends_on_dask_cuda:
     common:
-      - output_types: [conda, requirements]
+      - output_types: conda
         packages:
           - &dask_cuda_unsuffixed dask-cuda==26.10.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/
+          - *dask_cuda_unsuffixed
     specific:
       - output_types: pyproject
         matrices:


### PR DESCRIPTION
## Description
Pip does not allow constraints to have extras. `depends_on_dask_cuda` previously had extras depending on the CUDA version, and as a result, the constraint file contained `dask-cuda[cu12]`. As a result, we saw the following error:

```
DEPRECATION: Constraints are only allowed to take the form of a package name and a version specifier. Other forms were originally permitted as an accident of the implementation, but were undocumented. The new implementation of the resolver no longer supports these forms. A possible replacement is replacing the constraint with a requirement. Discussion can be found at https://github.com/pypa/pip/issues/8210
ERROR: Constraints cannot have extras
```

Remove the extras in the constraints and allow the other dependencies to install the CUDA libraries instead.

This bug happened at least partly as a result of https://github.com/rapidsai/cudf/pull/21671.

Context:
https://github.com/rapidsai/cudf/actions/runs/30818064363/job/91710572211?pr=23472#step:13:86
https://github.com/rapidsai/cudf/actions/runs/30671159887/job/91293198335#step:13:95

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
