### PR TITLE
Fix order preservation in grouped-window evaluation

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
@@ -247,7 +247,7 @@ class OriginStamps:
 
 
 def _origin_stamps_for(ir: Over) -> OriginStamps:
-    """Pick three stamp column names that do not collide with the schema."""
+    """Pick stamp column names that do not collide with the schema."""
     names = unique_names((*ir.children[0].schema.keys(), *ir.schema.keys()))
     return OriginStamps(next(names), next(names), next(names))
 
@@ -300,10 +300,15 @@ def _evaluate_window_with_stamps(
         columns = table.columns()
         table = plc.sorting.stable_sort_by_key(
             table,
-            # Sort by (rank, chunk_index)
-            plc.Table([columns[n_child + 2], columns[n_child]]),
-            [plc.types.Order.ASCENDING] * 2,
-            [plc.types.NullOrder.AFTER] * 2,
+            plc.Table(
+                [
+                    columns[n_child + 2],  # origin rank
+                    columns[n_child],  # source chunk index
+                    columns[n_child + 1],  # row position within that chunk
+                ]
+            ),
+            [plc.types.Order.ASCENDING] * 3,
+            [plc.types.NullOrder.AFTER] * 3,
             stream=stream,
         )
     columns = table.columns()

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
@@ -303,8 +303,8 @@ def _evaluate_window_with_stamps(
             plc.Table(
                 [
                     columns[n_child + 2],  # origin rank
-                    columns[n_child],  # source chunk index
-                    columns[n_child + 1],  # row position within that chunk
+                    columns[n_child],  # origin chunk index
+                    columns[n_child + 1],  # origin position (local)
                 ]
             ),
             [plc.types.Order.ASCENDING] * 3,

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
@@ -303,8 +303,8 @@ def _evaluate_window_with_stamps(
             plc.Table(
                 [
                     columns[n_child + 2],  # origin rank
-                    columns[n_child],  # origin chunk index
-                    columns[n_child + 1],  # origin position (local)
+                    columns[n_child],  # origin chunk index (local)
+                    columns[n_child + 1],  # origin row index (in chunk)
                 ]
             ),
             [plc.types.Order.ASCENDING] * 3,

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/over.py
@@ -247,7 +247,7 @@ class OriginStamps:
 
 
 def _origin_stamps_for(ir: Over) -> OriginStamps:
-    """Pick stamp column names that do not collide with the schema."""
+    """Pick three stamp column names that do not collide with the schema."""
     names = unique_names((*ir.children[0].schema.keys(), *ir.schema.keys()))
     return OriginStamps(next(names), next(names), next(names))
 

--- a/python/cudf_polars/tests/streaming/test_spmd.py
+++ b/python/cudf_polars/tests/streaming/test_spmd.py
@@ -29,6 +29,7 @@ from cudf_polars.engine.spmd import (
 )
 from cudf_polars.streaming.actor_graph.collectives.common import reserve_op_id
 from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.io import make_partitioned_source
 from cudf_polars.utils.config import MemoryResourceConfig
 
 if TYPE_CHECKING:
@@ -709,13 +710,17 @@ def test_over_preserves_input_order_within_source_chunk(
     comm: Communicator, tmp_path: Path
 ) -> None:
     n_rows = 64
-    path = tmp_path / "data.parquet"
-    pl.DataFrame(
-        {
-            "g": [0] * n_rows,
-            "x": list(range(n_rows)),
-        }
-    ).write_parquet(path, row_group_size=2)
+    make_partitioned_source(
+        pl.DataFrame(
+            {
+                "g": [0] * n_rows,
+                "x": list(range(n_rows)),
+            }
+        ),
+        tmp_path,
+        "parquet",
+        row_group_size=2,
+    )
 
     with SPMDEngine(
         comm=comm,
@@ -729,7 +734,7 @@ def test_over_preserves_input_order_within_source_chunk(
             pytest.skip("expected values are defined for exactly 1 rank")
 
         q = (
-            pl.scan_parquet(path)
+            pl.scan_parquet(tmp_path)
             .sort("x")
             .select(
                 "x",

--- a/python/cudf_polars/tests/streaming/test_spmd.py
+++ b/python/cudf_polars/tests/streaming/test_spmd.py
@@ -32,6 +32,8 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.config import MemoryResourceConfig
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from rapidsmpf.communicator.communicator import Communicator
 
 pytestmark = pytest.mark.spmd
@@ -701,6 +703,40 @@ def test_over_shared_group_ordering_multirank(
             expected_values = [None]
             expected_values.extend((left + right) / 2 for left, right in pairwise(xs))
         assert global_result["result"].to_list() == expected_values
+
+
+def test_over_preserves_input_order_within_source_chunk(
+    comm: Communicator, tmp_path: Path
+) -> None:
+    n_rows = 64
+    path = tmp_path / "data.parquet"
+    pl.DataFrame(
+        {
+            "g": [0] * n_rows,
+            "x": list(range(n_rows)),
+        }
+    ).write_parquet(path, row_group_size=2)
+
+    with SPMDEngine(
+        comm=comm,
+        executor_options={
+            "max_rows_per_partition": 2,
+            "dynamic_planning": {},
+            "fallback_mode": "raise",
+        },
+    ) as engine:
+        if engine.nranks != 1:
+            pytest.skip("expected values are defined for exactly 1 rank")
+
+        q = (
+            pl.scan_parquet(path)
+            .sort("x")
+            .select(
+                "x",
+                pl.col("x").cum_sum().over("g").alias("result"),
+            )
+        )
+        assert_gpu_result_equal(q, engine=engine)
 
 
 def test_over_nonscalar_duplicated_input(


### PR DESCRIPTION
## Description
Follow-up to https://github.com/rapidsai/cudf/pull/23466

That PR introduced support for input-order-sensitive `over(...)` expressions without an explicit `order_by` argument. However, there is a bug: We do not properly sort by the original local row-position (only the rank and chunk index). Since the hash-partitioning of the forward shuffle is not technically "stable", we need to include this local row position in the forward sort operation as well.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
