### PR TITLE
[BUG] Avoid writing duplicated data in cudf-polars ``sink``

### DIFF
--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
@@ -893,64 +893,63 @@ async def sink_node(
         )
         skip_write = metadata.duplicated and comm.rank != 0
 
-        path_root = f"{ir.sink.path}/part"
-        if comm.nranks > 1:
-            rank_width = math.ceil(math.log10(comm.nranks))
-            rank_str = str(comm.rank).zfill(rank_width)
-            path_root = f"{path_root}.{rank_str}"
-        # local_count may be 0 when a rank receives no partitions
-        # (e.g. more ranks than input files); log10(0) is undefined.
-        count_width = math.ceil(math.log10(max(metadata.local_count, 1)))
-        count_width = max(count_width, 6)
-
-        if ir.sink_to_directory:
-            if not skip_write:
-                _prepare_sink_directory(ir.sink.path)
-            i = 0
-            while (msg := await ch_in.recv(context)) is not None:
-                if skip_write:
-                    continue
-                chunk = TableChunk.from_message(
-                    msg, br=context.br()
-                ).make_available_and_spill(context.br(), allow_overbooking=True)
-                df = chunk_to_frame(chunk, child_ir)
-                part_path = f"{path_root}.{str(i).zfill(count_width)}.{suffix}"
-                await ir_context.to_thread(
-                    Sink.do_evaluate,
-                    ir.sink.schema,
-                    ir.sink.kind,
-                    part_path,
-                    ir.sink.parquet_options,
-                    ir.sink.options,
-                    df,
-                    context=ir_context,
-                )
-                i += 1
+        if skip_write:
+            while await ch_in.recv(context) is not None:
+                pass
         else:
-            # Write chunks to a single file
-            writer_state = None
-            while (msg := await ch_in.recv(context)) is not None:
-                if skip_write:
-                    continue
-                chunk = TableChunk.from_message(
-                    msg, br=context.br()
-                ).make_available_and_spill(context.br(), allow_overbooking=True)
-                # Multiple chunks - use chunked writer
-                df = chunk_to_frame(chunk, child_ir)
-                writer_state = await ir_context.to_thread(
-                    _sink_to_file,  # type: ignore[arg-type]  # (to_thread accepts this keyword-only sink helper)
-                    ir.sink.kind,
-                    ir.sink.path,
-                    ir.sink.options,
-                    writer_state=writer_state,
-                    df=df,
-                )
+            path_root = f"{ir.sink.path}/part"
+            if comm.nranks > 1:
+                rank_width = math.ceil(math.log10(comm.nranks))
+                rank_str = str(comm.rank).zfill(rank_width)
+                path_root = f"{path_root}.{rank_str}"
+            # local_count may be 0 when a rank receives no partitions
+            # (e.g. more ranks than input files); log10(0) is undefined.
+            count_width = math.ceil(math.log10(max(metadata.local_count, 1)))
+            count_width = max(count_width, 6)
 
-            # Finalize the writer after all chunks are processed
-            if writer_state and ir.sink.kind == "Parquet":
-                # We know that with ir.sink.kind == "Parquet", writer_state being truthy
-                # means that it's a ChunkedParquetWriter.
-                await ir_context.to_thread(writer_state.close, [])  # type: ignore[attr-defined]
+            if ir.sink_to_directory:
+                _prepare_sink_directory(ir.sink.path)
+                i = 0
+                while (msg := await ch_in.recv(context)) is not None:
+                    chunk = TableChunk.from_message(
+                        msg, br=context.br()
+                    ).make_available_and_spill(context.br(), allow_overbooking=True)
+                    df = chunk_to_frame(chunk, child_ir)
+                    part_path = f"{path_root}.{str(i).zfill(count_width)}.{suffix}"
+                    await ir_context.to_thread(
+                        Sink.do_evaluate,
+                        ir.sink.schema,
+                        ir.sink.kind,
+                        part_path,
+                        ir.sink.parquet_options,
+                        ir.sink.options,
+                        df,
+                        context=ir_context,
+                    )
+                    i += 1
+            else:
+                # Write chunks to a single file
+                writer_state = None
+                while (msg := await ch_in.recv(context)) is not None:
+                    chunk = TableChunk.from_message(
+                        msg, br=context.br()
+                    ).make_available_and_spill(context.br(), allow_overbooking=True)
+                    # Multiple chunks - use chunked writer
+                    df = chunk_to_frame(chunk, child_ir)
+                    writer_state = await ir_context.to_thread(
+                        _sink_to_file,  # type: ignore[arg-type]  # (to_thread accepts this keyword-only sink helper)
+                        ir.sink.kind,
+                        ir.sink.path,
+                        ir.sink.options,
+                        writer_state=writer_state,
+                        df=df,
+                    )
+
+                # Finalize the writer after all chunks are processed
+                if writer_state and ir.sink.kind == "Parquet":
+                    # We know that with ir.sink.kind == "Parquet", writer_state being truthy
+                    # means that it's a ChunkedParquetWriter.
+                    await ir_context.to_thread(writer_state.close, [])  # type: ignore[attr-defined]
 
         # Signal completion on the metadata and data channels with empty results
         stream = ir_context.get_cuda_stream()

--- a/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
+++ b/python/cudf_polars/cudf_polars/streaming/actor_graph/io.py
@@ -891,6 +891,7 @@ async def sink_node(
         await send_metadata(
             ch_out, context, ChannelMetadata(local_count=1, duplicated=True)
         )
+        skip_write = metadata.duplicated and comm.rank != 0
 
         path_root = f"{ir.sink.path}/part"
         if comm.nranks > 1:
@@ -903,9 +904,12 @@ async def sink_node(
         count_width = max(count_width, 6)
 
         if ir.sink_to_directory:
-            _prepare_sink_directory(ir.sink.path)
+            if not skip_write:
+                _prepare_sink_directory(ir.sink.path)
             i = 0
             while (msg := await ch_in.recv(context)) is not None:
+                if skip_write:
+                    continue
                 chunk = TableChunk.from_message(
                     msg, br=context.br()
                 ).make_available_and_spill(context.br(), allow_overbooking=True)
@@ -926,6 +930,8 @@ async def sink_node(
             # Write chunks to a single file
             writer_state = None
             while (msg := await ch_in.recv(context)) is not None:
+                if skip_write:
+                    continue
                 chunk = TableChunk.from_message(
                     msg, br=context.br()
                 ).make_available_and_spill(context.br(), allow_overbooking=True)

--- a/python/cudf_polars/tests/streaming/test_io_multirank.py
+++ b/python/cudf_polars/tests/streaming/test_io_multirank.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """IO tests for the streaming engines."""
 
@@ -68,6 +68,17 @@ def test_sink_parquet_empty_rank(engine: StreamingEngine, tmp_path: Path) -> Non
 
     gpu_path = path.with_name(f"{path.stem}_gpu{path.suffix}")
     assert gpu_path.is_dir()
+
+
+def test_sink_parquet_duplicated(engine: StreamingEngine, tmp_path: Path) -> None:
+    """Duplicated input should only be written once."""
+    lazydf = (
+        pl.LazyFrame({"x": [1] * 4, "y": [1, 2, 3, 4]})
+        .group_by("x")
+        .agg(pl.col("y").sum())
+    )
+    path = tmp_path / "duplicated.parquet"
+    assert_sink_result_equal(lazydf, path, engine=engine)
 
 
 @pytest.mark.parametrize(

--- a/python/cudf_polars/tests/streaming/test_spmd.py
+++ b/python/cudf_polars/tests/streaming/test_spmd.py
@@ -29,6 +29,7 @@ from cudf_polars.engine.spmd import (
 )
 from cudf_polars.streaming.actor_graph.collectives.common import reserve_op_id
 from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.io import make_partitioned_source
 from cudf_polars.utils.config import MemoryResourceConfig
 
 if TYPE_CHECKING:
@@ -376,6 +377,61 @@ def test_execute_duplicated_result_chained_into_distributed_agg(
     # 1.0 + 2.0 = 3.0, independent of nranks (would be 3.0 * nranks if the
     # duplicated partitions were treated as distinct).
     assert total["total"].to_list() == [3.0]
+
+
+def test_sink_deduplicates_single_partition_fallback(comm: Communicator) -> None:
+    """A single-partition fallback result must not be written once per rank."""
+    import shutil
+    from pathlib import Path
+
+    from rapidsmpf.communicator.ucxx import barrier
+
+    if comm.nranks < 2:
+        pytest.skip("requires multiple ranks")
+
+    test_id = uuid.uuid5(uuid.NAMESPACE_URL, os.environ["PYTEST_CURRENT_TEST"])
+    shared_root = Path("/tmp") / f"cudf-polars-{test_id}"
+    source_path = shared_root / "input.parquet"
+    sink_path = shared_root / "out.parquet"
+    if comm.rank == 0:
+        shutil.rmtree(shared_root, ignore_errors=True)
+        shared_root.mkdir()
+        make_partitioned_source(
+            pl.DataFrame(
+                {
+                    "row": [0, 1, 2, 3],
+                    "value": [None, 1, None, 3],
+                }
+            ),
+            source_path,
+            "parquet",
+            row_group_size=2,
+        )
+    barrier(comm)
+
+    with SPMDEngine(
+        comm=comm,
+        executor_options={
+            "target_partition_size": 1,
+            "fallback_mode": "silent",
+            "sink_to_directory": True,
+        },
+    ) as engine:
+        query = pl.scan_parquet(source_path).select(
+            "row",
+            pl.col("value").fill_null(strategy="forward").alias("value"),
+        )
+        query.sink_parquet(sink_path, mkdir=True, engine=engine)
+        barrier(engine.comm)
+
+        result = pl.read_parquet(sink_path).sort("row")
+        assert result["row"].to_list() == [0, 1, 2, 3]
+        assert result["value"].to_list() == [None, 1, 1, 3]
+        barrier(engine.comm)
+
+    if comm.rank == 0:
+        shutil.rmtree(shared_root, ignore_errors=True)
+    barrier(comm)
 
 
 def test_reset_keeps_comm_alive(comm: Communicator) -> None:

--- a/python/cudf_polars/tests/streaming/test_spmd.py
+++ b/python/cudf_polars/tests/streaming/test_spmd.py
@@ -29,7 +29,6 @@ from cudf_polars.engine.spmd import (
 )
 from cudf_polars.streaming.actor_graph.collectives.common import reserve_op_id
 from cudf_polars.testing.asserts import assert_gpu_result_equal
-from cudf_polars.testing.io import make_partitioned_source
 from cudf_polars.utils.config import MemoryResourceConfig
 
 if TYPE_CHECKING:
@@ -377,61 +376,6 @@ def test_execute_duplicated_result_chained_into_distributed_agg(
     # 1.0 + 2.0 = 3.0, independent of nranks (would be 3.0 * nranks if the
     # duplicated partitions were treated as distinct).
     assert total["total"].to_list() == [3.0]
-
-
-def test_sink_deduplicates_single_partition_fallback(comm: Communicator) -> None:
-    """A single-partition fallback result must not be written once per rank."""
-    import shutil
-    from pathlib import Path
-
-    from rapidsmpf.communicator.ucxx import barrier
-
-    if comm.nranks < 2:
-        pytest.skip("requires multiple ranks")
-
-    test_id = uuid.uuid5(uuid.NAMESPACE_URL, os.environ["PYTEST_CURRENT_TEST"])
-    shared_root = Path("/tmp") / f"cudf-polars-{test_id}"
-    source_path = shared_root / "input.parquet"
-    sink_path = shared_root / "out.parquet"
-    if comm.rank == 0:
-        shutil.rmtree(shared_root, ignore_errors=True)
-        shared_root.mkdir()
-        make_partitioned_source(
-            pl.DataFrame(
-                {
-                    "row": [0, 1, 2, 3],
-                    "value": [None, 1, None, 3],
-                }
-            ),
-            source_path,
-            "parquet",
-            row_group_size=2,
-        )
-    barrier(comm)
-
-    with SPMDEngine(
-        comm=comm,
-        executor_options={
-            "target_partition_size": 1,
-            "fallback_mode": "silent",
-            "sink_to_directory": True,
-        },
-    ) as engine:
-        query = pl.scan_parquet(source_path).select(
-            "row",
-            pl.col("value").fill_null(strategy="forward").alias("value"),
-        )
-        query.sink_parquet(sink_path, mkdir=True, engine=engine)
-        barrier(engine.comm)
-
-        result = pl.read_parquet(sink_path).sort("row")
-        assert result["row"].to_list() == [0, 1, 2, 3]
-        assert result["value"].to_list() == [None, 1, 1, 3]
-        barrier(engine.comm)
-
-    if comm.rank == 0:
-        shutil.rmtree(shared_root, ignore_errors=True)
-    barrier(comm)
 
 
 def test_reset_keeps_comm_alive(comm: Communicator) -> None:


### PR DESCRIPTION
## Description
cuDF-Polars will currently write data on all ranks for a ``sink`` operation. This is a problem when the corresponding data is "duplicated" across ranks. This PR updates the sink actor to check the `duplicated` metadata before writing on ranks >0.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
